### PR TITLE
Add missing types in function prototypes

### DIFF
--- a/cif/CIFrdpt.c
+++ b/cif/CIFrdpt.c
@@ -237,6 +237,7 @@ void
 CIFPropRecordPath(def, pathheadp, iswire, propname)
     CellDef *def;
     CIFPath *pathheadp;
+    bool iswire;
     char *propname;
 {
     extern float CIFGetOutputScale();

--- a/commands/CmdLQ.c
+++ b/commands/CmdLQ.c
@@ -2228,6 +2228,7 @@ void
 CmdDoProperty(def, cmd, argstart)
     CellDef *def;
     TxCommand *cmd;
+    int argstart;
 {
     int printPropertiesFunc();
     char *value;

--- a/extflat/EFread.c
+++ b/extflat/EFread.c
@@ -132,7 +132,7 @@ static bool efReadDef();
 bool
 EFReadFile(name, dosubckt, resist, noscale)
     char *name; /* Name of def to be read in */
-    bool dosubckt, resist;
+    bool dosubckt, resist, noscale;
 {
     Def *def;
     bool  rc;

--- a/extract/ExtMain.c
+++ b/extract/ExtMain.c
@@ -660,6 +660,7 @@ struct saveList {
 void
 extExtractStack(stack, doExtract, rootDef)
     Stack *stack;
+    bool doExtract;
     CellDef *rootDef;
 {
     int errorcnt = 0, warnings = 0;

--- a/net2ir/net2ir.c
+++ b/net2ir/net2ir.c
@@ -47,6 +47,7 @@ typedef struct
 
 int
 main(argc, argv)
+    int argc;
     char *argv[];
 {
     char line1[LINESIZE], line2[LINESIZE], layer[LINESIZE], label[LINESIZE];

--- a/plow/PlowMain.c
+++ b/plow/PlowMain.c
@@ -1940,6 +1940,7 @@ plowMoveEdge(edge)
 Tile *
 plowSplitY(tp, y)
     Tile *tp;
+    int y;
 {
     Tile *newTile;
 

--- a/router/rtrPin.c
+++ b/router/rtrPin.c
@@ -88,6 +88,7 @@ RtrPinsInit(ch)
 int
 rtrPinArrayInit(ch, side, pins, nPins)
     GCRChannel *ch;
+    int side;
     GCRPin *pins;
     int nPins;
 {

--- a/router/rtrStem.c
+++ b/router/rtrStem.c
@@ -1237,15 +1237,17 @@ bool
 RtrComputeJogs(loc, stem, dir, contact, jog, start, width)
     NLTermLoc *loc;	/* Terminal whose stem is to be painted */
     Point *stem;		/* Point intersecting channel*/
-    Point *start;		/* Somewhere along terminal area */
-    Point *jog;			/* Where the stem crosses the first usable
-				 * grid line as it runs out from the cell.
-				 */
+    int dir;
     Point *contact;		/* A second grid point, where a contact can
 				 * be placed if necessary.  This is a the
 				 * nearest grid crossing to crossing outside
 				 * the channel.
 				 */
+    Point *jog;			/* Where the stem crosses the first usable
+				 * grid line as it runs out from the cell.
+				 */
+    Point *start;		/* Somewhere along terminal area */
+    int width;
 {
     Rect *area;
     area = &loc->nloc_rect;


### PR DESCRIPTION
It would be nice to convert the codebase from K&R to ANSI function
prototypes, but for now just clean up the warnings.