### PR TITLE
maxwidth not registering DRC error when only one direction exceeds limit

### DIFF
--- a/drc/DRCextend.c
+++ b/drc/DRCextend.c
@@ -274,7 +274,7 @@ drcCheckMaxwidth(starttile,arg,cptr)
 	    if (TTMaskHasType(oktypes, TiGetLeftType(tp))) PUSHTILE(tp);
     }
 
-    if (boundrect.r_xtop - boundrect.r_xbot > edgelimit &&
+    if (boundrect.r_xtop - boundrect.r_xbot > edgelimit ||
              boundrect.r_ytop - boundrect.r_ybot > edgelimit)
     {
 	Rect	rect;


### PR DESCRIPTION
Commit message: When comparing maxwidth, only one direction (x or y) need exceed the edgelimit parameter; versus both directions need to exceed the limit.  Changed the '&&' to a '||'

tech file maxwidth declaration in the drc section.  The DRC error is only registered when both the x and y directions exceed the limit.  By changing the logical && operator to a logical || operator, the DRC error will be registers if either direction exceeds the limit.

However, in looking at the documentation:

 ```
Maxwidth Rules

Sometimes a technology requires that a region not be wider than a certain value. The maxwidth rule can be 
used to check this.

    maxwidth layers mwidth [bends] why 

Layers, the types that compose the region, must all be in the same plane. The region must be less than mwidth wide 
in either the horizontal or vertical dimension. Bends takes one of two values, bend_illegal and bend_ok. 
For bend_illegal rules, the checker forms a bounding box around all contiguous tiles of the correct type, then 
checks this box's width.
```
...maybe this behavior is intended. If so, then may I propose an additional option to maxwidth?  That being a "both" option so that both directions are checked. 