### PR TITLE
Build system tweaks to make magic more relocatable

### DIFF
--- a/scripts/configure.in
+++ b/scripts/configure.in
@@ -407,6 +407,8 @@ AC_ARG_WITH(tcllibs,    [  --with-tcllibs=DIR      Find Tcl library in DIR],
   magic_with_tcl_libraries=$withval)
 AC_ARG_WITH(tklibs,     [  --with-tklibs=DIR       Find Tk library in DIR],
   magic_with_tk_libraries=$withval)
+AC_ARG_WITH(wish,       [  --with-wish=EXE         Use wish binary at EXE],
+  magic_with_wish_binary=$withval)
 
 # -----------------------------------------------------------------------
 # Find the Tcl build configuration file "tclConfig.sh"
@@ -709,33 +711,37 @@ if test $usingTcl ; then
 # Find the version of "wish" that corresponds to TCL_EXEC_PREFIX
 # We really ought to run "ldd" to confirm that the linked libraries match.
 
-  AC_MSG_CHECKING([for wish executable])
-  for dir in \
-   ${TK_EXEC_PREFIX}/bin \
-   ${TK_EXEC_PREFIX}
-  do
-    for wishexe in \
-      wish-X11 \
-      wish \
-      wish${TK_VERSION} \
-      wish.exe \
-      wish${TK_VERSION}.exe
+  if text "x${magic_with_wish_binary}" = "x" ; then
+    AC_MSG_CHECKING([for wish executable])
+    for dir in \
+    ${TK_EXEC_PREFIX}/bin \
+    ${TK_EXEC_PREFIX}
     do
-      if test -r "$dir/$wishexe" ; then
-        WISH_EXE=$dir/$wishexe
+      for wishexe in \
+        wish-X11 \
+        wish \
+        wish${TK_VERSION} \
+        wish.exe \
+        wish${TK_VERSION}.exe
+      do
+        if test -r "$dir/$wishexe" ; then
+          WISH_EXE=$dir/$wishexe
+          break
+        fi
+      done
+      if test "x${WISH_EXE}" != "x" ; then
         break
       fi
     done
-    if test "x${WISH_EXE}" != "x" ; then
-      break
+    if test "x${WISH_EXE}" = "x" ; then
+      echo "Warning: Can't find executable for \"wish\".  You may have to"
+      echo "manually set the value for WISH_EXE in the magic startup script."
+      AC_MSG_RESULT(no)
+    else
+      AC_MSG_RESULT([${WISH_EXE}])
     fi
-  done
-  if test "x${WISH_EXE}" = "x" ; then
-    echo "Warning: Can't find executable for \"wish\".  You may have to"
-    echo "manually set the value for WISH_EXE in the magic startup script." 
-    AC_MSG_RESULT(no)
   else
-    AC_MSG_RESULT([${WISH_EXE}])
+    WISH_EXE=${magic_with_wish_binary}
   fi
 
 # Find the version of "tclsh" that corresponds to TCL_EXEC_PREFIX

--- a/tcltk/Makefile
+++ b/tcltk/Makefile
@@ -59,10 +59,9 @@ magicdnull: magicdnull.c ${MAGICDIR}/defs.mak
 		${GR_LIBS}
 
 magic.tcl: magic.tcl.in ${MAGICDIR}/defs.mak
-	sed -e /TCL_DIR/s%TCL_DIR%${TCLDIR}%g  \
-	    -e /MAGIC_VERSION/s%MAGIC_VERSION%${MAGIC_VERSION}%g \
+	sed -e /MAGIC_VERSION/s%MAGIC_VERSION%${MAGIC_VERSION}%g \
 	    -e /MAGIC_REVISION/s%MAGIC_REVISION%${MAGIC_REVISION}%g \
-            -e /SHDLIB_EXT/s%SHDLIB_EXT%${SHDLIB_EXT}%g magic.tcl.in > magic.tcl
+		magic.tcl.in > magic.tcl
 
 magic.sh: magic.sh.in ${MAGICDIR}/defs.mak
 	sed -e /TCL_DIR/s%TCL_DIR%${TCLDIR}%g \

--- a/tcltk/Makefile
+++ b/tcltk/Makefile
@@ -31,6 +31,11 @@ TCL_FILES = \
 	readspice.tcl \
 	magic.tcl
 
+TCL_DIR_REL_OR_ABS = $(shell ${MAGICDIR}/tcltk/relpath.sh "$(DESTDIR)${INSTALL_BINDIR}" ${TCLDIR})
+ifeq ($(TCL_DIR_REL_OR_ABS),)
+TCL_DIR_REL_OR_ABS = ${TCLDIR}
+endif
+
 BIN_FILES = \
 	$(DESTDIR)${INSTALL_BINDIR}/magic.sh \
 	$(DESTDIR)${INSTALL_BINDIR}/ext2spice.sh \
@@ -64,15 +69,15 @@ magic.tcl: magic.tcl.in ${MAGICDIR}/defs.mak
 		magic.tcl.in > magic.tcl
 
 magic.sh: magic.sh.in ${MAGICDIR}/defs.mak
-	sed -e /TCL_DIR/s%TCL_DIR%${TCLDIR}%g \
+	sed -e /TCL_DIR_REL_OR_ABS/s%TCL_DIR_REL_OR_ABS%${TCL_DIR_REL_OR_ABS}%g \
 	    -e /TCLLIB_DIR/s%TCLLIB_DIR%${TCL_LIB_DIR}%g \
 	    -e /WISH_EXE/s%WISH_EXE%${WISH_EXE}%g magic.sh.in > magic.sh
 
 ext2spice.sh: ext2spice.sh.in ${MAGICDIR}/defs.mak
-	sed -e /TCL_DIR/s%TCL_DIR%${TCLDIR}%g ext2spice.sh.in > ext2spice.sh
+	sed -e /TCL_DIR_REL_OR_ABS/s%TCL_DIR_REL_OR_ABS%${TCL_DIR_REL_OR_ABS}%g ext2spice.sh.in > ext2spice.sh
 
 ext2sim.sh: ext2sim.sh.in ${MAGICDIR}/defs.mak
-	sed -e /TCL_DIR/s%TCL_DIR%${TCLDIR}%g ext2sim.sh.in > ext2sim.sh
+	sed -e /TCL_DIR_REL_OR_ABS/s%TCL_DIR_REL_OR_ABS%${TCL_DIR_REL_OR_ABS}%g ext2sim.sh.in > ext2sim.sh
 
 $(DESTDIR)${INSTALL_TCLDIR}/%: %
 	${RM} $(DESTDIR)${INSTALL_TCLDIR}/$*

--- a/tcltk/ext2sim.sh.in
+++ b/tcltk/ext2sim.sh.in
@@ -14,8 +14,14 @@ for i in $@; do
       *) esargs="$esargs $i" ;;
    esac
 done
+TCL_REL_OR_ABS=TCL_DIR_REL_OR_ABS
+if [ "${TCL_REL_OR_ABS:0:1}" = "/" ]; then
+TCL_DIR=$TCL_REL_OR_ABS
+else
+TCL_DIR=$(dirname $(realpath ${BASH_SOURCE[0]}))/$TCL_REL_OR_ABS
+fi
 #
-eval TCL_DIR/magicdnull -dnull -noconsole -nowrapper $mgargs <<EOF
+eval ${TCL_DIR}/magicdnull -dnull -noconsole -nowrapper $mgargs <<EOF
 drc off
 box 0 0 0 0
 ext2sim $esargs

--- a/tcltk/ext2spice.sh.in
+++ b/tcltk/ext2spice.sh.in
@@ -14,8 +14,14 @@ for i in $@; do
       *) esargs="$esargs $i" ;;
    esac
 done
+TCL_REL_OR_ABS=TCL_DIR_REL_OR_ABS
+if [ "${TCL_REL_OR_ABS:0:1}" = "/" ]; then
+TCL_DIR=$TCL_REL_OR_ABS
+else
+TCL_DIR=$(dirname $(realpath ${BASH_SOURCE[0]}))/$TCL_REL_OR_ABS
+fi
 #
-eval TCL_DIR/magicdnull -dnull -noconsole -nowrapper $mgargs <<EOF
+eval ${TCL_DIR}/magicdnull -dnull -noconsole -nowrapper $mgargs <<EOF
 drc off
 box 0 0 0 0
 ext2spice $esargs

--- a/tcltk/magic.sh.in
+++ b/tcltk/magic.sh.in
@@ -11,6 +11,12 @@
 # Parse for the argument "-c[onsole]".  If it exists, run magic
 # with the TkCon console.  Strip this argument from the argument list.
 
+TCL_REL_OR_ABS=TCL_DIR_REL_OR_ABS
+if [ "${TCL_REL_OR_ABS:0:1}" = "/" ]; then
+TCL_DIR=$TCL_REL_OR_ABS
+else
+TCL_DIR=$(dirname $(realpath ${BASH_SOURCE[0]}))/$TCL_REL_OR_ABS
+fi
 TKCON=true
 DNULL=
 MAGIC_WISH=WISH_EXE
@@ -37,12 +43,12 @@ done
 if [ $TKCON ]; then
 
    if [ $DNULL ]; then
-      exec TCL_DIR/tkcon.tcl -eval "source TCL_DIR/console.tcl" \
-	   -slave "set argc $#; set argv [list $*]; source TCL_DIR/magic.tcl"
+      exec $TCL_DIR/tkcon.tcl -eval "source $TCL_DIR/console.tcl" \
+	   -slave "set argc $#; set argv [list $*]; source $TCL_DIR/magic.tcl"
    else
-      exec TCL_DIR/tkcon.tcl -eval "source TCL_DIR/console.tcl" \
+      exec $TCL_DIR/tkcon.tcl -eval "source $TCL_DIR/console.tcl" \
 	   -slave "package require Tk; set argc $#; set argv [list $arglist]; \
-	   source TCL_DIR/magic.tcl"
+	   source $TCL_DIR/magic.tcl"
    fi
 
 else
@@ -57,8 +63,8 @@ else
 # only, efficient for running in batch mode).
 #
    if [ $DNULL ]; then
-      exec TCL_DIR/magicdnull -nowrapper "$@"
+      exec $TCL_DIR/magicdnull -nowrapper "$@"
    else
-      exec TCL_DIR/magicexec -- "$@"
+      exec $TCL_DIR/magicexec -- "$@"
    fi
 fi

--- a/tcltk/magic.tcl.in
+++ b/tcltk/magic.tcl.in
@@ -1,19 +1,20 @@
 # Wishrc startup for ToolScript (magic)
 #
 # For installation:  Put this file and also magicwrap.so into
-# directory TCL_DIR, and set the "load" line below
-# to point to the location of magicwrap.so.  Also see comments
-# in shell script "magic.sh".
+# the same directory. Also see comments in shell script "magic.sh".
 
 global Opts
-  
+
 # If we called magic via the non-console script, then we want to reset
 # the environment variable HOME to its original value.
-   
+
+variable MAGIC_TCL_DIR [file dirname [file normalize [info script]]]
+variable CAD_ROOT_DEFAULT [file normalize [file join $MAGIC_TCL_DIR ../..]]
+
 if {${tcl_version} >= 8.6} {
-   load -lazy TCL_DIR/tclmagicSHDLIB_EXT
+   load -lazy [file join $MAGIC_TCL_DIR tclmagic[info sharedlibextension]]
 } else {
-   load TCL_DIR/tclmagicSHDLIB_EXT
+   load [file join $MAGIC_TCL_DIR tclmagic[info sharedlibextension]]
 }
 
 # It is important to make sure no magic commands overlap with Tcl built-in
@@ -30,8 +31,8 @@ proc pushnamespace { name } {
    foreach v $y {
       regsub -all {\*} $v {\\*} i
       set x [namespace tail $i]
-      if {[lsearch $z $x] < 0} { 
-         namespace import $i                       
+      if {[lsearch $z $x] < 0} {
+         namespace import $i
       }
    }
 }
@@ -124,7 +125,7 @@ proc xcircuit { args } {
       # execute script in the scope of magic, because its variable space is
       # not modularized.
       set argv $args
-      set argc [llength $args] 
+      set argc [llength $args]
       uplevel #0 source $xcircscript
    }
 }
@@ -143,7 +144,7 @@ proc netgen { args } {
       puts stderr "\"source <path>/netgen.tcl\"."
    } else {
       set argv $args
-      set argc [llength $args] 
+      set argc [llength $args]
       uplevel #0 source $netgenscript
    }
 }
@@ -151,7 +152,7 @@ proc netgen { args } {
 # Add the "echo" command
 
 proc echo {args} {
-   puts stdout $args  
+   puts stdout $args
 }
 
 # Parse argument list for "-c[onsole]" and "-now[rapper]".

--- a/tcltk/relpath.sh
+++ b/tcltk/relpath.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# From https://stackoverflow.com/questions/2564634/convert-absolute-path-into-relative-path-given-a-current-directory-using-bash
+# both $1 and $2 are absolute paths beginning with /
+# returns relative path to $2/$target from $1/$source
+source=$1
+target=$2
+
+common_part=$source # for now
+result="" # for now
+
+while [[ "${target#$common_part}" == "${target}" ]]; do
+    # no match, means that candidate common part is not correct
+    # go up one level (reduce common part)
+    common_part="$(dirname $common_part)"
+    # and record that we went back, with correct / handling
+    if [[ -z $result ]]; then
+        result=".."
+    else
+        result="../$result"
+    fi
+done
+
+if [[ $common_part == "/" ]]; then
+    # special case for root (no common path)
+    result="$result/"
+fi
+
+# since we now have identified the common part,
+# compute the non-common part
+forward_part="${target#$common_part}"
+
+# and now stick all parts together
+if [[ -n $result ]] && [[ -n $forward_part ]]; then
+    result="$result$forward_part"
+elif [[ -n $forward_part ]]; then
+    # extra slash removal
+    result="${forward_part:1}"
+fi
+
+echo $result

--- a/tcltk/tclmagic.c
+++ b/tcltk/tclmagic.c
@@ -1224,7 +1224,7 @@ Tclmagic_Init(interp)
     /* Set $CAD_ROOT as a Tcl variable */
 
     cadroot = getenv("CAD_ROOT");
-    if (cadroot == NULL) cadroot = CAD_DIR;
+    if (cadroot == NULL) cadroot = Tcl_GetVar(interp, "CAD_ROOT_DEFAULT", TCL_GLOBAL_ONLY);
 
     Tcl_SetVar(interp, "CAD_ROOT", cadroot, TCL_GLOBAL_ONLY);
 


### PR DESCRIPTION
I was trying to put together a [binarybuilder.org](https://binarybuilder.org) recipe for `magic`,
but BinaryBuilder was upset that the final result embedded lots of build system paths and
was not relocatable (i.e. being able to be moved to a different prefix after the fact).
Unfortunately, the `magic` build system appears to embed paths all over the place,
so I didn't manage to fix everything, but with the three commits in this PR, it at least
started up correctly after moving it to a different prefix.