### PR TITLE
Fix bugs in port first, next commands.

### DIFF
--- a/commands/CmdLQ.c
+++ b/commands/CmdLQ.c
@@ -1745,7 +1745,7 @@ CmdPort(w, cmd)
 		    if (sl->lab_flags & PORT_DIR_MASK)
 		    {
 		    	idx = (int)sl->lab_port;
-		    	if (idx < i) i = idx;
+		    	if (idx < i || i == -1) i = idx;
 		    }
 		}
 #ifdef MAGIC_WRAPPER
@@ -1764,7 +1764,7 @@ CmdPort(w, cmd)
 		    {
 		    	idx = (int)sl->lab_port;
 		    	if (idx > refidx)
-		            if (idx < i) i = idx;
+		            if (idx < i || i == -1) i = idx;
 		    }
 		}
 #ifdef MAGIC_WRAPPER


### PR DESCRIPTION
Previous commits changed the port IDs to an integer rather than a
bitfield. However, the first and next commands were utilizing that
a -1 became a large positive integer when masked. This resulted in
the min port operations failing. Added a default comparison with -1
to fix the problem.