### PR TITLE
Patch for gcc11/RHEL9

### DIFF
--- a/database/DBio.c
+++ b/database/DBio.c
@@ -2829,12 +2829,12 @@ DBCellWriteFile(cellDef, f)
 
 #define FPRINTF(f,s)\
 {\
-     if (fprintf(f,s) == EOF) goto ioerror;\
+     if (fputs(s,f) == EOF) goto ioerror;\
      DBFileOffset += strlen(s);\
 }
 #define FPRINTR(f,s)\
 {\
-     if (fprintf(f,s) == EOF) return 1;\
+     if (fputs(s,f) == EOF) return 1;\
      DBFileOffset += strlen(s);\
 }
 


### PR DESCRIPTION
A very small patch, so magic willl build under the latest CentOS Stream 9, which uses gcc11.