### PR TITLE
Fixes for relocatability [round 2]

### DIFF
--- a/tcltk/Makefile
+++ b/tcltk/Makefile
@@ -32,6 +32,11 @@ TCL_FILES = \
 	readspice.tcl \
 	magic.tcl
 
+TCL_DIR_REL_OR_ABS = $(shell ${MAGICDIR}/tcltk/relpath.sh "$(DESTDIR)${INSTALL_BINDIR}" ${TCLDIR})
+ifeq ($(TCL_DIR_REL_OR_ABS),)
+TCL_DIR_REL_OR_ABS = ${TCLDIR}
+endif
+
 BIN_FILES = \
 	$(DESTDIR)${INSTALL_BINDIR}/magic.sh \
 	$(DESTDIR)${INSTALL_BINDIR}/ext2spice.sh \
@@ -65,16 +70,16 @@ magic.tcl: magic.tcl.in ${MAGICDIR}/defs.mak ${MAGICDIR}/VERSION
 	    magic.tcl.in > magic.tcl
 
 magic.sh: magic.sh.in ${MAGICDIR}/defs.mak
-	sed -e /TCL_DIR/s%TCL_DIR%${TCLDIR}%g \
+	sed -e /TCL_DIR_REL_OR_ABS/s%TCL_DIR_REL_OR_ABS%${TCL_DIR_REL_OR_ABS}%g \
 	    -e /TCLLIB_DIR/s%TCLLIB_DIR%${TCL_LIB_DIR}%g \
 	    -e /WISH_EXE/s%WISH_EXE%${WISH_EXE}%g magic.sh.in > magic.sh
 
 ext2spice.sh: ext2spice.sh.in ${MAGICDIR}/defs.mak
-	sed -e /TCL_DIR/s%TCL_DIR%${TCLDIR}%g \
+	sed -e /TCL_DIR_REL_OR_ABS/s%TCL_DIR_REL_OR_ABS%${TCL_DIR_REL_OR_ABS}%g \
 	    ext2spice.sh.in > ext2spice.sh
 
 ext2sim.sh: ext2sim.sh.in ${MAGICDIR}/defs.mak
-	sed -e /TCL_DIR/s%TCL_DIR%${TCLDIR}%g \
+	sed -e /TCL_DIR_REL_OR_ABS/s%TCL_DIR_REL_OR_ABS%${TCL_DIR_REL_OR_ABS}%g \
 	    ext2sim.sh.in > ext2sim.sh
 
 $(DESTDIR)${INSTALL_TCLDIR}/%: %

--- a/tcltk/ext2sim.sh.in
+++ b/tcltk/ext2sim.sh.in
@@ -14,12 +14,14 @@ for i in $@; do
       *) esargs="$esargs $i" ;;
    esac
 done
-TCL_MAG_DIR=${CAD_ROOT}/magic/tcl
-if [ "${TCL_MAG_DIR}" = "/magic/tcl" ]; then
-   TCL_MAG_DIR=TCL_DIR
+TCL_REL_OR_ABS=TCL_DIR_REL_OR_ABS
+if [ "${TCL_REL_OR_ABS:0:1}" = "/" ]; then
+   TCL_DIR=$TCL_REL_OR_ABS
+else
+   TCL_DIR=$(cd $(dirname ${BASH_SOURCE[0]})/$TCL_REL_OR_ABS; pwd -P)
 fi
 #
-eval ${TCL_MAG_DIR}/magicdnull -dnull -noconsole -nowrapper $mgargs <<EOF
+eval ${TCL_DIR}/magicdnull -dnull -noconsole -nowrapper $mgargs <<EOF
 drc off
 box 0 0 0 0
 ext2sim $esargs

--- a/tcltk/ext2spice.sh.in
+++ b/tcltk/ext2spice.sh.in
@@ -14,12 +14,14 @@ for i in $@; do
       *) esargs="$esargs $i" ;;
    esac
 done
-TCL_MAG_DIR=${CAD_ROOT}/magic/tcl
-if [ "${TCL_MAG_DIR}" = "/magic/tcl" ]; then
-   TCL_MAG_DIR=TCL_DIR
+TCL_REL_OR_ABS=TCL_DIR_REL_OR_ABS
+if [ "${TCL_REL_OR_ABS:0:1}" = "/" ]; then
+   TCL_DIR=$TCL_REL_OR_ABS
+else
+   TCL_DIR=$(cd $(dirname ${BASH_SOURCE[0]})/$TCL_REL_OR_ABS; pwd -P)
 fi
 #
-eval ${TCL_MAG_DIR}/magicdnull -dnull -noconsole -nowrapper $mgargs <<EOF
+eval ${TCL_DIR}/magicdnull -dnull -noconsole -nowrapper $mgargs <<EOF
 drc off
 box 0 0 0 0
 ext2spice $esargs

--- a/tcltk/magic.sh.in
+++ b/tcltk/magic.sh.in
@@ -11,9 +11,11 @@
 # Parse for the argument "-c[onsole]".  If it exists, run magic
 # with the TkCon console.  Strip this argument from the argument list.
 
-TCL_MAG_DIR=${CAD_ROOT}/magic/tcl
-if [ "${TCL_MAG_DIR}" = "/magic/tcl" ]; then
-   TCL_MAG_DIR=TCL_DIR
+TCL_REL_OR_ABS=TCL_DIR_REL_OR_ABS
+if [ "${TCL_REL_OR_ABS:0:1}" = "/" ]; then
+   TCL_DIR=$TCL_REL_OR_ABS
+else
+   TCL_DIR=$(cd $(dirname ${BASH_SOURCE[0]})/$TCL_REL_OR_ABS; pwd -P)
 fi
 TKCON=true
 DNULL=
@@ -41,12 +43,12 @@ done
 if [ $TKCON ]; then
 
    if [ $DNULL ]; then
-      exec $TCL_MAG_DIR/tkcon.tcl -eval "source $TCL_MAG_DIR/console.tcl" \
-	   -slave "set argc $#; set argv [list $*]; source $TCL_MAG_DIR/magic.tcl"
+      exec $TCL_DIR/tkcon.tcl -eval "source $TCL_DIR/console.tcl" \
+	   -slave "set argc $#; set argv [list $*]; source $TCL_DIR/magic.tcl"
    else
-      exec $TCL_MAG_DIR/tkcon.tcl -eval "source $TCL_MAG_DIR/console.tcl" \
+      exec $TCL_DIR/tkcon.tcl -eval "source $TCL_DIR/console.tcl" \
 	   -slave "package require Tk; set argc $#; set argv [list $arglist]; \
-	   source $TCL_MAG_DIR/magic.tcl"
+	   source $TCL_DIR/magic.tcl"
    fi
 
 else
@@ -61,8 +63,8 @@ else
 # only, efficient for running in batch mode).
 #
    if [ $DNULL ]; then
-      exec $TCL_MAG_DIR/magicdnull -nowrapper "$@"
+      exec $TCL_DIR/magicdnull -nowrapper "$@"
    else
-      exec $TCL_MAG_DIR/magicexec -- "$@"
+      exec $TCL_DIR/magicexec -- "$@"
    fi
 fi

--- a/tcltk/magic.sh.in
+++ b/tcltk/magic.sh.in
@@ -15,7 +15,7 @@ TCL_REL_OR_ABS=TCL_DIR_REL_OR_ABS
 if [ "${TCL_REL_OR_ABS:0:1}" = "/" ]; then
    TCL_DIR=$TCL_REL_OR_ABS
 else
-   TCL_DIR=$(cd $(dirname ${BASH_SOURCE[0]})/$TCL_REL_OR_ABS; pwd -P)
+   TCL_DIR=$(cd $(dirname $(readlink -f ${BASH_SOURCE[0]}))/$TCL_REL_OR_ABS; pwd -P)
 fi
 TKCON=true
 DNULL=

--- a/tcltk/magic.tcl.in
+++ b/tcltk/magic.tcl.in
@@ -9,7 +9,10 @@ global Opts
 # the environment variable HOME to its original value.
 
 variable MAGIC_TCL_DIR [file dirname [file normalize [info script]]]
-variable CAD_ROOT_DEFAULT [file normalize [file join $MAGIC_TCL_DIR ../..]]
+
+if {![info exists CAD_ROOT]} {
+   variable CAD_ROOT [file normalize [file join $MAGIC_TCL_DIR ../..]]
+}
 
 if {${tcl_version} >= 8.6} {
    load -lazy [file join $MAGIC_TCL_DIR tclmagic[info sharedlibextension]]

--- a/tcltk/magicdnull.c
+++ b/tcltk/magicdnull.c
@@ -28,8 +28,17 @@ magic_AppInit(interp)
 
     /* This is where we replace the home ".tclshrc" file with	*/
     /* magic's startup script.					*/
-
-    Tcl_SetVar(interp, "tcl_rcFileName", TCL_DIR "/magic.tcl", TCL_GLOBAL_ONLY);
+    /* Try to find magic.tcl relative to the current executable.
+       If that fails, try to load it from the path where it was located
+       at build time.
+     */
+    const char *magic_tcl_path = NULL;
+    if (Tcl_ExprString(interp, "[file join [file dirname [info nameofexecutable]] magic.tcl]") == TCL_OK) {
+        magic_tcl_path = Tcl_GetStringResult(interp);
+    } else {
+        magic_tcl_path = TCL_DIR "/magic.tcl";
+    }
+    Tcl_SetVar(interp, "tcl_rcFileName", magic_tcl_path, TCL_GLOBAL_ONLY);
 
     /* Additional variable can be used to tell if magic is in batch mode */
     Tcl_SetVar(interp, "batch_mode", "true", TCL_GLOBAL_ONLY);

--- a/tcltk/magicexec.c
+++ b/tcltk/magicexec.c
@@ -59,7 +59,17 @@ magic_AppInit(interp)
     /* This is where we replace the home ".wishrc" file with	*/
     /* magic's startup script.					*/
 
-    Tcl_SetVar(interp, "tcl_rcFileName", TCL_DIR "/magic.tcl", TCL_GLOBAL_ONLY);
+    /* Try to find magic.tcl relative to the current executable.
+       If that fails, try to load it from the path where it was located
+       at build time.
+     */
+    const char *magic_tcl_path = NULL;
+    if (Tcl_ExprString(interp, "[file join [file dirname [info nameofexecutable]] magic.tcl]") == TCL_OK) {
+        magic_tcl_path = Tcl_GetStringResult(interp);
+    } else {
+        magic_tcl_path = TCL_DIR "/magic.tcl";
+    }
+    Tcl_SetVar(interp, "tcl_rcFileName", magic_tcl_path, TCL_GLOBAL_ONLY);
     return TCL_OK;
 }
 

--- a/tcltk/relpath.sh
+++ b/tcltk/relpath.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# From https://stackoverflow.com/questions/2564634/convert-absolute-path-into-relative-path-given-a-current-directory-using-bash
+# both $1 and $2 are absolute paths beginning with /
+# returns relative path to $2/$target from $1/$source
+source=$1
+target=$2
+
+common_part=$source # for now
+result="" # for now
+
+while [[ "${target#$common_part}" == "${target}" ]]; do
+    # no match, means that candidate common part is not correct
+    # go up one level (reduce common part)
+    common_part="$(dirname $common_part)"
+    # and record that we went back, with correct / handling
+    if [[ -z $result ]]; then
+        result=".."
+    else
+        result="../$result"
+    fi
+done
+
+if [[ $common_part == "/" ]]; then
+    # special case for root (no common path)
+    result="$result/"
+fi
+
+# since we now have identified the common part,
+# compute the non-common part
+forward_part="${target#$common_part}"
+
+# and now stick all parts together
+if [[ -n $result ]] && [[ -n $forward_part ]]; then
+    result="$result$forward_part"
+elif [[ -n $forward_part ]]; then
+    # extra slash removal
+    result="${forward_part:1}"
+fi
+
+echo $result


### PR DESCRIPTION
I'm updating our distribution of magic and noticed that my fixes in #41
had broken, so this attempts to restore them. I understand that there's
a number of different configurations that people use magic in, so I'm
happy to carry these locally in our distribution setup if they break something
else, but I figured I'd at least have another go at it.

The three changes here are:
- Restoration of the automatic CAD_ROOT detection from the `bin/magic` script.

I understand this got reverted in c0867ef because it broke symlinking to the script. This adds an extra `readlink -f` to fix that corner case. However, since I don't know the exact details of what broke there, it'd be good to verify that.

- In merging #41, there was a change to just respect an already set `CAD_ROOT` rather than using the `CAD_ROOT_DEFAULT` variable I added. However, the corresponding creation of the `CAD_ROOT_DEFAULT` variable in magic.tcl was not adjusted, so cad root was not set automatically. Fix that by renaming the `CAD_ROOT_DEFAULT` to `CAD_ROOT` there also (making sure to respect it if already set).
- Also fix relocation of `magicdnull` and `magicexec`. This fixes downstream tooling that does things like `magic --version` which currently just starts a tcl interpreter (blocking forever) is `magic.tcl` is not found because it was relocated.