### PR TITLE
Use the python3 that configure found

### DIFF
--- a/scripts/configure
+++ b/scripts/configure
@@ -5367,7 +5367,7 @@ if test "x${PYTHON3}" == "x"; then
    fi
 
 else
-   MCPP="\${MAGICDIR}/scripts/preproc.py -ccomm"
+   MCPP="${PYTHON3} \${MAGICDIR}/scripts/preproc.py -ccomm"
    MSED="cat"
    usingPython3=1
 fi

--- a/scripts/configure.in
+++ b/scripts/configure.in
@@ -307,7 +307,7 @@ if test "x${PYTHON3}" == "x"; then
    fi
 
 else
-   MCPP="\${MAGICDIR}/scripts/preproc.py -ccomm"
+   MCPP="${PYTHON3} \${MAGICDIR}/scripts/preproc.py -ccomm"
    MSED="cat"
    usingPython3=1
 fi


### PR DESCRIPTION
When running preproc.py, use the python3 that the configure script found instead of assuming (via preproc.py's `#!` line) that it is called "python3" and is located in PATH. This allows the user to specify a different python3 by running e.g.:

```
./configure ac_cv_path_PYTHON3=/path/to/python3
```