### PR TITLE
Fix inadequate quoting in MSED variable

### DIFF
--- a/scripts/configure
+++ b/scripts/configure
@@ -5374,10 +5374,10 @@ if test "x${PYTHON3}" == "xno"; then
    usingPython3=
    if test "$CPP" = "$CC -E" ; then
       MCPP="$CPP -x c"
-      MSED="sed -e 's/\\/\\\\/'"
+      MSED="sed -e 's/\\\\/\\\\\\\\/'"
    else
       MCPP="$CPP"
-      MSED="sed -e 's/\\/\\\\/'"
+      MSED="sed -e 's/\\\\/\\\\\\\\/'"
    fi
 
 else

--- a/scripts/configure.in
+++ b/scripts/configure.in
@@ -299,10 +299,10 @@ if test "x${PYTHON3}" == "xno"; then
    usingPython3=
    if test "$CPP" = "$CC -E" ; then
       MCPP="$CPP -x c"
-      MSED="sed -e 's/\\/\\\\/'"
+      MSED="sed -e 's/\\\\/\\\\\\\\/'"
    else
       MCPP="$CPP"
-      MSED="sed -e 's/\\/\\\\/'"
+      MSED="sed -e 's/\\\\/\\\\\\\\/'"
    fi
 
 else


### PR DESCRIPTION
Fixes:

```
sed: 1: "s/\/\\/
": unescaped newline inside substitute pattern
```