### PR TITLE
Fixed two bugs on the `def write` command

### DIFF
--- a/lef/defWrite.c
+++ b/lef/defWrite.c
@@ -950,7 +950,7 @@ defNetGeometryFunc(tile, plane, defdata)
 	{
 	    /* Diagnostic */
 	    TxPrintf("Net has width %d, default width is %d\n",
-			(h > w) ? h : w, routeWidth);
+			(h < w) ? h : w, routeWidth);
 	}
 
 	/* Find the route orientation and centerline endpoint coordinates */

--- a/lef/defWrite.c
+++ b/lef/defWrite.c
@@ -1982,10 +1982,10 @@ defComponentFunc(cellUse, defdata)
 	nameroot = cellUse->cu_def->cd_name;
 
     fprintf(f, "   - %s %s\n      + PLACED ( %.10g %.10g ) %s ;\n",
-	cellUse->cu_id, nameroot,
-	(float)cellUse->cu_bbox.r_xbot * oscale,
-	(float)cellUse->cu_bbox.r_ybot * oscale,
-	defTransPos(&cellUse->cu_transform));
+		cellUse->cu_id, nameroot,
+		(float)(cellUse->cu_bbox.r_xbot - cellUse->cu_def->cd_bbox.r_ll.p_x) * oscale,
+		(float)(cellUse->cu_bbox.r_ybot - cellUse->cu_def->cd_bbox.r_ll.p_y) * oscale,
+		defTransPos(&cellUse->cu_transform));
 
     return 0;	/* Keep the search going */
 }

--- a/lef/defWrite.c
+++ b/lef/defWrite.c
@@ -963,8 +963,13 @@ defNetGeometryFunc(tile, plane, defdata)
 	    x1 = r.r_xbot * oscale;
 	    x2 = r.r_xtop * oscale;
 	    if (routeWidth == 0) routeWidth = h;
-	    extlen = (defdata->specialmode != DO_REGULAR) ?
-			0 : (routeWidth * oscale) / 2;
+	    
+		extlen = 0;
+		if(defdata->specialmode == DO_REGULAR)
+		{
+			x1 = x1 + (routeWidth/2*oscale);
+			x2 = x2 - (routeWidth/2*oscale);
+		}
 	}
 	else	/* vertical orientation */
 	{
@@ -974,8 +979,13 @@ defNetGeometryFunc(tile, plane, defdata)
 	    y1 = r.r_ybot * oscale;
 	    y2 = r.r_ytop * oscale;
 	    if (routeWidth == 0) routeWidth = w;
-	    extlen = (defdata->specialmode != DO_REGULAR) ?
-			0 : (routeWidth * oscale) / 2;
+		
+		extlen = 0;
+		if(defdata->specialmode == DO_REGULAR)
+		{
+			y1 = y1 + (routeWidth/2*oscale);
+			y2 = y2 - (routeWidth/2*oscale);
+		}
 	}
     }
     else	/* Type is a via */


### PR DESCRIPTION
- def write was setting x,y location of `COMPONENTS` using the boundaries of the cell, without taking into account it's internal origin point
- The warning message about nets not having the default width was showing the wrong dimension (the bigger one instead of the smaller)