### PR TITLE
Ignore derived files when compiling on OSX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ tcltk/magicdnull
 tcltk/magicexec
 tcltk/ext2spice.sh
 tcltk/ext2sim.sh
+magic/tclmagic.dylib
+tcltk/magicdnull.dSYM/
+tcltk/magicexec.dSYM/


### PR DESCRIPTION
Add a file and a couple of directories to the .gitignore. These are derived when compiling on OSX