### PR TITLE
Resolve -Wcomment warnings

### DIFF
--- a/database/DBpaint.c
+++ b/database/DBpaint.c
@@ -19,7 +19,7 @@
  *     *********************************************************************
  */
 
-/* #define	PAINTDEBUG /* For debugging */
+/* #define	PAINTDEBUG */	/* For debugging */
 
 #ifndef lint
 static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/database/DBpaint.c,v 1.15 2010/09/24 19:53:19 tim Exp $";

--- a/gcr/gcrRoute.c
+++ b/gcr/gcrRoute.c
@@ -79,7 +79,7 @@ GCRroute(ch)
 
     gcrSetEndDist(ch);
     density = gcrDensity(ch);
-/*  gcrPrDensity(ch, density);	/* Debugging */
+/*  gcrPrDensity(ch, density); */	/* Debugging */
     if (density > ch->gcr_width)
     {
 	(void) sprintf(mesg, "Density (%d) > channel size (%d)",

--- a/scmos/cif_template/cifin-cmos14b.gen
+++ b/scmos/cif_template/cifin-cmos14b.gen
@@ -1,4 +1,4 @@
-/*  For IBM triple metal process... No CCD, Bipolar, Poly2 layers.
+/*  For IBM triple metal process... No CCD, Bipolar, Poly2 layers. */
 /*  This is prelimanary, please let me know if anything here seems
     abnormal to you...   pi@lepton.isi.edu 1/13/94		    */
 #ifdef NOWELL

--- a/scmos/cif_template/cifin-cmosx.gen
+++ b/scmos/cif_template/cifin-cmosx.gen
@@ -1,4 +1,4 @@
-/*  For IBM triple metal process... No CCD, Bipolar, Poly2 layers.
+/*  For IBM triple metal process... No CCD, Bipolar, Poly2 layers. */
 /*  This is prelimanary, please let me know if anything here seems
     abnormal to you...   pi@lepton.isi.edu 3/14/95		    */
 #ifdef NOWELL

--- a/scmos/cif_template/cifin-ibm.gen
+++ b/scmos/cif_template/cifin-ibm.gen
@@ -1,4 +1,4 @@
-/*  For IBM triple metal process... No CCD, Bipolar, Poly2 layers.
+/*  For IBM triple metal process... No CCD, Bipolar, Poly2 layers. */
 /*  This is prelimanary, please let me know if anything here seems
     abnormal to you...   pi@lepton.isi.edu 1/13/94		    */
 #ifdef NOWELL

--- a/select/selDisplay.c
+++ b/select/selDisplay.c
@@ -445,7 +445,7 @@ SelCopyToFeedback(celldef, seluse, style, text)
 }
 
 /*----------------------------------------------------------------------*/
-/* Callback function per tile of the selection
+/* Callback function per tile of the selection				*/
 /*----------------------------------------------------------------------*/
 
 int


### PR DESCRIPTION
Resolve `-Wcomment` warnings like:

```
./cifin-cmos14b.gen:2:1: warning: '/*' within block comment [-Wcomment]
```