### PR TITLE
Fix a few compiler warnings

### DIFF
--- a/calma/CalmaRead.c
+++ b/calma/CalmaRead.c
@@ -385,7 +385,7 @@ CalmaReadError(format, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10)
             {
                 fprintf(calmaErrorFile, "Error while reading cell \"%s\" ",
                                 cifReadCellDef->cd_name);
-		fprintf(calmaErrorFile, "(byte position %"DLONG_PREFIX"ld): ",
+		fprintf(calmaErrorFile, "(byte position %"DLONG_PREFIX"d): ",
 				(dlong)filepos);
                 fprintf(calmaErrorFile, format, a1, a2, a3, a4, a5, a6, a7,
                                 a8, a9, a10);

--- a/database/DBcellsrch.c
+++ b/database/DBcellsrch.c
@@ -21,6 +21,7 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 #endif  /* not lint */
 
 #include <stdio.h>
+#include <string.h>
 
 #include "utils/magic.h"
 #include "utils/malloc.h"

--- a/plow/PlowRandom.c
+++ b/plow/PlowRandom.c
@@ -26,6 +26,7 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <sys/types.h>
 #include <sys/file.h>
 #include <sys/stat.h>


### PR DESCRIPTION
We were missing string.h in a few places, and were also creating
a string format of %llld.