### PR TITLE
Correct & has lower precedence than parentheses warnings.

### DIFF
--- a/commands/CmdRS.c
+++ b/commands/CmdRS.c
@@ -1266,7 +1266,7 @@ Okay:
 		if ((windowMask & ~xMask) != 0) {
 		    window = CmdGetRootPoint ((Point *) NULL, (Rect *) NULL);
 		    xMask = ((DBWclientRec *)window->w_clientData)->dbw_bitmask;
-		    if (windowMask & xMask == 0) {
+		    if ((windowMask & xMask) == 0) {
 			TxError("Box present in multiple windows; use the"
 				"cursor\nto select the one you want\n");
 			return;

--- a/drc/DRCtech.c
+++ b/drc/DRCtech.c
@@ -2570,7 +2570,7 @@ drcEdge(argc, argv)
 		    /* For fastest DRC, checkPlane and plane should be	*/
 		    /* the same, if possible.				*/
 
-		    if (pset & pMaskM != 0)
+		    if ((pset & pMaskM) != 0)
 		    {
 			plane = LowestMaskBit(pset & pMaskM);
 			checkPlane = plane;


### PR DESCRIPTION
CmdRS.c:1269:22: warning: & has lower precedence than ==; == will be evaluated first [-Wparentheses]
DRCtech.c:2573:16: warning: & has lower precedence than !=; != will be evaluated first [-Wparentheses]