### PR TITLE
Fix typo in MakeLegalLEFSyntax

### DIFF
--- a/lef/lefWrite.c
+++ b/lef/lefWrite.c
@@ -945,7 +945,7 @@ MakeLegalLEFSyntax(text)
     rstr = StrDup((char **)NULL, text);
 
     for (cptr = rstr; *cptr != '\0'; cptr++)
-	for (bptr = badLEFchars; bptr != '\0'; bptr++)
+	for (bptr = badLEFchars; *bptr != '\0'; bptr++)
 	    if (*cptr == *bptr)
 	    {
 		*cptr = '_';


### PR DESCRIPTION
In MakeLegalLEFSyntax we step through the badLEFchars string
but instead of looking for the NULL terminator, we instead
look for a NULL pointer.