### PR TITLE
Added constraint layers to CIF Grow-min and Bridge

### DIFF
--- a/cif/CIFint.h
+++ b/cif/CIFint.h
@@ -55,6 +55,8 @@ typedef struct bloat_data
 typedef struct bridge_data
 {
     int br_width;		/* Minimum width rule for bridge */
+    TileTypeBitMask co_paintMask;/* Zero or more paint layers to consider. */
+    TileTypeBitMask co_cifMask;  /* Zero or more other CIF layers. */
 } BridgeData;
 
 typedef struct squares_data

--- a/cif/CIFtech.c
+++ b/cif/CIFtech.c
@@ -1075,7 +1075,6 @@ CIFTechLine(sectionName, argc, argv)
 	    break;
 
 	case CIFOP_GROW:
-	case CIFOP_GROWMIN:
 	case CIFOP_GROW_G:
 	case CIFOP_SHRINK:
 	case CIFOP_CLOSE:
@@ -1087,23 +1086,32 @@ CIFTechLine(sectionName, argc, argv)
 		goto errorReturn;
 	    }
 	    break;
+		    
+        case CIFOP_GROWMIN:
+            if (argc != 3) goto wrongNumArgs;
 
 	case CIFOP_BRIDGE:
-	    if (argc != 3) goto wrongNumArgs;
-	    newOp->co_distance = atoi(argv[1]);
-	    if (newOp->co_distance <= 0)
-	    {
-		TechError("Bridge distance must be greater than zero.\n");
-		goto errorReturn;
-	    }
-	    bridge = (BridgeData *)mallocMagic(sizeof(BridgeData));
-	    bridge->br_width = atoi(argv[2]);
-	    if (bridge->br_width <= 0)
-	    {
-		TechError("Bridge width must be greater than zero.\n");
-		freeMagic(bridge);
-		goto errorReturn;
-	    }
+            if (newOp->co_opcode == CIFOP_BRIDGE && argc != 4) goto wrongNumArgs;
+            newOp->co_distance = atoi(argv[1]);
+            if (newOp->co_distance <= 0)
+            {
+                TechError("Bridge/Grow distance must be greater than zero.\n");
+                goto errorReturn;
+            }
+            bridge = (BridgeData *)mallocMagic(sizeof(BridgeData));
+            if (newOp->co_opcode == CIFOP_BRIDGE)
+            {
+                bridge->br_width = atoi(argv[2]);
+                if (bridge->br_width <= 0)
+                {
+                        TechError("Bridge width must be greater than zero.\n");
+                        freeMagic(bridge);
+                        goto errorReturn;
+                }
+                cifParseLayers(argv[3], CIFCurStyle, &bridge->co_paintMask, &bridge->co_cifMask,FALSE);
+            } else
+                cifParseLayers(argv[2], CIFCurStyle, &bridge->co_paintMask, &bridge->co_cifMask,FALSE);
+
 	    newOp->co_client = (ClientData)bridge;
 	    break;
 

--- a/cif/CIFtech.c
+++ b/cif/CIFtech.c
@@ -1552,7 +1552,6 @@ cifComputeRadii(layer, des)
 	    case CIFOP_OR: break;
 
 	    case CIFOP_GROW:
-	    case CIFOP_GROWMIN:
 	    case CIFOP_GROW_G:
 		grow += op->co_distance;
 		break;
@@ -1578,7 +1577,7 @@ cifComputeRadii(layer, des)
 		grow += curGrow;
 		shrink += curShrink;
 		break;
-
+	    case CIFOP_GROWMIN:
 	    case CIFOP_BRIDGE: break;
 	    case CIFOP_SQUARES: break;
 	    case CIFOP_SQUARES_G: break;
@@ -1839,6 +1838,7 @@ CIFTechFinal()
 			case CIFOP_MAXRECT:
 			case CIFOP_NET:
 			    break;
+			case CIFOP_GROWMIN:
 			case CIFOP_BRIDGE:
 			    bridge = (BridgeData *)op->co_client;
 			    c = FindGCF(style->cs_scaleFactor,
@@ -1936,6 +1936,7 @@ CIFTechFinal()
 		case CIFOP_ANDNOT:
 		case CIFOP_SHRINK:
 		case CIFOP_CLOSE:
+		case CIFOP_GROWMIN:
 		case CIFOP_BRIDGE:
 		    needThisLayer = TRUE;
 		    break;
@@ -2363,6 +2364,7 @@ CIFTechOutputScale(n, d)
 			case CIFOP_MAXRECT:
 			case CIFOP_NET:
 			    break;
+			case CIFOP_GROWMIN:
 			case CIFOP_BRIDGE:
 			    bridge = (BridgeData *)op->co_client;
 			    bridge->br_width *= d;
@@ -2467,6 +2469,7 @@ CIFTechOutputScale(n, d)
 			    if (bloats->bl_distance[j] != 0)
 				bloats->bl_distance[j] /= lexpand;
 			break;
+		    case CIFOP_GROWMIN:
 		    case CIFOP_BRIDGE:
 			bridge = (BridgeData *)op->co_client;
 			bridge->br_width /= lexpand;


### PR DESCRIPTION
Grow-min and Bridge CIF functions were modified to accept constraint layers. Modifications are:

- GROW-MIN: This function must be used to adjust tile sizes to meet a minimum width rule. This function is limited to horizontal and vertical directions (diagonal distances are not treated).
- BRIDGE: This function is used to meet minimum width (W) and minimum spacing (S) rules in the corner of tiles.

In the next example we generate implantation layers (implant_N and implant_P) from initial layers (rawN and rawP):

layer implant_N rawN
        grow-min W rawP
        bridge W S rawP
        grow S
        shrink S
calma 1 0

layer implant_P rawP
        grow-min W implant_N
        bridge W S implant_N
        grow S
        shrink S
calma 2 0
