### PR TITLE
swapDrainSource reimplemented to remove side-effects

### DIFF
--- a/ext2spice/ext2hier.c
+++ b/ext2spice/ext2hier.c
@@ -485,7 +485,7 @@ spcdevHierVisit(hc, dev, scale)
     EFNode  *subnode, *snode, *dnode, *subnodeFlat = NULL;
     int l, w, i, parmval;
     Rect r;
-    bool subAP = FALSE, hierS, hierD, extHierSDAttr(), swapped = FALSE;
+    bool subAP = FALSE, hierS, hierD, extHierSDAttr();
     float sdM;
     char devchar;
     bool has_model = TRUE;
@@ -507,6 +507,8 @@ spcdevHierVisit(hc, dev, scale)
 	source = drain = &dev->dev_terms[1];
     if (dev->dev_nterm >= 3)
     {
+        drain = &dev->dev_terms[2];
+        
         /* If any terminal is marked with attribute "D" or "S"  */
         /* (label "D$" or "S$" at poly-diffusion interface),    */
         /* then force order of source and drain accordingly.    */
@@ -516,11 +518,8 @@ spcdevHierVisit(hc, dev, scale)
                 (dev->dev_terms[2].dterm_attrs &&
                 !strcmp(dev->dev_terms[2].dterm_attrs, "S")))
 	{
-            swapDrainSource(dev, &source, &drain);
-	    swapped = TRUE;
-	}
-        else
-            drain = &dev->dev_terms[2];
+        swapDrainSource(dev);
+    }
     }
     else if (dev->dev_nterm == 1)	// Is a device with one terminal an error?
 	source = drain = &dev->dev_terms[0];
@@ -627,6 +626,7 @@ spcdevHierVisit(hc, dev, scale)
 	    case DEV_RSUBCKT:
 	    case DEV_CSUBCKT:
 	    case DEV_MSUBCKT:
+        //TxPrintf("Device %c%d extraction.\n", devchar, esSbckNum);
 		fprintf(esSpiceF, "%d", esSbckNum++);
 		break;
 	    default:
@@ -1008,9 +1008,6 @@ spcdevHierVisit(hc, dev, scale)
 	        break;
     }
     fprintf(esSpiceF, "\n");
-
-    /* If S/D parameters were swapped, then put them back */
-    if (swapped) swapDrainSource(dev, NULL, NULL);
 
     return 0;
 }

--- a/ext2spice/ext2spice.c
+++ b/ext2spice/ext2spice.c
@@ -2197,11 +2197,15 @@ getCurDevMult()
  * (label "D$" or "S$" at poly-diffusion interface),
  * then swap order of source and drain compared to the default ordering.	
  *
+ * Note:
+ *   before calling this function, ensure that: dev->dev_nterm >= 3
+ * 
  * Results:
  *   none
  * 
  * Side effects: 
- *   none (?)
+ *   source (dev->dev_terms[1]) and drain (dev->dev_terms[2]) terminals are swapped;
+ *   no unwanted (?)
  * 
  * ----------------------------------------------------------------------------
  */
@@ -2211,23 +2215,10 @@ swapDrainSource(dev)
 {
     DevTerm tmpTerm;
     
-    tmpTerm.dterm_node   = dev->dev_terms[1].dterm_node;
-    tmpTerm.dterm_attrs  = dev->dev_terms[1].dterm_attrs; 
-    tmpTerm.dterm_length = dev->dev_terms[1].dterm_length;
-    tmpTerm.dterm_perim  = dev->dev_terms[1].dterm_perim;
-    tmpTerm.dterm_area   = dev->dev_terms[1].dterm_area; 
-    
-    dev->dev_terms[1].dterm_node   = dev->dev_terms[2].dterm_node;
-    dev->dev_terms[1].dterm_attrs  = dev->dev_terms[2].dterm_attrs;  
-    dev->dev_terms[1].dterm_length = dev->dev_terms[2].dterm_length;
-    dev->dev_terms[1].dterm_perim  = dev->dev_terms[2].dterm_perim;
-    dev->dev_terms[1].dterm_area   = dev->dev_terms[2].dterm_area;  
-    
-    dev->dev_terms[2].dterm_node   = tmpTerm.dterm_node;  
-    dev->dev_terms[2].dterm_attrs  = tmpTerm.dterm_attrs;
-    dev->dev_terms[2].dterm_length = tmpTerm.dterm_length;
-    dev->dev_terms[2].dterm_perim  = tmpTerm.dterm_perim; 
-    dev->dev_terms[2].dterm_area   = tmpTerm.dterm_area;  
+    /* swap original terminals */
+    memcpy(&tmpTerm, &(dev->dev_terms[1]), sizeof(DevTerm));
+    memcpy(&(dev->dev_terms[1]), &(dev->dev_terms[2]), sizeof(DevTerm));
+    memcpy(&(dev->dev_terms[2]), &tmpTerm, sizeof(DevTerm));
 }
 
 


### PR DESCRIPTION
Thank you for fixing my proposed code - I tested it and it works!.

However, I created new pull request to solve the swapDrainSource() side-effects. The function now realy swaps the terminals (not parameters or parameter names) and causes (hopefully) no side-effects, whose must be corrected later; the "swapped" flag is thus no more required.

This code works also well.

This is related to issue #32 