### PR TITLE
Add missing includes

### DIFF
--- a/cif/CIFgen.c
+++ b/cif/CIFgen.c
@@ -24,6 +24,7 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 #include <stdio.h>
 #include <stdlib.h>             /* for abs() */
 #include <math.h>		/* for ceil() and sqrt() */
+#include <ctype.h>
 
 #include "utils/magic.h"
 #include "utils/geometry.h"

--- a/cif/CIFhier.c
+++ b/cif/CIFhier.c
@@ -27,6 +27,7 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 
 #include <stdio.h>
 #include <string.h>
+#include <ctype.h>
 
 #include "tcltk/tclmagic.h"
 #include "utils/magic.h"

--- a/database/DBcellsrch.c
+++ b/database/DBcellsrch.c
@@ -22,6 +22,7 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 
 #include <stdio.h>
 #include <string.h>
+#include <ctype.h>
 
 #include "utils/magic.h"
 #include "utils/malloc.h"

--- a/database/DBlabel.c
+++ b/database/DBlabel.c
@@ -25,6 +25,7 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 #include <stdlib.h>
 #include <string.h>
 #include <math.h>	/* For sin(), cos(), and round() functions */
+#include <ctype.h>
 
 #include "utils/magic.h"
 #include "utils/malloc.h"

--- a/database/DBprop.c
+++ b/database/DBprop.c
@@ -24,6 +24,7 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 #endif  /* not lint */
 
 #include <stdio.h>
+#include <string.h>
 #include "utils/magic.h"
 #include "utils/geometry.h"
 #include "tiles/tile.h"

--- a/drc/DRCtech.c
+++ b/drc/DRCtech.c
@@ -23,6 +23,7 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <ctype.h>
 
 #include "tcltk/tclmagic.h"
 #include "utils/magic.h"

--- a/extract/ExtBasic.c
+++ b/extract/ExtBasic.c
@@ -25,6 +25,7 @@ static char sccsid[] = "@(#)ExtBasic.c	4.13 MAGIC (Berkeley) 12/5/85";
 #include <stdlib.h>
 #include <string.h>
 #include <math.h>
+#include <ctype.h>
 
 #include "tcltk/tclmagic.h"
 #include "utils/magic.h"

--- a/mzrouter/mzMain.c
+++ b/mzrouter/mzMain.c
@@ -29,6 +29,7 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 /*--- includes --- */
 #include <stdio.h>
 #include <string.h>
+#include <stdlib.h>
 
 #include "utils/magic.h"
 #include "utils/geometry.h"

--- a/mzrouter/mzSearch.c
+++ b/mzrouter/mzSearch.c
@@ -127,6 +127,7 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 #endif  /* not lint */
 
 #include <stdio.h>
+#include <stdlib.h>
 
 #include "utils/magic.h"
 #include "utils/geometry.h"

--- a/utils/lookupfull.c
+++ b/utils/lookupfull.c
@@ -24,6 +24,7 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 
 #include <stdio.h>
 #include <string.h>
+#include <ctype.h>
 
 #include "utils/magic.h"
 

--- a/utils/macros.c
+++ b/utils/macros.c
@@ -23,6 +23,7 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 #include <stdio.h>
 #include <string.h>
 #include <signal.h>
+#include <ctype.h>
 #ifdef XLIB
 #include <X11/X.h>
 #include <X11/Xlib.h>


### PR DESCRIPTION
A number of places are using isspace(), tolower(), toupper() and strcmp()
without including the relevant header.