### PR TITLE
Add more information to illegal overlap warnings

### DIFF
--- a/extract/ExtHier.c
+++ b/extract/ExtHier.c
@@ -540,9 +540,13 @@ extHierConnectFunc2(cum, ha)
     }
     else if (r.r_xtop > r.r_xbot && r.r_ytop > r.r_ybot)
     {
+	char message[1024];
+	snprintf(message, sizeof(message), "Illegal overlap between %s and %s (types do not connect)",
+            DBTypeShortName(ha->hierType), DBTypeShortName(ttype));
+
 	extNumErrors++;
 	if (!DebugIsSet(extDebugID, extDebNoFeedback))
-	    DBWFeedbackAdd(&r, "Illegal overlap (types do not connect)",
+	    DBWFeedbackAdd(&r, message,
 		ha->ha_parentUse->cu_def, 1, STYLE_MEDIUMHIGHLIGHTS);
     }
 
@@ -642,9 +646,13 @@ extHierConnectFunc3(cum, ha)
     }
     else if (r.r_xtop > r.r_xbot && r.r_ytop > r.r_ybot)
     {
+	char message[1024];
+	snprintf(message, sizeof(message), "Illegal overlap between %s and %s (types do not connect)",
+            DBTypeShortName(ha->hierType), DBTypeShortName(ttype));
+
 	extNumErrors++;
 	if (!DebugIsSet(extDebugID, extDebNoFeedback))
-	    DBWFeedbackAdd(&r, "Illegal overlap (types do not connect)",
+	    DBWFeedbackAdd(&r, message,
 		ha->ha_parentUse->cu_def, 1, STYLE_MEDIUMHIGHLIGHTS);
     }
 


### PR DESCRIPTION
Print the names of the tile types that are illegally overlapping. This
gives us a better idea of what is wrong, eg:

feedback add "Illegal overlap between obsm2 and m2 (types do not connect)" medium