### PR TITLE
One last change for issue #50

### DIFF
--- a/extract/ExtBasic.c
+++ b/extract/ExtBasic.c
@@ -3938,7 +3938,7 @@ extNodeAreaFunc(tile, arg)
 	    GEOCLIP(&r, extNodeClipArea);
 	    area = (dlong)(r.r_xtop - r.r_xbot) * (dlong)(r.r_ytop - r.r_ybot);
 	}
-	else area = (dlong)TILEAREA(tile);
+	else area = (dlong)(TOP(tile) - BOTTOM(tile)) * (dlong)(RIGHT(tile) - LEFT(tile));
 
 	if (IsSplit(tile)) area /= 2;	/* Split tiles are 1/2 area! */
 


### PR DESCRIPTION
expanded TILEAREA macro and cast the operands for the product to dlong

Resolves Issue #50

Extraction for test case now as expected (negative area no longer present):

timestamp 1607100556
version 8.3
tech amic5n
style ngspice
scale 1000 1 1
resistclasses 816000 816000 82400 102700 22300 41300 41300 85 85 40
node "m1_0_0#" 0 5.87648e+06 0 0 m1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 2148322500 185400 0 0 0 0
substrate "vss" 0 0 -1073741817 -1073741817 space 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
