### PR TITLE
Fix build error with clang

### DIFF
--- a/extract/ExtCell.c
+++ b/extract/ExtCell.c
@@ -112,7 +112,7 @@ ExtCell(def, outName, doLength)
 	TxError("Cannot open output file: ");
 	perror(filename);
 #endif
-	return;
+	return NULL;
     }
 
     extNumFatal = extNumWarnings = 0;


### PR DESCRIPTION
At least in some configurations of clang, `-Wreturn-type` is set to
error by default, causing the magic build to fail with:

```
ExtCell.c:115:2: error: non-void function 'ExtCell' should return a value [-Wreturn-type]
```