### PR TITLE
fix tech file load error with qflow

### DIFF
--- a/utils/tech.c
+++ b/utils/tech.c
@@ -476,8 +476,13 @@ TechLoad(filename, initmask)
 
 	/* If a non-standard extension was used, then honor it */
 	if ((dptr != NULL) && (*dptr != '\0'))
+    {
 	    tf = PaOpen(filename, "r", (char *)NULL, ".", SysLibPath, &realname);
-	else
+        /* If the honored file in not there, try the filename with the suffix */
+        if (tf == (FILE *) NULL)
+	        tf = PaOpen(filename, "r", suffix, ".", SysLibPath, &realname);
+    }
+    else
 	    tf = PaOpen(filename, "r", suffix, ".", SysLibPath, &realname);
 
 	if (tf == (FILE *) NULL)


### PR DESCRIPTION
issue:
qflow passes tech file name without the '.tech' suffix. however magic tech load function treats any filename with suffix which in not '.tech' as a specified filename should be honored, leading to a problem that fails to load osu tech file

fix:
try loading a honored file with suffix '.tech' if the honored file is not there 