### PR TITLE
scripts/configure: enable building without x

### DIFF
--- a/scripts/configure
+++ b/scripts/configure
@@ -6058,10 +6058,10 @@ fi
 fi
 
 
-if test "x${X_DISPLAY_MISSING}" = "x"; then
+if test "x$no_x" = "x"; then
   usingX11=1
 else
-  as_fn_error $? "Unable to find X11---compiling without graphics" "$LINENO" 5
+  echo Unable to find X11---compiling without graphics.
   echo Cannot find X11---will attempt to compile anyway.
   echo Graphics options will be NULL only!
   if test $usingOGL ; then
@@ -7282,7 +7282,9 @@ if test "x$enable_threads" = "xyes" ; then
     $as_echo "#define HAVE_PTHREADS 1" >>confdefs.h
 
     gr_libs="$gr_libs -lpthread"
-    gr_srcs="$gr_srcs \${X11THREAD_SRCS}"
+    if test $usingX11 ; then    
+      gr_srcs="$gr_srcs \${X11THREAD_SRCS}"
+    fi
     gr_hsrcs=""
     gr_hprog=""
 fi

--- a/scripts/configure.in
+++ b/scripts/configure.in
@@ -315,10 +315,10 @@ dnl Check for X enabled/disabled
 
 AC_PATH_XTRA
 
-if test "x${X_DISPLAY_MISSING}" = "x"; then
+if test "x$no_x" = "x"; then
   usingX11=1
 else
-  AC_MSG_ERROR([Unable to find X11---compiling without graphics])
+  echo Unable to find X11---compiling without graphics.
   echo Cannot find X11---will attempt to compile anyway.
   echo Graphics options will be NULL only!
   if test $usingOGL ; then


### PR DESCRIPTION
- use `no_x` instead of `X_DISPLAY_MISSING` (which is only defined as a compiler flag)
- make `X11` related error message non fatal
- only add `X11THREAD_SRCS` if `X11` is enabled.