### PR TITLE
Restore terminal if exit is called inside a TCL script at startup

### DIFF
--- a/utils/main.c
+++ b/utils/main.c
@@ -770,6 +770,12 @@ mainInitAfterArgs()
     return 0;
 }
 
+void tcl_exit_hook(ClientData clientData)
+{
+    TxResetTerminal();
+    exit(0);
+}
+
 /*
  * ----------------------------------------------------------------------------
  * mainInitFinal:
@@ -793,6 +799,9 @@ mainInitFinal()
     FILE *f;
     char *rname;
     int result;
+
+    /* Reset terminal if exit is called inside a TCL script */
+    Tcl_SetExitProc(tcl_exit_hook);
 
 #ifdef MAGIC_WRAPPER
 
@@ -1186,6 +1195,8 @@ mainInitFinal()
      */
     UndoFlush();
     TxClearPoint();
+
+    Tcl_SetExitProc(NULL);
 
     return 0;
 }


### PR DESCRIPTION
If exit is called in a TCL script that is executed at startup, the libc
exit() function is called directly and we don't get a chance to reset
the terminal. We return to the shell with echo off, and have to run
"reset". A simple example:

echo exit > test.tcl
magic -noconsole -dnull  test.tcl

There are a few ways we could solve this. We could register an exit
handler using atexit(). Here I use Tcl_SetExitProc() to register a
callback with the TCL interpreter.