### PR TITLE
fix errors in cmdDumpParseArgs ( getcell command error)

### DIFF
--- a/commands/CmdCD.c
+++ b/commands/CmdCD.c
@@ -4573,6 +4573,7 @@ cmdDumpParseArgs(cmdName, w, cmd, dummy, scx)
      * points weren't provided.  (Lower-left of the box tool is interpreted
      * in root coordinates).
      */
+	// getcell cellname child 0 0 parent ll v 0 0
     av = &cmd->tx_argv[2];
     ac = cmd->tx_argc - 2;
     hasChild = hasRoot = hasTrans = FALSE;
@@ -4599,7 +4600,8 @@ cmdDumpParseArgs(cmdName, w, cmd, dummy, scx)
 		    TxError("Keyword must be followed by a reference point\n");
 		    goto usage;
 	        }
-		else if (ac == 3)
+		//else if (ac == 3) # error case: getcell cellname child 0 0 parent ll -> (ac > 3) -> read 0 as label 
+		else if (ac >= 3 && StrIsInt(av[1]) && StrIsInt(av[2]))
 		{
 		    childPoint.p_x = cmdParseCoord(w, av[1], TRUE, TRUE);
 		    childPoint.p_y = cmdParseCoord(w, av[2], TRUE, FALSE);
@@ -4652,8 +4654,9 @@ cmdDumpParseArgs(cmdName, w, cmd, dummy, scx)
 		{
 		    TxError("Keyword must be followed by a reference point\n");
 		    goto usage;
-	        }
-		else if (ac == 3)
+	    }
+		//else if (ac == 3) # error case: getcell cellname child 0 0 parent ll v 0 0 -> (ac > 3) -> read 0 as label 
+		else if (ac >= 3 && StrIsInt(av[1]) && StrIsInt(av[2]))
 		{
 		    editPoint.p_x = cmdParseCoord(w, av[1], TRUE, TRUE);
 		    editPoint.p_y = cmdParseCoord(w, av[2], TRUE, FALSE);
@@ -4730,8 +4733,10 @@ default_action:
 		    }
 		    av += 1;
 		    ac -= 1;
-	        }
-		else if (Lookup(av[1], kwdNames)>=0)
+	    }
+		// error case: getcell cellname v 0 0 -> read 0 in kwdNames -> goto default transform
+		// av[1] = "0", "90", "180", "270" case -> av[1] must mean editpoint coordinate
+		else if (Lookup(av[1], kwdNames)>=0 && Lookup(av[1], kwdNames)!= 2 && strcmp(av[1],"90") && strcmp(av[1],"180") && strcmp(av[1],"270"))
 		{
 		    goto default_action;
 		}


### PR DESCRIPTION
there are some errors in getcell command
error case1: getcell cellname child 0 0 parent ll -> read 0 as label
why: else if( ac ==3 ){ coordiate case } -> since ac = argc -2 at first -> argc > 3 -> pass else if() and go to label case
sol: (ac >= 3) and check if following two strings are number -> satisdfy coordinate case
error case2: getcell cellname v 0 0 -> not transform ( transform default case executed )
why: '0', '90', '180', '270' are in kwdNames -> else if ( Lookup(av[1], kwdNames)>=0 ) { go to default } executed
sol: these command never invoked before function checks transform option '0'(no transform) or '90'(rotate)...
so just check if av[1] are one of them, then just pass "else if ( )"