### PR TITLE
Set GrClosePtr back to NULL before calling MainExit()

### DIFF
--- a/graphics/grTk1.c
+++ b/graphics/grTk1.c
@@ -527,6 +527,7 @@ GrTkInit(dispType)
 	    TxPrintf("None of TrueColor 15, 16 or 24, or PseudoColor 8 found. "
 			"Cannot initialize DISPLAY %s\n", getenv("DISPLAY"));
 	    XFree(grvisual_get);
+	    GrClosePtr = NULL;
 	    MainExit(1);
 	}
 	else


### PR DESCRIPTION
to squash the seg fault. It appears that calling GrTkClose
before graphics are fully initialized causes this.