### PR TITLE
During efBuildNode, each node is visited.  If a node is found to be a

### DIFF
--- a/extflat/EFbuild.c
+++ b/extflat/EFbuild.c
@@ -163,6 +163,11 @@ efBuildNode(def, isSubsnode, nodeName, nodeCap, x, y, layerName, av, ac)
 	    newnode->efnode_pa[n].pa_area += atoi(*av++);
 	    newnode->efnode_pa[n].pa_perim += atoi(*av++);
 	}
+
+	/* If this node is identified as substrate, update the flag */
+	if (isSubsnode == TRUE)
+	    newnode->efnode_flags |= EF_SUBS_NODE;
+
 	return;
     }
 


### PR DESCRIPTION
duplicate, a couple of updates are made.  What's missing from these
updates is if the node is a "substrate" the second time around, the
EF_SUBS_NODE flag in efnode_flags needs to be set.

Then subsequent queries to this node can identify this as a substrate
node.  This is enable the removing of an earlier hack.

Quite possible not the correct solution to this problem