### PR TITLE
Changed the end-of-line comment character from ';' to '$' when

### DIFF
--- a/ext2spice/ext2hier.c
+++ b/ext2spice/ext2hier.c
@@ -553,7 +553,7 @@ spcdevHierVisit(hc, dev, scale)
 	case DEV_FET:
 	    if (source == drain)
 	    {
-		if (esFormat == NGSPICE) fprintf(esSpiceF, "; ");
+		if (esFormat == NGSPICE) fprintf(esSpiceF, "$ ");
 		fprintf(esSpiceF, "** SOURCE/DRAIN TIED\n");
 	    }
 	    break;
@@ -561,7 +561,7 @@ spcdevHierVisit(hc, dev, scale)
 	default:
 	    if (gate == source)
 	    {
-		if (esFormat == NGSPICE) fprintf(esSpiceF, "; ");
+		if (esFormat == NGSPICE) fprintf(esSpiceF, "$ ");
 		fprintf(esSpiceF, "** SHORTED DEVICE\n");
 	    }
 	    break;
@@ -1254,7 +1254,7 @@ spcnodeHierVisit(hc, node, res, cap)
 	static char ntmp[MAX_STR_SIZE];
 
 	EFHNSprintf(ntmp, hierName);
-	if (esFormat == NGSPICE) fprintf(esSpiceF, " ; ");
+	if (esFormat == NGSPICE) fprintf(esSpiceF, " $ ");
 	fprintf(esSpiceF, "** %s == %s\n", ntmp, nsn);
     }
     cap = cap  / 1000;
@@ -1262,12 +1262,12 @@ spcnodeHierVisit(hc, node, res, cap)
     {
 	fprintf(esSpiceF, esSpiceCapFormat, esCapNum++, nsn, cap,
 			(isConnected) ?  "" :
-			(esFormat == NGSPICE) ? " ; **FLOATING" :
+			(esFormat == NGSPICE) ? " $ **FLOATING" :
 			" **FLOATING");
     }
     if (node->efnode_attrs && !esNoAttrs)
     {
-	if (esFormat == NGSPICE) fprintf(esSpiceF, " ; ");
+	if (esFormat == NGSPICE) fprintf(esSpiceF, " $ ");
 	fprintf(esSpiceF, "**nodeattr %s :",nsn );
 	for (fmt = " %s", ap = node->efnode_attrs; ap; ap = ap->efa_next)
 	{

--- a/ext2spice/ext2spice.c
+++ b/ext2spice/ext2spice.c
@@ -2328,7 +2328,7 @@ spcdevVisit(dev, hc, scale, trans)
 	case DEV_FET:
 	    if (source == drain)
 	    {
-		if (esFormat == NGSPICE) fprintf(esSpiceF, "; ");
+		if (esFormat == NGSPICE) fprintf(esSpiceF, "$ ");
 		fprintf(esSpiceF, "** SOURCE/DRAIN TIED\n");
 	    }
 	    break;
@@ -2336,7 +2336,7 @@ spcdevVisit(dev, hc, scale, trans)
 	default:
 	    if (gate == source)
 	    {
-		if (esFormat == NGSPICE) fprintf(esSpiceF, "; ");
+		if (esFormat == NGSPICE) fprintf(esSpiceF, "$ ");
 		fprintf(esSpiceF, "** SHORTED DEVICE\n");
 	    }
 	    break;
@@ -3203,7 +3203,7 @@ spcnodeVisit(node, res, cap)
 	static char ntmp[MAX_STR_SIZE];
 
 	EFHNSprintf(ntmp, hierName);
-	if (esFormat == NGSPICE) fprintf(esSpiceF, "; ");
+	if (esFormat == NGSPICE) fprintf(esSpiceF, "$ ");
 	fprintf(esSpiceF, "** %s == %s\n", ntmp, nsn);
     }
     cap = cap  / 1000;
@@ -3211,12 +3211,12 @@ spcnodeVisit(node, res, cap)
     {
 	fprintf(esSpiceF, esSpiceCapFormat, esCapNum++, nsn, cap,
 			(isConnected) ?  "\n" :
-			(esFormat == NGSPICE) ? " ; **FLOATING\n" :
+			(esFormat == NGSPICE) ? " $ **FLOATING\n" :
 			" **FLOATING\n");
     }
     if (node->efnode_attrs && !esNoAttrs)
     {
-	if (esFormat == NGSPICE) fprintf(esSpiceF, " ; ");
+	if (esFormat == NGSPICE) fprintf(esSpiceF, " $ ");
 	fprintf(esSpiceF, "**nodeattr %s :",nsn );
 	for (fmt = " %s", ap = node->efnode_attrs; ap; ap = ap->efa_next)
 	{


### PR DESCRIPTION
formatting a SPICE netlist for NGSPICE.  This is the documented
character as described in the NGSPICE User Manual, section 2.2.4
End-of-line comments