### PR TITLE
Eliminate bogus clearing of CPPFLAGS so the contents of CPPFLAGS

### DIFF
--- a/scripts/configure.in
+++ b/scripts/configure.in
@@ -225,7 +225,6 @@ stub_defs=""
 extra_defs="$extra_defs -DCAD_DIR=\\\"\${LIBDIR}\\\" -DBIN_DIR=\\\"\${BINDIR}\\\""
 X_LIBS=
 X_CFLAGS=
-CPPFLAGS=
 INC_SPECS=
 DEPEND_FLAG=
 SHLIB_CFLAGS=""


### PR DESCRIPTION
is properly passed down throughout the autoconf script.