### PR TITLE
aarch64 fix + linux/mac build CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,22 +4,15 @@ name: CI
 
 # Controls when the workflow will run
 on:
-  # Triggers the workflow on push or pull request events but only for the master branch
   push:
-    branches: [ master ]
   pull_request:
-    branches: [ master ]
-
-  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
-  build:
+  vezzal:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
-
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       - name: Pulling the docker image
@@ -30,3 +23,29 @@ jobs:
         
       - name: Run the testing on the container and send the mail
         run: docker exec test_magic /vezzal/test_magic.sh "lankasaicharan123@gmail.com,tim@opencircuitdesign.com" ${{secrets.MAILING_KEY}}
+  simple_build_linux:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Get Dependencies
+        run: |
+          sudo apt-get install -y tcl-dev tk-dev libcairo-dev csh
+      - name: Build
+        run: |
+          ./configure
+          make database/database.h
+          make -j$(nproc)
+  simple_build_mac:
+    runs-on: macos-11
+    steps:
+      - uses: actions/checkout@v2
+      - name: Get Dependencies
+        run: |
+          brew install --cask xquartz
+          brew install cairo tcl-tk tcsh
+      - name: Build
+        run: |
+          export PATH="/opt/X11/bin:$PATH"
+          ./scripts/configure_mac
+          make database/database.h
+          make -j$(sysctl -n hw.ncpu)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,17 +35,17 @@ jobs:
           ./configure
           make database/database.h
           make -j$(nproc)
-  simple_build_mac:
-    runs-on: macos-11
-    steps:
-      - uses: actions/checkout@v2
-      - name: Get Dependencies
-        run: |
-          brew install --cask xquartz
-          brew install cairo tcl-tk tcsh
-      - name: Build
-        run: |
-          export PATH="/opt/X11/bin:$PATH"
-          ./scripts/configure_mac
-          make database/database.h
-          make -j$(sysctl -n hw.ncpu)
+  # simple_build_mac:
+  #   runs-on: macos-11
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: Get Dependencies
+  #       run: |
+  #         brew install --cask xquartz
+  #         brew install cairo tcl-tk tcsh
+  #     - name: Build
+  #       run: |
+  #         export PATH="/opt/X11/bin:$PATH"
+  #         ./scripts/configure_mac
+  #         make database/database.h
+  #         make -j$(sysctl -n hw.ncpu)

--- a/INSTALL_MacOS.md
+++ b/INSTALL_MacOS.md
@@ -1,7 +1,20 @@
-# In order to install magic on MacOS (Big Sur) follow these steps:
+# Installing Magic on macOS (Tested on Big Sur)
+## With Brew
+Get [Homebrew](https://brew.sh).
 
+```sh
+brew install cairo tcl-tk tcsh
+brew install --cask xquartz
+./scripts/configure_mac
+make database/database.h
+make -j$(sysctl -n hw.ncpu)
+make install # may need sudo depending on your setup
+```
 
-## Build Tcl for X11
+## Without Brew
+Get [XQuartz](https://github.com/XQuartz/XQuartz)
+
+### Build Tcl for X11
 
 We are following the instructions from xschem (https://github.com/StefanSchippers/xschem/blob/master/README_MacOS.md). 
 
@@ -15,7 +28,7 @@ make
 make install
 ```
 
-## Build Tk for X11
+### Build Tk for X11
 
 * Download Tk from https://prdownloads.sourceforge.net/tcl/tk8.6.10-src.tar.gz
 
@@ -27,7 +40,7 @@ make
 make install
 ```
 
-## Build magic
+### Build magic
 
 We need to provide this `tcl-tk` and suppress compilation errors.
 

--- a/scripts/configure_mac
+++ b/scripts/configure_mac
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -x
+./configure\
+    --with-tcl=$(brew --prefix tcl-tk)\
+    --with-tk=$(brew --prefix tcl-tk)\
+    --with-cairo=$(brew --prefix cairo)/include\
+    "CFLAGS=-Wno-error=implicit-function-declaration"\
+    "LDFLAGS=-L$(brew --prefix cairo)/lib"

--- a/tcltk/tclmagic.c
+++ b/tcltk/tclmagic.c
@@ -956,8 +956,8 @@ TxDispatch(f)
 void
 TxParseString(str, q, event)
     char *str;
-    caddr_t q;		/* unused */
-    caddr_t event;	/* always NULL (ignored) */
+    void* q;		/* unused */
+    void* event;	/* always NULL (ignored) */
 {
     char *reply;
 


### PR DESCRIPTION
+ Add "smoke test" build CI to Github Actions
+ Added a configure_mac script (requires brew)
~ caddr_t -> void* (was never a part of any UNIX standard)