### PR TITLE
Compatibility with C99 standard

### DIFF
--- a/calma/CalmaRdcl.c
+++ b/calma/CalmaRdcl.c
@@ -46,6 +46,9 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 #include "calma/calmaInt.h"
 #include "calma/calma.h"
 
+/* C99 compat */
+#include "drc/drc.h"
+
 int calmaNonManhattan;
 int CalmaFlattenLimit = 10;
 int NameConvertErrors = 0;

--- a/calma/CalmaRdio.c
+++ b/calma/CalmaRdio.c
@@ -46,6 +46,9 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 #include "textio/textio.h"
 #include "calma/calmaInt.h"
 
+/* C99 compat */
+#include "calma/calma.h"
+
 /* Forward declarations */
 bool calmaReadR8();
 bool calmaSkipBytes();

--- a/calma/CalmaRdpt.c
+++ b/calma/CalmaRdpt.c
@@ -48,6 +48,9 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 #include "calma/calmaInt.h"
 #include "calma/calma.h"
 
+/* C99 compat */
+#include "drc/drc.h"
+
 extern int calmaNonManhattan;
 
 extern int CalmaPolygonCount;

--- a/calma/CalmaRead.c
+++ b/calma/CalmaRead.c
@@ -49,6 +49,9 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 #include "utils/main.h"			/* for EditCellUse */
 #include "utils/undo.h"
 
+/* C99 compat */
+#include "calma/calma.h"
+
 /* Globals for Calma reading */
 FILETYPE calmaInputFile = NULL;		/* Read from this stream */
 FILE *calmaErrorFile = NULL;		/* Write error output here */

--- a/calma/CalmaWrite.c
+++ b/calma/CalmaWrite.c
@@ -53,6 +53,10 @@ static char rcsid[] __attribute__ ((unused)) ="$Header: /usr/cvsroot/magic-8.0/c
 #include "utils/main.h"		/* for Path and CellLibPath */
 #include "utils/stack.h"
 
+/* C99 compat */
+#include "utils/undo.h"
+#include "calma/calma.h"
+
     /* Exports */
 bool CalmaDoLibrary = FALSE;	  /* If TRUE, do not output the top level */
 bool CalmaDoLabels = TRUE;	  /* If FALSE, don't output labels with GDS-II */

--- a/calma/CalmaWriteZ.c
+++ b/calma/CalmaWriteZ.c
@@ -63,6 +63,10 @@ static char rcsid[] __attribute__ ((unused)) ="$Header: /usr/cvsroot/magic-8.0/c
 #include "utils/main.h"		/* for Path and CellLibPath */
 #include "utils/stack.h"
 
+/* C99 compat */
+#include "utils/undo.h"
+#include "calma/calma.h"
+
     /* External variables from CalmaWrite.c */
 extern HashTable calmaLibHash;
 extern HashTable calmaPrefixHash;

--- a/calma/calma.h
+++ b/calma/calma.h
@@ -43,7 +43,7 @@ extern char **CalmaFlattenUsesByName;
 extern bool CalmaReadOnly;
 extern bool CalmaContactArrays;
 #ifdef HAVE_ZLIB
-extern bool CalmaCompression;
+extern int  CalmaCompression;
 #endif
 extern bool CalmaPostOrder;
 extern bool CalmaAllowUndefined;
@@ -54,6 +54,34 @@ extern void CalmaReadFile();
 extern void CalmaTechInit();
 extern bool CalmaGenerateArray();
 extern void CalmaReadError();
+
+/* C99 compat */
+extern void CalmaReadError();
+extern int  calmaAddSegment();
+extern void calmaDelContacts();
+extern void calmaElementBoundary();
+extern void calmaElementBox();
+extern void calmaElementPath();
+extern void calmaElementText();
+extern bool calmaIsUseNameDefault();
+extern bool calmaParseStructure();
+extern int  calmaProcessDef();
+extern int  calmaProcessDefZ();
+extern bool calmaReadI2Record();
+extern bool calmaReadI4Record();
+extern void calmaReadPoint();
+extern bool calmaReadR8();
+extern bool calmaReadStampRecord();
+extern bool calmaReadStringRecord();
+extern bool calmaReadStringRecord();
+extern bool calmaReadTransform();
+extern bool calmaSkipBytes();
+extern bool calmaSkipExact();
+extern bool calmaSkipTo();
+extern void calmaUnexpected();
+extern void calmaMergeSegments();
+extern void calmaRemoveDegenerate();
+extern void calmaRemoveColinear();
 
 #ifdef HAVE_ZLIB
 extern bool CalmaWriteZ();

--- a/cif/CIFgen.c
+++ b/cif/CIFgen.c
@@ -41,6 +41,10 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 #include "utils/maxrect.h"
 #include "drc/drc.h"
 
+/* C99 compat */
+#include "textio/textio.h"
+#include "utils/undo.h"
+
 /* TRUE to run (very slow) algorithm for optimizing non-manhattan tiles */
 /* (cuts size of output;  see also the GDS "merge" option)		*/
 bool CIFUnfracture = FALSE;

--- a/cif/CIFint.h
+++ b/cif/CIFint.h
@@ -327,6 +327,26 @@ extern int cifHierCopyMaskHints();
 extern void CIFLoadStyle();
 extern void CIFCopyMaskHints();
 
+/* C99 compat */
+extern void CIFCoverageLayer();
+extern bool CIFWriteFlat();
+extern void CIFScalePlanes();
+extern void CIFInputRescale();
+extern int  CIFCalmaLayerToCifLayer();
+extern int  CIFScaleCoord();
+extern void CIFPropRecordPath();
+extern void CIFPaintWirePath();
+extern void CIFMakeManhattanPath();
+extern int  cifGrowSliver();
+extern int  cifHierElementFunc();
+extern int  cifSquareFunc();
+extern int  cifSquareGridFunc();
+extern int  cifSlotFunc();
+extern int  CIFParseScale();
+extern int  cifParseCalmaNums();
+extern int  CIFEdgeDirection();
+extern bool CIFReadTechLimitScale();
+
 /* Shared variables and structures: */
 
 extern Plane *CIFPlanes[];		/* Normal place to store CIF. */

--- a/cif/CIFrdpt.c
+++ b/cif/CIFrdpt.c
@@ -37,6 +37,8 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 #include "cif/CIFint.h"
 #include "cif/CIFread.h"
 
+/* C99 compat */
+#include "textio/textio.h"
 
 /*
  * ----------------------------------------------------------------------------

--- a/cif/CIFrdtech.c
+++ b/cif/CIFrdtech.c
@@ -40,6 +40,9 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 #include "calma/calmaInt.h"
 #include "utils/malloc.h"
 
+/* C99 compat */
+#include "cif/cif.h"
+
 /* Pointer to a list of all the CIF-reading styles: */
 
 CIFReadKeep *cifReadStyleList = NULL;

--- a/cif/CIFrdutils.c
+++ b/cif/CIFrdutils.c
@@ -27,6 +27,12 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 #include <stdarg.h>
 #include <ctype.h>
 
+/*
+ * C99 compat
+ * Mind: tcltk/tclmagic.h must be included prior to all the other headers
+ */
+#include "tcltk/tclmagic.h"
+
 #include "utils/magic.h"
 #include "utils/geometry.h"
 #include "tiles/tile.h"
@@ -39,6 +45,16 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 #include "utils/signals.h"
 #include "utils/undo.h"
 #include "utils/malloc.h"
+
+/* C99 compat */
+#include "lef/lef.h"
+#include "drc/drc.h"
+#include "extract/extract.h"
+#include "wiring/wiring.h"
+#include "router/router.h"
+#include "mzrouter/mzrouter.h"
+#include "irouter/irouter.h"
+#include "plow/plow.h"
 
 /* The following variables are used to provide one character of
  * lookahead.  cifParseLaAvail is TRUE if cifParseLaChar contains

--- a/cif/CIFsee.c
+++ b/cif/CIFsee.c
@@ -35,6 +35,9 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 #include "textio/textio.h"
 #include "utils/undo.h"
 
+/* C99 compat */
+#include "drc/drc.h"
+
 /* The following variable holds the CellDef into which feedback
  * is to be placed for displaying CIF.
  */

--- a/cif/CIFtech.c
+++ b/cif/CIFtech.c
@@ -42,6 +42,11 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 #include "cif/cif.h"
 #include "drc/drc.h"	/* For WRL's DRC-CIF extensions */
 
+/* C99 compat */
+#include "calma/calma.h"
+#include "dbwind/dbwind.h"
+#include "drc/drc.h"
+
 /* The following statics are used to keep track of things between
  * calls to CIFTechLine.
  */

--- a/cif/cif.h
+++ b/cif/cif.h
@@ -56,7 +56,7 @@ extern void CIFTechInit();
 extern bool CIFTechLine();
 extern void CIFTechFinal();
 extern void CIFTechOutputScale();
-extern void CIFTechInputScale();
+extern int  CIFTechInputScale();
 extern bool CIFTechLimitScale();
 extern void CIFReadTechStyleInit();
 extern void CIFReadTechInit();
@@ -90,5 +90,8 @@ extern int CIFOutputScaleFactor();
 
 extern void PaintWireList();
 extern LinkedRect *PaintPolygon();
+
+/* C99 compat */
+extern int  CIFGetContactSize();
 
 #endif /* _CIF_H */

--- a/cmwind/cmwind.h
+++ b/cmwind/cmwind.h
@@ -77,4 +77,8 @@ extern Rect cmwCurrentColorArea;
 extern void cmwUndoColor(int, int, int, int, int, int, int);
 extern bool CMWCheckWritten(void);
 
+/* C99 compat */
+extern void CMWinit();
+
+
 #endif /* _CMWIND_H */

--- a/commands/CmdCD.c
+++ b/commands/CmdCD.c
@@ -51,6 +51,9 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 #include "cif/CIFread.h"
 #include "calma/calmaInt.h"
 
+/* C99 compat */
+#include "dbwind/dbwtech.h"
+
 /* The following structure is used by CmdCorner to keep track of
  * areas to be filled.
  */

--- a/commands/CmdE.c
+++ b/commands/CmdE.c
@@ -44,6 +44,9 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 #include "extract/extract.h"
 #include "select/select.h"
 
+/* C99 compat */
+#include "dbwind/dbwtech.h"
+
 
 /*
  * ----------------------------------------------------------------------------

--- a/commands/CmdFI.c
+++ b/commands/CmdFI.c
@@ -58,6 +58,9 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 #include "sim/sim.h"
 #include "gcr/gcr.h"
 
+/* C99 compat */
+#include "cif/cif.h"
+
 /* The following structure is used by CmdFill to keep track of
  * areas to be filled.
  */

--- a/commands/CmdLQ.c
+++ b/commands/CmdLQ.c
@@ -46,6 +46,9 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 #include "select/select.h"
 #include "netmenu/netmenu.h"
 
+/* C99 compat */
+#include "cif/cif.h"
+
 /* Forward declarations */
 
 void CmdPaintEraseButton();

--- a/commands/CmdRS.c
+++ b/commands/CmdRS.c
@@ -52,6 +52,15 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 #include "utils/signals.h"
 #include "sim/sim.h"
 
+/* C99 compat */
+#include "cif/cif.h"
+#include "lef/lef.h"
+#include "extract/extract.h"
+#include "irouter/irouter.h"
+#include "mzrouter/mzrouter.h"
+#include "router/router.h"
+#include "wiring/wiring.h"
+
 extern void DisplayWindow();
 
 /* Used by CmdSetLabel() */
@@ -260,7 +269,6 @@ CmdScaleGrid(w, cmd)
     MagWindow *w;
     TxCommand *cmd;
 {
-    extern void DBScalePoint();
     int scalen, scaled;
     char *argsep;
     Rect rootBox;

--- a/commands/CmdTZ.c
+++ b/commands/CmdTZ.c
@@ -50,6 +50,9 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 #include "utils/tech.h"
 #include "drc/drc.h"
 
+/* C99 compat */
+#include "cif/cif.h"
+
 #ifdef	LLNL
 #include "yacr.h"
 #endif	/* LLNL */

--- a/commands/CmdWizard.c
+++ b/commands/CmdWizard.c
@@ -46,6 +46,9 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 #include "utils/utils.h"
 #include "textio/txcommands.h"
 
+/* C99 compat */
+#include "extract/extract.h"
+
 /* Forward declarations */
 
 extern void cmdPsearchStats();

--- a/commands/commands.h
+++ b/commands/commands.h
@@ -64,4 +64,16 @@ extern void CmdDoMacro();
 extern TileType CmdFindNetProc();
 extern bool CmdCheckForPaintFunc();
 
+/* C99 compat */
+extern int cmdScaleCoord();
+extern void FlatCopyAllLabels();
+extern bool cmdDumpParseArgs();
+extern void cmdFlushCell();
+extern int cmdParseCoord();
+extern void cmdSaveCell();
+extern void CmdInit();
+
+extern void CmdDoProperty();
+extern void CmdPaintEraseButton();
+
 #endif /* _COMMANDS_H */

--- a/database/DBcellcopy.c
+++ b/database/DBcellcopy.c
@@ -35,6 +35,9 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 #include "dbwind/dbwind.h"
 #include "commands/commands.h"
 
+/* C99 compat */
+#include "graphics/graphics.h"
+
 /*
  * The following variable points to the tables currently used for
  * painting.  The paint tables are occasionally switched, by clients

--- a/database/DBconnect.c
+++ b/database/DBconnect.c
@@ -36,6 +36,9 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 #include "utils/signals.h"
 #include "utils/malloc.h"
 
+/* C99 compat */
+#include "textio/textio.h"
+
 /* Global variable */
 Stack *dbConnectStack = (Stack *)NULL;
 

--- a/database/DBio.c
+++ b/database/DBio.c
@@ -63,6 +63,18 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 #include "utils/malloc.h"
 #include "utils/signals.h"
 
+/* C99 compat */
+#include "dbwind/dbwtech.h"
+#include "cif/cif.h"
+#include "lef/lef.h"
+#include "commands/commands.h"
+#include "graphics/graphics.h"
+#include "irouter/irouter.h"
+#include "mzrouter/mzrouter.h"
+#include "router/router.h"
+#include "wiring/wiring.h"
+#include "extract/extract.h"
+
 #ifndef _PATH_TMP
 #define _PATH_TMP "/tmp"
 #endif

--- a/database/database.h.in
+++ b/database/database.h.in
@@ -861,7 +861,7 @@ extern void DBClearCellPlane();
 
     /* Insertion/deletion of cell uses into the name space of a parent */
 extern bool DBLinkCell();
-extern void DBUnlinkCell();
+extern void DBUnLinkCell();
 
     /* Deletion of cell defs */
 extern void DBUndoReset();
@@ -946,6 +946,64 @@ extern int DBArraySr();
 extern bool DBNearestLabel();
 extern int DBSrLabelLoc();
 extern TileType DBTransformDiagonal();
+
+/* C99 compat */
+extern void DBEraseValid();
+extern void DBPaintValid();
+extern void DBTreeCountPaint();
+extern FILE *dbReadOpen();
+extern int  DBLoadFont();
+extern int  DBNameToFont();
+extern int  DBFontChar();
+extern void DBFontInitCurves();
+extern void DBUndoEraseLabel();
+extern void DBUndoPutLabel();
+extern bool DBCellRename();
+extern bool DBCellDelete();
+extern int  DBCellSrArea();
+extern int  DBSrCellPlaneArea();
+extern int  DBMoveCell();
+extern bool DBReLinkCell();
+extern int  DBBoundCellPlane();
+extern Label *DBCheckLabelsByContent();
+extern void DBMaskAddStacking();
+extern bool DBIsChild();
+extern void DBScaleEverything();
+extern bool DBScalePoint();
+extern int  DBScaleCell();
+extern TileType DBTechNameTypes();
+extern void DBTreeFindUse();
+extern void DBGenerateUniqueIds();
+extern TileType DBInvTransformDiagonal();
+extern bool DBIsSubcircuit();
+extern int  DBSrPaintNMArea();
+extern int  DBTreeSrNMTiles();
+extern void DRCOffGridError();
+extern int  dbCellUsePrintFunc();
+extern int  dbTechContactResidues();
+extern TileType dbTechNewStackedType();
+extern void dbUndoEdit();
+extern void DBSplitTile();
+extern int  DBSrCellUses();
+extern TileType DBTechNameTypeExact();
+extern void dbInstanceUnplace();
+extern int  dbIsPrimary();
+extern void dbTechMatchResidues();
+extern void DBUndoInit();
+extern void DBResetTilePlane();
+extern void DBNewYank();
+extern int  DBSrPaintClient();
+extern int  DBSrConnect();
+extern char *dbFgets();
+extern void DBAdjustLabelsNew();
+extern bool DBScaleValue();
+extern int  DBMergeNMTiles0();
+extern int  DBSearchLabel();
+extern int  dbCellUniqueTileSrFunc();
+extern void DBWDrawFontLabel();
+extern void DBCellCopyManhattanPaint();
+extern bool dbScalePlane();
+extern int  DBPaintPlaneVert();
 
 /* -------------------------- Layer locking ------------------------------*/
 

--- a/database/databaseInt.h
+++ b/database/databaseInt.h
@@ -212,6 +212,9 @@ ClientData  dbTechNameLookup();
 ClientData  dbTechNameLookupExact();
 extern int  strcmpbynum();
 
+/* C99 compat */
+extern int  dbScaleCell();
+
 /* --------------- Internal database technology variables ------------- */
 
 /*

--- a/dbwind/DBWbuttons.c
+++ b/dbwind/DBWbuttons.c
@@ -40,6 +40,9 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 #include "textio/txcommands.h"
 #include "utils/utils.h"
 
+/* C99 compat */
+#include "commands/commands.h"
+
 /* The arrays below are used to store information about the various
  * button handlers that have registered themselves.
  */

--- a/dbwind/DBWdisplay.c
+++ b/dbwind/DBWdisplay.c
@@ -42,6 +42,9 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 #include "utils/tech.h"
 #include "utils/signals.h"
 
+/* C99 compat */
+#include "textio/textio.h"
+
 /* The following variable is exported to the rest of the world.
  * It is read from the "styletype" line of the technology file,
  * and defines the class of display styles file expected for

--- a/dbwind/DBWelement.c
+++ b/dbwind/DBWelement.c
@@ -30,6 +30,9 @@
 #include "utils/malloc.h"
 #include "utils/signals.h"
 
+/* C99 compat */
+#include "textio/textio.h"
+
 /* Types of elements */
 
 #define ELEMENT_RECT	0

--- a/dbwind/DBWfdback.c
+++ b/dbwind/DBWfdback.c
@@ -40,6 +40,9 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 #include "utils/malloc.h"
 #include "utils/signals.h"
 
+/* C99 compat */
+#include "textio/textio.h"
+
 /* Use a reference-counted character structure for feedback info */
 
 typedef struct rcstring

--- a/dbwind/dbwind.h
+++ b/dbwind/dbwind.h
@@ -198,7 +198,7 @@ extern void DBWUndoNewEdit();
 extern void DBWHLAddClient();
 extern void DBWHLRemoveClient();
 extern void DBWHLRedraw();
-extern int DBWHLRedrawWind();
+extern int  DBWHLRedrawWind();
 extern void DBWDrawBox();
 extern void DBWDrawCrosshair();
 
@@ -231,6 +231,18 @@ extern void DBWElementParseFlags();
 extern char *DBWPrintElements();
 extern void DBWScaleElements();
 extern void DBWScaleCrosshair();
+
+/* C99 compat */
+extern void DBWreload();
+extern void DBWInitCommands();
+extern void dbwUndoInit();
+extern void dbwFeedbackInit();
+extern void DBWElementPos();
+extern bool DBCellDeleteUse();
+extern void DBWHLRedrawPrepWindow();
+extern void CmdInit();
+extern void DBWinit();
+extern int  DBWTechParseStyle();
 
 /* Random procedures used internally to this module.  None of these
  * should ever need to be called by the outside world.

--- a/dbwind/dbwind.h
+++ b/dbwind/dbwind.h
@@ -243,6 +243,7 @@ extern void DBWHLRedrawPrepWindow();
 extern void CmdInit();
 extern void DBWinit();
 extern int  DBWTechParseStyle();
+extern void dbwButtonSetCursor();
 
 /* Random procedures used internally to this module.  None of these
  * should ever need to be called by the outside world.

--- a/dbwind/dbwtech.h
+++ b/dbwind/dbwtech.h
@@ -16,6 +16,11 @@ extern TileTypeBitMask	*DBWStyleToTypesTbl;
 #define	DBWStyleToTypes(s)	(DBWStyleToTypesTbl + s)
 
 /* forward declarations */
-int  DBWTechParseStyle();
+extern int  DBWTechParseStyle();
+
+/* C99 compat */
+extern void DBWElementStyle();
+extern void DBWElementText();
+extern void DBWSetCrosshair();
 
 #endif /* _DBWTECH_H */

--- a/drc/DRCcif.c
+++ b/drc/DRCcif.c
@@ -46,7 +46,10 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 #include "utils/signals.h"
 #include "utils/stack.h"
 #include "utils/malloc.h"
-#include "utils/utils.h"
+
+/* C99 compat */
+#include "utils/tech.h"
+#include "textio/textio.h"
 
 extern int  drcCifTile();
 extern int  areaCifCheck();

--- a/drc/DRCtech.c
+++ b/drc/DRCtech.c
@@ -28,7 +28,6 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 #include "tcltk/tclmagic.h"
 #include "utils/magic.h"
 #include "utils/geometry.h"
-#include "utils/utils.h"
 #include "tiles/tile.h"
 #include "utils/hash.h"
 #include "database/database.h"
@@ -39,6 +38,10 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 #include "cif/cif.h"
 #include "cif/CIFint.h"
 #include "drc/drc.h"
+
+/* C99 compat */
+#include "utils/tech.h"
+#include "plow/plow.h"
 
 CIFStyle *drcCifStyle = NULL;
 bool	 DRCForceReload = FALSE;

--- a/drc/drc.h
+++ b/drc/drc.h
@@ -286,6 +286,21 @@ extern void DRCLoadStyle();
 
 extern PlaneMask CoincidentPlanes(TileTypeBitMask *typeMask, PlaneMask pmask);
 
+/* C99 compat */
+extern void DRCBreak();
+extern void DRCFlatCheck();
+extern void DRCWhyAll();
+extern void drcCifInit();
+extern void drcCifCheck();
+extern void drcCifFinal();
+extern void drcCheckAngles();
+extern void drcCheckArea();
+extern int  drcCheckMaxwidth();
+extern void drcCheckRectSize();
+extern void drcCheckOffGrid();
+extern int  LowestMaskBit();
+extern void drcCifScale();
+
 /* The following macro can be used by the outside world to see if
  * the background checker needs to be called.
  */

--- a/ext2sim/ext2sim.c
+++ b/ext2sim/ext2sim.c
@@ -40,6 +40,9 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 #include "utils/runstats.h"
 #include "utils/malloc.h"
 
+/* C99 compat */
+#include "extflat/extflat.h"
+
 /* Forward declarations */
 void CmdExtToSim();
 bool simnAP();
@@ -47,6 +50,10 @@ bool simnAPHier();
 int simParseArgs();
 int simdevVisit(), simresistVisit(), simcapVisit(), simnodeVisit();
 int simmergeVisit();
+
+/* C99 compat */
+int simdevOutNode();
+int simdevSubstrate();
 
 /* Options specific to ext2sim */
 #ifdef EXT2SIM_AUTO

--- a/ext2spice/ext2hier.c
+++ b/ext2spice/ext2hier.c
@@ -46,6 +46,9 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 #include "utils/runstats.h"
 #include "ext2spice/ext2spice.h"
 
+/* C99 compat */
+#include "extflat/extflat.h"
+
 /* These global values are defined in ext2spice.c */
 extern HashTable subcktNameTable;
 extern DQueue    subcktNameQueue;

--- a/ext2spice/ext2spice.h
+++ b/ext2spice/ext2spice.h
@@ -41,6 +41,18 @@ extern float getCurDevMult();
 extern void addDevMult();
 extern void setDevMult();
 
+/* C99 compat */
+extern int  EFHNSprintf();
+extern int  printSubcktDict();
+extern int  spcdevOutNode();
+extern int  spcnAP();
+extern int  parallelDevs();
+extern int  nodeHspiceName();
+extern int  devDistJunctHierVisit();
+extern int  spcnAPHier();
+extern void mergeAttr();
+extern int  update_w();
+
 /* Options specific to ext2spice */
 extern bool esDoExtResis;
 extern bool esDoPorts;

--- a/extflat/EFantenna.c
+++ b/extflat/EFantenna.c
@@ -37,6 +37,9 @@
 #include "select/select.h"
 #include "utils/malloc.h"
 
+/* C99 compat */
+#include "extract/extract.h"
+
 /* Forward declarations */
 int antennacheckArgs();
 int antennacheckVisit();

--- a/extflat/EFargs.c
+++ b/extflat/EFargs.c
@@ -36,6 +36,9 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 #include "extflat/extflat.h"
 #include "extflat/EFint.h"
 
+/* C99 compat */
+#include "textio/textio.h"
+
 #define        atoCap(s)       ((EFCapValue)atof(s))
 
 /* --------------------- Visible outside extflat ---------------------- */

--- a/extflat/EFargs.c
+++ b/extflat/EFargs.c
@@ -38,6 +38,7 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 
 /* C99 compat */
 #include "textio/textio.h"
+#include "utils/pathvisit.h"
 
 #define        atoCap(s)       ((EFCapValue)atof(s))
 

--- a/extflat/EFbuild.c
+++ b/extflat/EFbuild.c
@@ -37,6 +37,9 @@ static char rcsid[] __attribute__ ((unused)) = "$Header$";
 #include "extract/extract.h"	/* for device class list */
 #include "extract/extractInt.h"	/* for extGetDevType()	*/
 
+/* C99 compat */
+#include "textio/textio.h"
+
 /*
  * To avoid allocating ridiculously large amounts of memory to hold
  * transistor types and the names of node types, we maintain the following

--- a/extflat/EFflat.c
+++ b/extflat/EFflat.c
@@ -34,6 +34,9 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 #include "extflat/extflat.h"
 #include "extflat/EFint.h"
 
+/* C99 compat */
+#include "textio/textio.h"
+
 /* Initial size of the hash table of all flattened node names */
 #define	INITFLATSIZE	1024
 

--- a/extflat/EFname.c
+++ b/extflat/EFname.c
@@ -34,6 +34,9 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 #include "extflat/extflat.h"
 #include "extflat/EFint.h"
 
+/* C99 compat */
+#include "textio/textio.h"
+
 #ifdef MAGIC_WRAPPER
 #define PrintErr TxError
 #else

--- a/extflat/EFread.c
+++ b/extflat/EFread.c
@@ -41,6 +41,9 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 #include "extract/extractInt.h"
 #include "utils/paths.h"
 
+/* C99 compat */
+#include "textio/textio.h"
+
 #ifndef MAGIC_WRAPPER
 /* This must match the definition for extDevTable in extract/ExtBasic.c */
 char *extDevTable[] = {"fet", "mosfet", "asymmetric", "bjt", "devres",

--- a/extflat/EFsym.c
+++ b/extflat/EFsym.c
@@ -42,6 +42,9 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 #include "extflat/extflat.h"
 #include "extflat/EFint.h"
 
+/* C99 compat */
+#include "textio/textio.h"
+
 /* Forward declarations */
 bool efSymAdd();
 

--- a/extflat/EFvisit.c
+++ b/extflat/EFvisit.c
@@ -37,6 +37,9 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 #include "tiles/tile.h"
 #include "extract/extract.h"
 
+/* C99 compat */
+#include "textio/textio.h"
+
 /* Root of the tree being flattened */
 extern Def *efFlatRootDef;
 extern Use efFlatRootUse;

--- a/extflat/extflat.h
+++ b/extflat/extflat.h
@@ -353,6 +353,67 @@ extern HierName *EFStrToHN();
 extern char *EFHNToStr();
 extern int EFGetPortMax();
 
+/* C99 compat */
+extern void EFHNFree();
+extern bool EFHNIsGlob();
+extern int  EFNodeResist();
+extern void efAdjustSubCap();
+extern int  efBuildAddStr();
+extern void efBuildAttr();
+extern int  efBuildDevice();
+extern void efBuildDeviceParams();
+extern void efBuildDist();
+extern void efBuildEquiv();
+extern void efBuildKill();
+extern void efBuildPortNode();
+extern void efBuildUse();
+extern int  efFlatCaps();
+extern int  efFlatDists();
+extern int  efFlatKills();
+extern int  efFlatNodes();
+extern int  efFlatNodesStdCell();
+extern void efFreeConn();
+extern void efFreeDevTable();
+extern void efFreeNodeList();
+extern void efFreeNodeTable();
+extern void efFreeUseTable();
+extern void efHNBuildDistKey();
+extern int  efHNLexOrder();
+extern void efHNPrintSizes();
+extern void efHNRecord();
+extern int  efHierSrArray();
+extern int  efHierSrUses();
+extern int  efHierVisitDevs();
+extern void efNodeMerge();
+extern void efReadError();
+extern int  efReadLine();
+extern bool efSymAdd();
+extern bool efSymAddFile();
+extern void efSymInit();
+extern void EFDone();
+extern void EFFlatBuild();
+extern void EFFlatDone();
+extern bool EFHNIsGND();
+extern void EFInit();
+extern bool EFReadFile();
+extern int  EFVisitDevs();
+extern int  efVisitDevs();
+extern bool efSymLook();
+extern int  efVisitResists();
+extern int  EFVisitResists();
+extern int  EFVisitNodes();
+extern int  EFVisitCaps();
+extern void EFGetLengthAndWidth();
+extern void EFHNOut();
+extern int  EFHierSrDefs();
+extern int  EFVisitSubcircuits();
+extern int  EFHierVisitSubcircuits();
+extern int  EFHierVisitDevs();
+extern int  EFHierVisitResists();
+extern int  EFHierVisitCaps();
+extern int  EFHierVisitNodes();
+
+
 /* ------------------------- constants used by clients -------------- */
 
 /*

--- a/extract/ExtSubtree.c
+++ b/extract/ExtSubtree.c
@@ -49,6 +49,9 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 #include "dbwind/dbwind.h"
 #include "utils/styles.h"
 
+/* C99 compat */
+#include "drc/drc.h"
+
 #ifdef	exactinteractions
 /*
  * If "exactinteractions" is defined, we use an experimental algorithm

--- a/extract/extract.h
+++ b/extract/extract.h
@@ -94,7 +94,6 @@ extern int ExtGetGateTypesMask();
 extern int ExtGetDiffTypesMask();
 
 #ifdef MAGIC_WRAPPER
-extern bool ExtGetDevInfo();
 extern bool ExtCompareStyle();
 #endif
 
@@ -143,5 +142,6 @@ extern void extSubtree();
 extern int  extUniqueCell();
 extern void ExtLabelOneRegion();
 extern void ExtInit();
+extern bool ExtGetDevInfo();
 
 #endif /* _EXTRACT_H */

--- a/extract/extract.h
+++ b/extract/extract.h
@@ -107,5 +107,41 @@ extern void ExtDumpCaps();
 extern int extEnumTilePerim();
 extern Plane *extPrepSubstrate();
 
+/* C99 compat */
+extern void ExtAll();
+extern void ExtIncremental();
+extern void ExtLengthClear();
+extern void ExtParents();
+extern void ExtSetDriver();
+extern void ExtSetReceiver();
+extern void ExtShowParents();
+extern void ExtTechScale();
+extern void ExtUnique();
+extern void ExtractTest();
+extern int  ExtFindNeighbors();
+extern void ExtFreeLabRegions();
+extern void ExtResetTiles();
+extern void extArray();
+extern void extFindCoupling();
+extern void extHierAdjustments();
+extern void extHierConnections();
+extern void extHierFreeLabels();
+extern void extHierFreeOne();
+extern void extHierFreeOne();
+extern void extHierSubstrate();
+extern int  extHierYankFunc();
+extern bool extLabType();
+extern void extLength();
+extern void extLengthInit();
+extern void extOutputConns();
+extern void extOutputCoupling();
+extern int  extPathTileDist();
+extern void extRelocateSubstrateCoupling();
+extern void extSetNodeNum();
+extern void extShowTile();
+extern void extSubtree();
+extern int  extUniqueCell();
+extern void ExtLabelOneRegion();
+extern void ExtInit();
 
 #endif /* _EXTRACT_H */

--- a/extract/extractInt.h
+++ b/extract/extractInt.h
@@ -1085,6 +1085,21 @@ extern NodeRegion *temp_subsnode;	/* Substrate connection to subcell */
      */
 extern struct stack *extNodeStack;
 
+/* C99 compat */
+extern void ExtFindInteractions();
+extern void ExtInterCount();
+extern void ExtInterCount();
+extern void ExtTimes();
+extern void ExtParentArea();
+extern void extHierCopyLabels();
+extern int  extTimesInitFunc();
+extern int  extTimesHierFunc();
+extern int  extTimesFlatFunc();
+extern Plane *extCellFile();
+extern int  extInterAreaFunc();
+extern int  extTreeSrPaintArea();
+extern int  extMakeUnique();
+
 /* ------------------ Connectivity table management ------------------- */
 
 /*

--- a/garouter/gaChannel.c
+++ b/garouter/gaChannel.c
@@ -42,6 +42,9 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 #include "utils/styles.h"
 #include "debug/debug.h"
 
+/* C99 compat */
+#include "gaRouter/gaInternal.h"
+
 /* List of all active channels */
 GCRChannel *gaChannelList = NULL;
 

--- a/garouter/gaInternal.h
+++ b/garouter/gaInternal.h
@@ -96,4 +96,16 @@ typedef struct nnl
 /* procedure declarations */
 extern bool gaMazeInit();
 
+/* C99 compat */
+extern bool gaMazeInit();
+extern void gaChannelInit();
+extern void gaStemPaintAll();
+extern void gaStemAssignAll();
+extern bool gaStemSimpleInit();
+extern bool gaStemSimpleRoute();
+extern bool gaStemSimpleInit();
+extern bool gaStemSimpleRoute();
+extern bool gaStemSimpleRoute();
+extern int  gaBuildNetList();
+
 #endif /* _GAINTERNAL_H */

--- a/garouter/gaMain.c
+++ b/garouter/gaMain.c
@@ -230,6 +230,10 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 #include "debug/debug.h"
 #include "drc/drc.h"
 
+/* C99 compat */
+#include "utils/netlist.h"
+#include "garouter/gaInternal.h"
+
 
 /*
  * ----------------------------------------------------------------------------

--- a/garouter/garouter.h
+++ b/garouter/garouter.h
@@ -97,6 +97,12 @@ extern void GAClearChannels();
 extern bool GADefineChannel();
 extern bool GAMazeInitParms();
 
+/* C99 compat */
+extern void GAInit();
+extern void GAGenChans();
+extern int  GARouteCmd();
+extern void GATest();
+
 /* Exported variables */
 extern bool GAStemWarn;
 

--- a/gcr/gcr.h
+++ b/gcr/gcr.h
@@ -343,4 +343,38 @@ extern void GCRFlipXY();
 extern void GCRNoFlip();
 extern void GCRShow();
 
+/* C99 compat */
+extern void gcrSaveChannel();
+extern bool gcrBlocked();
+extern void gcrEvalPat();
+extern void gcrLinkTrack();
+extern void gcrMoveTrack();
+extern int  gcrNextSplit();
+extern void gcrUnlinkPin();
+extern bool gcrVertClear();
+extern void gcrWanted();
+extern void gcrBuildNets();
+extern void gcrCheckCol();
+extern int  gcrClass();
+extern void gcrCollapse();
+extern int  gcrDensity();
+extern void gcrDumpResult();
+extern void gcrFeasible();
+extern void gcrInitCol();
+extern void gcrInitCollapse();
+extern int  gcrLook();
+extern void gcrMakeRuns();
+extern void gcrMarkWanted();
+extern void gcrPickBest();
+extern void gcrPrintCol();
+extern int  gcrRealDist();
+extern void gcrReduceRange();
+extern bool gcrRiverRoute();
+extern void gcrSetEndDist();
+extern void gcrSetFlags();
+extern void gcrShellSort();
+extern int  gcrTryRun();
+extern void gcrUncollapse();
+extern void gcrVacate();
+
 #endif /* _GCR_H */

--- a/gcr/gcrRoute.c
+++ b/gcr/gcrRoute.c
@@ -31,6 +31,9 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 #include "utils/malloc.h"
 #include "utils/styles.h"
 
+/* C99 compat */
+#include "router/router.h"
+
 int gcrRouterErrors;
 extern int gcrStandalone;
 

--- a/graphics/W3Dmain.c
+++ b/graphics/W3Dmain.c
@@ -50,6 +50,9 @@
 #include "cif/cif.h"
 #include "cif/CIFint.h"		/* access to CIFPlanes, CIFCurStyle, etc. */
 
+/* C99 compat */
+#include "utils/signals.h"
+
 extern Display     *grXdpy;		/* X11 display */
 extern GLXContext  grXcontext;		/* OpenGL/X11 interface def. */
 extern XVisualInfo *grVisualInfo;	/* OpenGL preferred visual */

--- a/graphics/grDStyle.c
+++ b/graphics/grDStyle.c
@@ -42,6 +42,9 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 #include "database/database.h"
 #include "dbwind/dbwind.h"
 
+/* C99 compat */
+#include "utils/main.h"
+
 /* imports from other graphics files */
 extern void (*grSetSPatternPtr)();
 extern void (*grDefineCursorPtr)();

--- a/graphics/grMain.c
+++ b/graphics/grMain.c
@@ -57,6 +57,9 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 #include <errno.h>
 #include <ctype.h>
 
+/* C99 compat */
+#include <unistd.h>
+
 #include "utils/magic.h"
 #include "utils/magsgtty.h"
 #include "textio/textio.h"

--- a/graphics/grOGL1.c
+++ b/graphics/grOGL1.c
@@ -30,6 +30,11 @@
 #include "grOGLInt.h"
 #include "utils/paths.h"
 
+/* C99 compat */
+#include "dbwind/dbwind.h"
+#include "utils/main.h"
+#include "utils/malloc.h"
+
 GLubyte 	**grOGLStipples;
 HashTable	grOGLWindowTable;
 Display 	*grXdpy;

--- a/graphics/grOGL3.c
+++ b/graphics/grOGL3.c
@@ -38,6 +38,9 @@
 #include "database/fonts.h"
 #include "grOGLInt.h"
 
+/* C99 compat */
+#include "utils/malloc.h"
+
 extern Display *grXdpy;
 
 static XFontStruct *grXFonts[4];

--- a/graphics/grTCairo1.c
+++ b/graphics/grTCairo1.c
@@ -46,6 +46,9 @@
 #include "utils/paths.h"
 #include "graphics/grTkCommon.h"
 
+/* C99 compat */
+#include "dbwind/dbwind.h"
+
 uint8_t			**grTCairoStipples;
 HashTable		grTCairoWindowTable;
 XVisualInfo		*grTCairoVisualInfo;

--- a/graphics/grTOGL1.c
+++ b/graphics/grTOGL1.c
@@ -44,6 +44,9 @@
 #include "utils/paths.h"
 #include "graphics/grTkCommon.h"
 
+/* C99 compat */
+#include "dbwind/dbwind.h"
+
 GLubyte		**grTOGLStipples;
 HashTable	grTOGLWindowTable;
 GLXContext	grXcontext;

--- a/graphics/grTOGL3.c
+++ b/graphics/grTOGL3.c
@@ -11,10 +11,6 @@
 #include <stdio.h>
 #include <string.h>
 
-#include <GL/gl.h>
-#include <GL/glx.h>
-#include <GL/glu.h>
-
 #include "tcltk/tclmagic.h"
 #include "utils/magic.h"
 #include "utils/geometry.h"
@@ -30,6 +26,14 @@
 #include "graphics/grTOGLInt.h"
 #include "graphics/grTkCommon.h"
 #include "database/fonts.h"
+
+/* C99 compat
+ * GL headers must be included after graphics/grTOGLInt.h
+ */
+#include <GL/gl.h>
+#include <GL/glx.h>
+#include <GL/glu.h>
+#include <GL/glext.h>
 
 extern Display *grXdpy;
 

--- a/graphics/grTOGLInt.h
+++ b/graphics/grTOGLInt.h
@@ -19,6 +19,11 @@
 
 #define TOGL_BATCH_SIZE	10000
 
+/* C99 compat
+ * Include OpenGL prototype headers
+ */
+#define GL_GLEXT_PROTOTYPES
+
 /* Current settings for X function parameters */
 typedef struct {
     Tk_Font		font;

--- a/graphics/grTk1.c
+++ b/graphics/grTk1.c
@@ -41,6 +41,9 @@
 #include "utils/paths.h"
 #include "graphics/grTkCommon.h"
 
+/* C99 compat */
+#include "dbwind/dbwind.h"
+
 GR_CURRENT grCurrent = {
 	(Tk_Font)0, 0, 0, 0, 0, 0,
 	(MagWindow *)NULL

--- a/graphics/grTk3.c
+++ b/graphics/grTk3.c
@@ -14,6 +14,9 @@
 
 #include <X11/Xlib.h>
 
+/* C99 compat */
+#include <X11/Xutil.h>
+
 #include "tcltk/tclmagic.h"
 #include "utils/magic.h"
 #include "utils/geometry.h"
@@ -28,6 +31,9 @@
 #include "graphics/grTkInt.h"
 #include "graphics/grTkCommon.h"
 #include "database/fonts.h"
+
+/* C99 compat */
+#include "database/database.h"
 
 
 /*---------------------------------------------------------

--- a/graphics/grTkCommon.c
+++ b/graphics/grTkCommon.c
@@ -16,6 +16,7 @@
 
 #include "tcltk/tclmagic.h"
 #include "utils/magic.h"
+#include "utils/main.h"
 #include "utils/styles.h"
 #include "utils/geometry.h"
 #include "utils/hash.h"
@@ -31,14 +32,6 @@
 #include "dbwind/dbwind.h"
 #include "graphics/grTkCommon.h"
 #include "graphics/glyphs.h"
-
-/* C99 compat
- * GL headers must be included after graphics/grTOGLInt.h
- */
-#include <GL/gl.h>
-#include <GL/glx.h>
-#include <GL/glu.h>
-#include <mach/mach.h> /* Needed to define panic */
 
 #include "textio/textio.h"
 
@@ -1260,7 +1253,8 @@ ImgLayerCmd(clientData, interp, objc, objv)
 	return code;
       }
       default: {
-	panic("bad const entries to layerOptions in ImgLayerCmd");
+	TxError("bad const entries to layerOptions in ImgLayerCmd\n");
+        MainExit(1);
       }
     }
     return TCL_OK;
@@ -1462,7 +1456,8 @@ ImgLayerDelete(masterData)
     LayerMaster *masterPtr = (LayerMaster *) masterData;
 
     if (masterPtr->instancePtr != NULL) {
-	panic("tried to delete layer image when instances still exist");
+	TxError("tried to delete layer image when instances still exist\n");
+        MainExit(1);
     }
     masterPtr->tkMaster = NULL;
     if (masterPtr->imageCmd != NULL) {

--- a/graphics/grTkCommon.c
+++ b/graphics/grTkCommon.c
@@ -32,6 +32,16 @@
 #include "graphics/grTkCommon.h"
 #include "graphics/glyphs.h"
 
+/* C99 compat
+ * GL headers must be included after graphics/grTOGLInt.h
+ */
+#include <GL/gl.h>
+#include <GL/glx.h>
+#include <GL/glu.h>
+#include <mach/mach.h> /* Needed to define panic */
+
+#include "textio/textio.h"
+
 /* Variables declared by grClip.c */
 
 extern int grCurFill, grCurOutline, grCurColor;

--- a/graphics/grTkCommon.h
+++ b/graphics/grTkCommon.h
@@ -38,6 +38,10 @@ extern bool grtkGetBackingStore();
 extern bool grtkScrollBackingStore();
 extern void grtkPutBackingStore();
 
+/* C99 compat */
+extern bool grTkLoadFont();
+extern void grTkFreeFonts();
+
 extern Tk_Font grTkFonts[4];
 extern Tk_Cursor grCursors[MAX_CURSORS];
 

--- a/graphics/grX11su1.c
+++ b/graphics/grX11su1.c
@@ -45,6 +45,11 @@
 #include "grX11Int.h"
 #include "utils/paths.h"
 
+/* C99 compat */
+#include "utils/main.h"
+#include "utils/malloc.h"
+#include "dbwind/dbwind.h"
+
 extern char  *DBWStyleType;
 
 Display      *grXdpy;

--- a/graphics/grX11su2.c
+++ b/graphics/grX11su2.c
@@ -33,6 +33,9 @@
 #include "graphics/graphicsInt.h"
 #include "grX11Int.h"
 
+/* C99 compat */
+#include "utils/main.h"
+
 extern char *DBWStyleType;
 extern unsigned long grPlanes[256];
 extern unsigned long grPixels[256];

--- a/graphics/grX11su3.c
+++ b/graphics/grX11su3.c
@@ -23,6 +23,9 @@
 #include <math.h>
 #include <X11/Xlib.h>
 
+/* C99 compat */
+#include <X11/Xutil.h>
+
 #include "utils/magic.h"
 #include "utils/geometry.h"
 #include "graphics/graphics.h"
@@ -35,6 +38,9 @@
 #include "dbwind/dbwind.h"
 #include "database/fonts.h"
 #include "grX11Int.h"
+
+/* C99 compat */
+#include "utils/malloc.h"
 
 /* locals */
 

--- a/graphics/grX11thread.c
+++ b/graphics/grX11thread.c
@@ -15,6 +15,10 @@
 #include <X11/keysym.h>
 #include <pthread.h>
 
+/* C99 compat */
+#include <stdlib.h>
+#include <unistd.h>
+
 #include "utils/magic.h"
 #include "utils/geometry.h"
 #include "graphics/graphics.h"

--- a/graphics/graphics.h
+++ b/graphics/graphics.h
@@ -138,6 +138,17 @@ extern void (*GrResumePtr)();
 #define GrStop	(*GrStopPtr)
 #define GrResume (*GrResumePtr)
 
+/* C99 compat */
+extern void GrClipTriangle();
+extern void GrBox();
+extern bool GrFontText();
+extern void GrDiagonal();
+extern bool grTkLoadFont();
+extern void grTkFreeFonts();
+extern bool grtoglLoadFont();
+extern void GrDrawTriangleEdge();
+extern bool GrReadGlyphs();
+
 /* Number of colors defined in the colormap */
 extern int GrNumColors;
 

--- a/graphics/graphicsInt.h
+++ b/graphics/graphicsInt.h
@@ -89,4 +89,9 @@ extern void grInformDriver();
      (((x) >> SUBPIXELBITS) < 4) || (((y) >> SUBPIXELBITS) < 4) \
 )
 
+/* C99 compat */
+extern bool GrReadGlyphs();
+extern bool GrBoxOutline();
+extern bool grtcairoLoadFont();
+
 #endif /* _GRAPHICSINT_H */

--- a/graphics/graphicsInt.h
+++ b/graphics/graphicsInt.h
@@ -93,5 +93,11 @@ extern void grInformDriver();
 extern bool GrReadGlyphs();
 extern bool GrBoxOutline();
 extern bool grtcairoLoadFont();
+extern int  xloop_create();
+extern bool groglLoadFont();
+extern void GrX11Close();
+extern bool grx11LoadFont();
+extern void xloop_end();
+extern bool groglPreLoadFont();
 
 #endif /* _GRAPHICSINT_H */

--- a/graphics/graphicsInt.h
+++ b/graphics/graphicsInt.h
@@ -92,12 +92,15 @@ extern void grInformDriver();
 /* C99 compat */
 extern bool GrReadGlyphs();
 extern bool GrBoxOutline();
-extern bool grtcairoLoadFont();
 extern int  xloop_create();
 extern bool groglLoadFont();
 extern void GrX11Close();
 extern bool grx11LoadFont();
 extern void xloop_end();
 extern bool groglPreLoadFont();
+
+#ifdef CAIRO
+extern bool grtcairoLoadFont();
+#endif
 
 #endif /* _GRAPHICSINT_H */

--- a/grouter/grouter.h
+++ b/grouter/grouter.h
@@ -237,6 +237,41 @@ GlPoint *glProcessLoc();
 Tile *glChanPinToTile();
 void glCrossMark();
 
+/* C99 compat */
+extern void GlGlobalRoute();
+extern void GlInit();
+extern void dbSetPlaneTile();
+extern void glChanBlockDens();
+extern void glChanBuildMap();
+extern void glChanFreeMap();
+extern int  glCrossCost();
+extern int  glCrossEnum();
+extern void glCrossScalePenalties();
+extern void glCrossUnreserve();
+extern void glDMAlloc();
+extern void glDMCopy();
+extern void glDMFree();
+extern int  glDMMaxInRange();
+extern bool glDensAdjust();
+extern void glDensInit();
+extern void glHistoAdd();
+extern void glListAdd();
+extern void glListToHeap();
+extern void glMazeResetCost();
+extern int  glMultiSteiner();
+extern int  glMultiStemCost();
+extern int  glPathFreePerm();
+extern void glPathFreeTemp();
+extern int  glPenClearPerChan();
+extern void glPenCompute();
+extern int  glPenDeleteNet();
+extern void glPenSetPerChan();
+extern void glShowCross();
+extern void glStatsDone();
+extern void glStatsInit();
+extern int  glPenEnumCross();
+extern void GlTest();
+
     /* Penalties for crossings */
 extern int glJogPenalty;
 extern int glObsPenalty1;

--- a/irouter/irRoute.c
+++ b/irouter/irRoute.c
@@ -44,9 +44,12 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 #include "utils/geofast.h"
 #include "utils/touchingtypes.h"
 #include "select/select.h"
-#include "../mzrouter/mzrouter.h"
+#include "mzrouter/mzrouter.h"
 #include "irouter/irouter.h"
 #include "irouter/irInternal.h"
+
+/* C99 compat */
+#include "select/select.h"
 
 /* --- Routines local to this file that are referenced before they are
  *     defined --- */

--- a/irouter/irTestCmd.c
+++ b/irouter/irTestCmd.c
@@ -43,8 +43,11 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 #include "utils/styles.h"
 #include "utils/malloc.h"
 #include "utils/list.h"
-#include "../mzrouter/mzrouter.h"
+#include "mzrouter/mzrouter.h"
 #include "irouter/irInternal.h"
+
+/* C99 compat */
+#include "debug/debug.h"
 
 /* Subcommand table - declared here since its referenced before defined */
 typedef struct

--- a/irouter/irouter.h
+++ b/irouter/irouter.h
@@ -49,4 +49,8 @@ extern bool IRTechLine();
 extern void IRDRCInit();
 extern bool IRDRCLine();
 
+/* C99 compat */
+extern int  irRoute();
+extern void IRCommand();
+
 #endif /* _IROUTER_H */

--- a/lef/defRead.c
+++ b/lef/defRead.c
@@ -36,6 +36,10 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 #include "cif/cif.h"
 #include "lef/lefInt.h"
 
+/* C99 compat */
+#include "textio/textio.h"
+#include "commands/commands.h"
+
 /*
  *------------------------------------------------------------
  *

--- a/lef/defWrite.c
+++ b/lef/defWrite.c
@@ -33,6 +33,10 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 #include "lef/lefInt.h"
 #include "drc/drc.h"		/* for querying width,spacing rules */
 
+/* C99 compat */
+#include "utils/signals.h"
+#include "textio/textio.h"
+
 /*----------------------------------------------------------------------*/
 /* Structures used by various routines					*/
 /*----------------------------------------------------------------------*/

--- a/lef/lefCmd.c
+++ b/lef/lefCmd.c
@@ -27,6 +27,11 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 #include "textio/txcommands.h"
 #include "commands/commands.h"
 
+/* C99 compat */
+#include "textio/textio.h"
+#include "cif/cif.h"
+#include "lef/lefInt.h"
+
 int lefDateStamp = -1;	/* If not -1, defines the timestamp to use when creating
 			 * new cell defs from LEF or DEF.  Useful when generating
 			 * libraries to make sure that full and abstract views of

--- a/lef/lefInt.h
+++ b/lef/lefInt.h
@@ -157,6 +157,17 @@ LefMapping *defMakeInverseLayerMap();
 void LefError(int, char *, ...);	/* Variable argument procedure requires */
 					/* parameter list.			*/
 
+/* C99 compat */
+extern void LefRead();
+extern void DefRead();
+
+void LefWriteAll();
+void DefWriteCell();
+void LefWriteCell();
+int  DRCGetDefaultLayerWidth();
+void LefTechInit();
+void lefRemoveGeneratedVias();
+
 /* Definitions for type passed to LefError() */
 
 #define LEF_ERROR	0

--- a/lef/lefRead.c
+++ b/lef/lefRead.c
@@ -44,6 +44,12 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 #include "cif/CIFread.h"	/* Access to cifCurReadStyle. . . */
 #include "lef/lefInt.h"
 
+/* C99 compat */
+#include "utils/signals.h"
+#include "utils/signals.h"
+#include "drc/drc.h"
+#include "lef/lef.h"
+
 /* ---------------------------------------------------------------------*/
 
 /* Current line number for reading */

--- a/lef/lefTech.c
+++ b/lef/lefTech.c
@@ -39,6 +39,9 @@ static char rcsid[] __attribute__ ((unused)) = "$Header$";
 #include "drc/drc.h"
 #include "cif/cif.h"
 
+/* C99 compat */
+#include "utils/tech.h"
+
 /* ---------------------------------------------------------------------*/
 
 /* Layer and Via routing information table.  */

--- a/lef/lefWrite.c
+++ b/lef/lefWrite.c
@@ -44,6 +44,10 @@ static char rcsid[] __attribute__ ((unused)) = "$Header$";
 #include "cif/CIFint.h"
 #include "lef/lefInt.h"
 
+/* C99 compat */
+#include "textio/textio.h"
+#include "select/select.h"
+
 
 #define FP "%s"
 #define POINT FP " " FP

--- a/magic/magicTop.c
+++ b/magic/magicTop.c
@@ -30,6 +30,9 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 #include "utils/magic.h"
 #include "utils/malloc.h"
 
+/* C99 compat */
+#include "utils/main.h"
+
 /*---------------------------------------------------------------------------
  * main:
  *

--- a/mzrouter/mzInternal.h
+++ b/mzrouter/mzInternal.h
@@ -432,6 +432,27 @@ extern dlong mzWindowMaxToGo;
 /* Marked cell list */
 extern List *mzMarkedCellsList;
 
+/* C99 compat */
+extern void mzExtendBlockBounds();
+extern void mzBuildDestAreaBlocks();
+extern void mzBuildEstimate();
+extern void mzBuildHFR();
+extern void mzCleanEstimate();
+extern void mzComputeDerivedParms();
+extern void mzDumpEstimates();
+extern void mzDumpTags();
+extern void mzExtendDown();
+extern void mzExtendLeft();
+extern void mzExtendRight();
+extern void mzExtendUp();
+extern void mzFreeAllRPaths();
+extern void mzMarkConnectedTiles();
+extern void mzPaintBlockType();
+extern void mzPrintPathHead();
+extern bool mzStart();
+extern void mzWalkLRContact();
+extern void mzWalkUDContact();
+
 /* ------------ Interesting Point Macros -------------------------------- */
 /* The following macros are used in the low-level routines for finding
  * the NEXT interesting point to the Right, Left, Up and Down.

--- a/mzrouter/mzTech.c
+++ b/mzrouter/mzTech.c
@@ -45,6 +45,9 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 #include "mzrouter/mzrouter.h"
 #include "mzrouter/mzInternal.h"
 
+/* C99 compat */
+#include "drc/drc.h"
+
 /* Procedures referenced before they are defined
  * (these procedures are local to this file)
  */

--- a/mzrouter/mzTestCmd.c
+++ b/mzrouter/mzTestCmd.c
@@ -47,6 +47,9 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 #include "mzrouter/mzrouter.h"
 #include "mzrouter/mzInternal.h"
 
+/* C99 compat */
+#include "debug/debug.h"
+
 /* Subcommand table - declared here since its referenced before defined */
 typedef struct
 {

--- a/netmenu/NMwiring.c
+++ b/netmenu/NMwiring.c
@@ -43,6 +43,9 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 #include "router/router.h"
 #include "utils/utils.h"
 
+/* C99 compat */
+#include "select/select.h"
+
 /* The following structure is used to hold information about
  * areas to be erased during net ripup.
  */

--- a/netmenu/netmenu.h
+++ b/netmenu/netmenu.h
@@ -56,4 +56,8 @@ extern void NMButtonRight();
 extern void NMMeasureAll();
 #endif
 
+/* C99 compat */
+extern void nmGetNums();
+
+
 #endif /* _NETMENU_H */

--- a/netmenu/nmInt.h
+++ b/netmenu/nmInt.h
@@ -128,6 +128,15 @@ extern void NMWriteAll();
 extern void NMUndo();
 extern void NMUndoInit();
 
+/* C99 compat */
+extern void NMMeasureNet();
+extern int  NMcommand();
+extern int  NMredisplay();
+extern int  NMCull();
+extern bool CmdParseLayers();
+extern int  NMredisplay();
+extern int  NMEnumTerms();
+
 /* Various global variables (within this module): */
 
 extern char * NMCurNetName;

--- a/plot/plotCmd.c
+++ b/plot/plotCmd.c
@@ -41,6 +41,9 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 #include "commands/commands.h"
 #include "plot/plotInt.h"
 
+/* C99 compat */
+#include "textio/textio.h"
+
 
 /*
  * ----------------------------------------------------------------------------

--- a/plot/plotHP.c
+++ b/plot/plotHP.c
@@ -15,6 +15,9 @@
 #include "utils/malloc.h"
 #include "plot/plotInt.h"
 
+/* C99 compat */
+#include "textio/textio.h"
+
 #ifdef VERSATEC
 
 extern int PlotRTLCompress();

--- a/plot/plotInt.h
+++ b/plot/plotInt.h
@@ -235,4 +235,19 @@ extern unsigned char PlotPNMBG;
 extern bool PlotPNMRTL;
 #endif
 
+/* C99 compat */
+extern void PlotRastFatLine();
+extern void PlotHPRTLHeader();
+extern void PlotPS();
+extern void PlotHPGL2Header();
+extern void PlotPrintParams();
+extern int  PlotDumpHPRTL();
+extern void PlotHPGL2Trailer();
+extern void PlotSetParam();
+extern void PlotHPRTLTrailer();
+extern void PlotVersatec();
+extern void PlotPNM();
+extern void PlotPNM();
+extern int  PlotRTLCompress();
+
 #endif /* _PLOTINT_H */

--- a/plot/plotPNM.c
+++ b/plot/plotPNM.c
@@ -36,6 +36,9 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 #include <string.h>
 #include <math.h>
 
+/* C99 compat */
+#include <stdlib.h>
+
 #include "utils/magic.h"
 #include "utils/geometry.h"
 #include "utils/geofast.h"

--- a/plot/plotPS.c
+++ b/plot/plotPS.c
@@ -38,6 +38,9 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 #include "dbwind/dbwind.h"
 #include "textio/textio.h"
 
+/* C99 compat */
+#include "graphics/graphics.h"
+
 /* Records of the following type are used to describe how to generate
  * PS output for a particular set of mask layers.  Each style
  * describes the PS figures to draw for a particular set of

--- a/plot/plotVers.c
+++ b/plot/plotVers.c
@@ -24,6 +24,9 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 #include <stdio.h>
 #include <string.h>
 
+/* C99 compat */
+#include <stdlib.h>
+
 #include "utils/magic.h"
 #include "utils/geometry.h"
 #include "utils/geofast.h"
@@ -40,6 +43,9 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 #include "utils/signals.h"
 #include "dbwind/dbwind.h"
 #include "cif/cif.h"		/* for CIFGetOutputScale() */
+
+/* C99 compat */
+#include "plot/plotInt.h"
 
 #ifdef VERSATEC
 

--- a/plow/PlowCmd.c
+++ b/plow/PlowCmd.c
@@ -38,6 +38,11 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 #include "plow/plow.h"
 #include "select/select.h"
 
+/* C99 compat */
+#include "textio/textio.h"
+#include "commands/commands.h"
+#include "plow/plowInt.h"
+
 /*
  * ----------------------------------------------------------------------------
  *

--- a/plow/PlowRandom.c
+++ b/plow/PlowRandom.c
@@ -45,6 +45,9 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 #include "utils/signals.h"
 #include "extract/extract.h"
 
+/* C99 compat */
+#include "drc/drc.h"
+
 /* Imports from PlowMain.c */
 extern CellDef *plowYankDef;
 

--- a/plow/PlowTech.c
+++ b/plow/PlowTech.c
@@ -36,6 +36,10 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 #include "plow/plowInt.h"
 #include "drc/drc.h"
 
+/* C99 compat */
+#include "utils/tech.h"
+#include "drc/drc.h"
+
 /* Imports from DRC */
 extern char *maskToPrint();
 

--- a/plow/plow.h
+++ b/plow/plow.h
@@ -54,4 +54,9 @@ extern int PlowJogHorizon;
 /* TRUE if we should eliminate jogs after each plow operation */
 extern bool PlowDoStraighten;
 
+/* C99 compat */
+extern void DRCPlowScale();
+extern void PlowInit();
+extern void PlowAfterTech();
+
 #endif /* _PLOW_H */

--- a/plow/plowInt.h
+++ b/plow/plowInt.h
@@ -247,6 +247,39 @@ extern bool plowQueueLeftmost();
 extern bool plowQueueRightmost();
 extern Tile *plowSplitY();
 
+/* C99 compat */
+extern bool Plow();
+extern void PlowClearBound();
+extern bool PlowSelection();
+extern void PlowSetBound();
+extern void PlowStraighten();
+extern int  plowApplySearchRules();
+extern int  plowAtomize();
+extern void plowCleanupJogs();
+extern void plowDebugEdge();
+extern int  plowFindWidth();
+extern int  plowFindWidthBack();
+extern int  plowGenRandom();
+extern void plowQueueDone();
+extern void plowQueueInit();
+extern int  plowSrFinalArea();
+extern void plowSrOutline();
+extern int  plowSrShadow();
+extern int  plowSrShadowBack();
+extern int  plowSrShadowInitial();
+extern bool plowYankMore();
+extern void PlowRandomTest();
+extern void plowDebugInit();
+extern void plowMergeBottom();
+extern void plowMergeTop();
+extern void plowMoveEdge();
+extern int  plowShadowInitialRHS();
+extern int  plowShadowLHS();
+extern int  plowShadowRHS();
+extern void plowTechShow();
+extern void plowUpdateLabels();
+extern void plowYankCreate();
+
 /* ------------------------- Debugging flags -------------------------- */
 
 /*

--- a/resis/ResFract.c
+++ b/resis/ResFract.c
@@ -25,6 +25,10 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 #include "windows/windows.h"
 #include "utils/main.h"
 
+/* C99 compat */
+#include "extract/extractInt.h"
+#include "resis/resis.h"
+
 extern Tile *ResSplitX();
 
 

--- a/resis/ResMakeRes.c
+++ b/resis/ResMakeRes.c
@@ -26,6 +26,9 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 #include "resis/resis.h"
 #include "cif/CIFint.h"
 
+/* C99 compat */
+#include "cif/cif.h"
+
 /* Forward declarations */
 bool ResCalcNearDevice();
 bool ResCalcNorthSouth();

--- a/resis/resis.h
+++ b/resis/resis.h
@@ -635,6 +635,47 @@ extern void			ResFixDevName();
 extern void			ResWriteLumpFile();
 extern void			ResSortBreaks();
 
+/* C99 compat */
+extern void ResAddToQueue();
+extern bool ResCalcTileResistance();
+extern void ResCleanNode();
+extern void ResCleanUpEverything();
+extern void ResDeleteResPointer();
+extern void ResDoContacts();
+extern int  ResDoSimplify();
+extern void ResDoneWithNode();
+extern void ResEliminateResistor();
+extern bool ResExtractNet();
+extern int  ResFracture();
+extern void ResMergeNodes();
+extern void ResNewSDDevice();
+extern void ResNewSubDevice();
+extern void ResPreProcessDevices();
+extern void ResPrintDeviceList();
+extern void ResPrintExtDev();
+extern void ResPrintReference();
+extern void ResPrintResistorList();
+extern void ResPrintStats();
+extern void ResProcessJunction();
+extern int  ResReadNode();
+extern int  ResReadSim();
+extern void ResRemoveFromQueue();
+extern int  ResSimNewNode();
+extern int  ResWriteExtFile();
+extern void ResPrintExtNode();
+extern void ResPrintExtRes();
+extern void ResPrintFHNodes();
+extern void ResPrintFHRects();
+extern int  ResCreateCenterlines();
+extern int  ResSeriesCheck();
+extern int  ResParallelCheck();
+extern int  ResTriangleCheck();
+extern int  gettokens();
+extern int  resWalkdown();
+extern int  resWalkleft();
+extern int  resWalkright();
+extern int  resWalkup();
+
 
 /* macros */
 

--- a/router/router.h
+++ b/router/router.h
@@ -175,6 +175,28 @@ extern Point RtrOrigin;
 extern void RtrTechInit(), RtrTechFinal();
 extern bool RtrTechLine();
 
+/* C99 compat */
+extern int  RtrTechScale();
+extern void RtrChannelBounds();
+extern void RtrMilestoneStart();
+extern void RtrMilestonePrint();
+extern void RtrChannelObstacles();
+extern void RtrMilestoneDone();
+extern void RtrChannelDensity();
+extern void RtrChannelRoute();
+extern void RtrChannelCleanObstacles();
+extern void RtrStemProcessAll();
+extern void RtrPaintBack();
+extern bool RtrStemAssignExt();
+extern void RtrPinsInit();
+extern void RtrHazards();
+extern void RtrPinsLink();
+extern bool RtrPinsBlock();
+extern bool rtrStemMask();
+extern bool RtrStemPaintExt();
+extern int  rtrEnumSides();
+extern void RtrChannelError();
+
 /* Overall procedure to do routing */
 extern void Route();
 

--- a/router/routerInt.h
+++ b/router/routerInt.h
@@ -30,4 +30,20 @@ extern int	rtrTarget;			/* Via minimization, target type	*/
 extern int	rtrReplace;			/* Via minimization, replacement type	*/
 extern int	rtrDelta;			/* Change in layer width		*/
 
+/* C99 compat */
+extern void RtrPinsFixStems();
+extern int  RtrViaMinimize();
+extern int  rtrPinArrayFixStems();
+extern int  rtrPinArrayInit();
+extern int  rtrPinArrayLink();
+extern int  rtrSidePassToClient();
+extern int  rtrSideProcess();
+extern int  rtrXDist();
+extern int  rtrYDist();
+extern int  rtrStemContactLine();
+extern int  rtrStemTypes();
+extern int  rtrSrTraverse();
+extern int  rtrListVia();
+extern void rtrListArea();
+
 #endif /* _ROUTERINT_H */

--- a/router/rtrChannel.c
+++ b/router/rtrChannel.c
@@ -40,6 +40,9 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 #include "textio/textio.h"
 #include "utils/styles.h"
 
+/* C99 compat */
+#include "router/routerInt.h"
+
 /*
  * Maps a tile pointer to a channel structure.
  * We use this rather than the client fields of tiles because

--- a/router/rtrCmd.c
+++ b/router/rtrCmd.c
@@ -45,6 +45,13 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 #include "gcr/gcr.h"
 #include "grouter/grouter.h"
 
+/* C99 compat */
+#include "textio/textio.h"
+#include "irouter/irouter.h"
+#include "mzrouter/mzrouter.h"
+#include "garouter/garouter.h"
+#include "router/routerInt.h"
+
 /* Global variable initialization */
 
 bool RtrMazeStems = FALSE;	/* Set by default to original behavior */

--- a/router/rtrDcmpose.c
+++ b/router/rtrDcmpose.c
@@ -61,6 +61,9 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 #include "netmenu/netmenu.h"
 #include "debug/debug.h"
 
+/* C99 compat */
+#include "router/routerInt.h"
+
 /* The following tile types are used during channel decomposition */
 #define	CELLTILE	1	/* Cell tile -- no channels here */
 #define	USERCHAN	2	/* User-defined channel */

--- a/router/rtrMain.c
+++ b/router/rtrMain.c
@@ -45,6 +45,9 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 #include "netmenu/netmenu.h"
 #include "utils/runstats.h"
 
+/* C99 compat */
+#include "garouter/garouter.h"
+
 /* Forward declarations */
 
 extern int rtrMakeChannel();

--- a/router/rtrPaint.c
+++ b/router/rtrPaint.c
@@ -37,6 +37,9 @@ static char rcsid[] __attribute__ ((unused)) ="$Header: /usr/cvsroot/magic-8.0/r
 #include "dbwind/dbwind.h"
 #include "utils/main.h"
 
+/* C99 compat */
+#include "textio/textio.h"
+
 int RtrViaLimit		= 2;
 int rtrMetalLength	= 0;
 int rtrPolyLength	= 0;

--- a/router/rtrPin.c
+++ b/router/rtrPin.c
@@ -41,6 +41,9 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 #include "grouter/grouter.h"
 #include "textio/textio.h"
 
+/* C99 compat */
+#include "router/routerInt.h"
+
 /* Forward declarations */
 bool rtrPinArrayBlock();
 void rtrPinShow(GCRPin *);

--- a/router/rtrSide.c
+++ b/router/rtrSide.c
@@ -40,6 +40,9 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 #include "utils/main.h"
 #include "utils/signals.h"
 
+/* C99 compat */
+#include "router/routerInt.h"
+
 /*
  * Local data used for communicating with filter functions.
  * This procedure is non-reentrant because it needs to use a temporary

--- a/router/rtrStem.c
+++ b/router/rtrStem.c
@@ -46,6 +46,9 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 #include "utils/signals.h"
 #include "utils/maxrect.h"
 
+/* C99 compat */
+#include "router/routerInt.h"
+
 /* Used when searching for stems */
 typedef struct
 {

--- a/router/rtrVia.c
+++ b/router/rtrVia.c
@@ -40,6 +40,9 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 #include "router/router.h"
 #include "router/routerInt.h"
 
+/* C99 compat */
+#include "router/routerInt.h"
+
 /*
  * The following structures are used to hold information about
  * areas to be erased/modified/painted during via minimization.

--- a/scripts/configure_mac
+++ b/scripts/configure_mac
@@ -4,5 +4,4 @@ set -x
     --with-tcl=$(brew --prefix tcl-tk)\
     --with-tk=$(brew --prefix tcl-tk)\
     --with-cairo=$(brew --prefix cairo)/include\
-    "CFLAGS=-Wno-error=implicit-function-declaration"\
     "LDFLAGS=-L$(brew --prefix cairo)/lib"

--- a/select/selCreate.c
+++ b/select/selCreate.c
@@ -39,6 +39,9 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 #include "utils/main.h"
 #include "utils/signals.h"
 
+/* C99 compat */
+#include "graphics/graphics.h"
+
 /* Two cells worth of information are kept around by the selection
  * module.  SelectDef and SelectUse are for the cells whose contents
  * are the current selection.  Select2Def and Select2Use provide a

--- a/select/selDisplay.c
+++ b/select/selDisplay.c
@@ -34,6 +34,9 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 #include "textio/textio.h"
 #include "utils/signals.h"
 
+/* C99 compat */
+#include "utils/undo.h"
+
 /* The current selection is displayed by displaying the outline of
  * shapes in one cell as an overlay (using the higlight facilities)
  * on top of another cell.  The variables below are used to remember

--- a/select/selEnum.c
+++ b/select/selEnum.c
@@ -38,6 +38,9 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 #include "utils/malloc.h"
 #include "textio/textio.h"
 
+/* C99 compat */
+#include "graphics/graphics.h"
+
 /* Structure passed from top-level enumeration procedures to lower-level
  * ones:
  */

--- a/select/selInt.h
+++ b/select/selInt.h
@@ -31,10 +31,12 @@
  */
 
 extern int SelRedisplay();
-extern void SelSetDisplay();
 extern void SelUndoInit();
 extern void SelRememberForUndo();
 extern void SelectAndCopy2();
+
+/* C99 compat */
+extern void SelNetRememberForUndo();
 
 extern CellUse *Select2Use;
 extern CellDef *Select2Def;

--- a/select/selOps.c
+++ b/select/selOps.c
@@ -41,6 +41,10 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 #include "utils/malloc.h"
 #include "drc/drc.h"
 
+/* C99 compat */
+#include "commands/commands.h"
+#include "netmenu/netmenu.h"
+
 /* The following variables are shared between SelectStretch and the
  * search functions that it causes to be invoked.
  */

--- a/select/select.h
+++ b/select/select.h
@@ -57,6 +57,13 @@ extern void SelectStretch();
 extern void SelectArray();
 extern void SelectDump();
 
+/* C99 compat */
+extern void SelCopyToFeedback();
+extern void SelectAndCopy1();
+extern void SelectFlat();
+extern void SelSetDisplay();
+extern void SelRememberForUndo();
+
 /* Flag to indicate whether selection captures subcell labels */
 
 extern unsigned char SelectDoLabels;

--- a/sim/SimExtract.c
+++ b/sim/SimExtract.c
@@ -42,6 +42,9 @@
 #include "utils/stack.h"
 #include "sim/sim.h"
 
+/* C99 compat */
+#include "extract/extract.h"
+
 
 /* When performing node name extraction, we mark all tiles of a node
  * as we walk through the database.  Since nodes can span multiple cells,

--- a/sim/SimRsim.c
+++ b/sim/SimRsim.c
@@ -27,6 +27,7 @@
 #include <ctype.h>
 #include <signal.h>
 #include <unistd.h>
+#include <errno.h>
 
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -45,7 +46,9 @@
 #include "windows/windows.h"
 #include "dbwind/dbwind.h"
 #include "sim/sim.h"
-#include <errno.h>
+
+/* C99 compat */
+#include "textio/textio.h"
 
 static bool InitRsim();
 

--- a/sim/SimSelect.c
+++ b/sim/SimSelect.c
@@ -41,6 +41,10 @@ static char sccsid[] = "@(#)SimSelect.c	4.14 MAGIC (Berkeley) 10/3/85";
 #include "utils/signals.h"
 #include "sim/sim.h"
 
+/* C99 compat */
+#include "textio/textio.h"
+#include "extract/extract.h"
+
 /* Two cells worth of information are kept around by the selection
  * module.  SelectDef and SelectUse are for the cells whose contents
  * are the current selection.  Select2Def and Select2Use provide a

--- a/sim/sim.h
+++ b/sim/sim.h
@@ -28,4 +28,14 @@ extern HashTable SimGNAliasTbl;
 extern HashTable SimGetnodeTbl;
 extern HashTable SimAbortSeenTbl;
 
+/* C99 compat */
+extern void SimGetnode();
+extern void SimGetsnode();
+extern void SimGetNodeCleanUp();
+extern int  SimPutLabel();
+extern int  SimSrConnect();
+extern void SimTreeCopyConnect();
+extern int  SimTreeSrNMTiles();
+extern int  SimTreeSrTiles();
+
 #endif /* _SIM_H */

--- a/sim/sim.h
+++ b/sim/sim.h
@@ -37,5 +37,10 @@ extern int  SimSrConnect();
 extern void SimTreeCopyConnect();
 extern int  SimTreeSrNMTiles();
 extern int  SimTreeSrTiles();
+extern bool SimStartRsim();
+extern void SimConnectRsim();
+extern bool SimSelection();
+extern void SimRsimMouse();
+extern int  SimFillBuffer();
 
 #endif /* _SIM_H */

--- a/tcltk/tclmagic.h
+++ b/tcltk/tclmagic.h
@@ -22,7 +22,11 @@ extern Tcl_Interp *consoleinterp;
 /* Forward declaration of procedures */
 
 extern char *Tcl_escape();
-extern int TagVerify();
+extern int  TagVerify();
+
+/* C99 compat */
+extern int  Tcl_printf();
+extern void MakeWindowCommand();
 
 /* Backward compatibility issues */
 #ifndef CONST84

--- a/textio/textio.h
+++ b/textio/textio.h
@@ -92,6 +92,10 @@ extern char TxInterruptChar;		/* The current interrupt character */
 /* command procedures */
 extern void TxDispatch();
 
+/* C99 compat */
+extern void TxMore();
+extern void txGetFileCommand();
+
 /* variables that tell if stdin and stdout are to a terminal */
 extern bool TxStdinIsatty;
 extern bool TxStdoutIsatty;

--- a/textio/textioInt.h
+++ b/textio/textioInt.h
@@ -55,13 +55,12 @@ extern bool TxGetInputEvent();
 extern void txFprintfBasic(FILE *, ...);
 
 /* C99 compat */
-int  Tcl_printf();
 void txCommandsInit();
-int  Tcl_printf();
-int  Tcl_printf();
-int  Tcl_printf();
-int  Tcl_printf();
 int  TranslateChar();
 char *TxGetLineWPrompt();
+
+#ifdef MAGIC_WRAPPER
+int  Tcl_printf();
+#endif
 
 #endif /* _TEXTIOINT_H */

--- a/textio/textioInt.h
+++ b/textio/textioInt.h
@@ -54,4 +54,14 @@ extern bool TxGetInputEvent();
 
 extern void txFprintfBasic(FILE *, ...);
 
+/* C99 compat */
+int  Tcl_printf();
+void txCommandsInit();
+int  Tcl_printf();
+int  Tcl_printf();
+int  Tcl_printf();
+int  Tcl_printf();
+int  TranslateChar();
+char *TxGetLineWPrompt();
+
 #endif /* _TEXTIOINT_H */

--- a/textio/txCommands.c
+++ b/textio/txCommands.c
@@ -50,6 +50,9 @@ static char rcsid[] __attribute__ ((unused)) ="$Header: /usr/cvsroot/magic-8.0/t
 #include "utils/utils.h"
 #include "lisp/lisp.h"
 
+/* C99 compat */
+#include "windows/windows.h"
+
 /* Turning this flag on prints out input events and commands as they
  * are processed.
  */

--- a/textio/txCommands.c
+++ b/textio/txCommands.c
@@ -52,6 +52,7 @@ static char rcsid[] __attribute__ ((unused)) ="$Header: /usr/cvsroot/magic-8.0/t
 
 /* C99 compat */
 #include "windows/windows.h"
+#include "utils/main.h"
 
 /* Turning this flag on prints out input events and commands as they
  * are processed.

--- a/textio/txInput.c
+++ b/textio/txInput.c
@@ -49,6 +49,9 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 #include "cif/CIFint.h"
 #include "cif/CIFread.h"
 
+/* C99 compat */
+#include "utils/malloc.h"
+
 #ifdef USE_READLINE
 #ifdef HAVE_READLINE
 #include <readline/readline.h>

--- a/textio/txMain.c
+++ b/textio/txMain.c
@@ -37,6 +37,9 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 #include "database/database.h"
 #include "dbwind/dbwind.h"
 
+/* C99 compat */
+#include "utils/malloc.h"
+
 /* Global variables that indicate if we are reading or writing to a tty.
  */
 global bool TxStdinIsatty;

--- a/textio/txMore.c
+++ b/textio/txMore.c
@@ -24,6 +24,9 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 
 #include "utils/magic.h"
 
+/* C99 compat */
+#include "textio/textio.h"
+
 
 /*
  * ----------------------------------------------------------------------------

--- a/tiles/tile.c
+++ b/tiles/tile.c
@@ -29,6 +29,9 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 #include "utils/geometry.h"
 #include "tiles/tile.h"
 
+/* C99 compat */
+#include "textio/textio.h"
+
 /*
  * Debugging version of TiSetBody() macro in tile.h
  * Includes sanity check that a tile at "infinity"

--- a/utils/args.c
+++ b/utils/args.c
@@ -25,6 +25,9 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 #include "utils/magic.h"
 #include "utils/utils.h"
 
+/* C99 compat */
+#include "textio/textio.h"
+
 /*
  * ----------------------------------------------------------------------------
  *

--- a/utils/flock.c
+++ b/utils/flock.c
@@ -24,6 +24,9 @@
 #include "windows/windows.h"
 #include "utils/malloc.h"
 
+/* C99 compat */
+#include "textio/textio.h"
+
 /*
  *-------------------------------------------------------------------------
  * Below are the service routines for file locking.

--- a/utils/geometry.h
+++ b/utils/geometry.h
@@ -193,6 +193,10 @@ extern void GeoDecomposeTransform(Transform *, bool *, int *);
 extern void GeoIncludeRectInBBox(Rect *, Rect *);
 extern void GeoCanonicalRect(Rect *, Rect *);
 
+/* C99 compat */
+extern bool GeoDisjoint();
+extern void GeoScaleTrans();
+
 /*
  *-------------------------------------------------------------------
  *	Declarations of exported transforms and rectangles:

--- a/utils/heap.c
+++ b/utils/heap.c
@@ -29,6 +29,9 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 #include "utils/utils.h"
 #include "utils/malloc.h"
 
+/* C99 compat */
+#include "textio/textio.h"
+
 #define heapLeft(used,i)  ((used) < ( (i)<<1)    ? 0 : (i)+(i)  )
 #define heapRight(used,i) ((used) < (((i)<<1)+1) ? 0 : (i)+(i)+1)
 

--- a/utils/macros.c
+++ b/utils/macros.c
@@ -38,6 +38,9 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 #include "utils/macros.h"
 #include "windows/windows.h"
 
+/* C99 compat */
+#include "textio/textio.h"
+
 /* Define the macro client table */
 
 HashTable MacroClients;

--- a/utils/main.c
+++ b/utils/main.c
@@ -77,6 +77,18 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 #include "graphics/wind3d.h"
 #endif
 
+/* C99 compat */
+#include "utils/utils.h"
+#include "utils/tech.h"
+#include "commands/commands.h"
+#include "dbwind/dbwind.h"
+#include "cmwind/cmwind.h"
+#include "extract/extract.h"
+#include "plow/plow.h"
+#include "select/select.h"
+#include "irouter/irouter.h"
+#include "lef/lefInt.h"
+
 
 /*
  * Global data structures

--- a/utils/main.h
+++ b/utils/main.h
@@ -95,4 +95,10 @@ extern Transform RootToEditTransform;
 extern void MainExit(int);	/* a way of exiting that cleans up after itself */
 extern void magicMain();
 
+/* C99 compat */
+extern int  mainInitBeforeArgs();
+extern int  mainDoArgs();
+extern int  mainInitAfterArgs();
+extern int  mainInitFinal();
+
 #endif /* _MAIN_H */

--- a/utils/netlist.c
+++ b/utils/netlist.c
@@ -36,6 +36,10 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 #include "utils/malloc.h"
 #include "utils/styles.h"
 
+/* C99 compat */
+#include "netmenu/netmenu.h"
+#include "dbwind/dbwind.h"
+
 /* Compute the "cost" of a net from the bounding rect for all its terminals */
 #define	NETSIZE(r)  ((int)((r)->r_xtop - (r)->r_xbot + (r)->r_ytop - (r)->r_ybot))
 

--- a/utils/netlist.h
+++ b/utils/netlist.h
@@ -123,4 +123,9 @@ typedef struct
 /* Exports */
 extern char *NLNetName();
 
+/* C99 compat */
+extern void NLFree();
+extern int  NLBuild();
+extern void NLSort();
+
 #endif /* _RMNETLIST_H */

--- a/utils/pathvisit.h
+++ b/utils/pathvisit.h
@@ -41,4 +41,9 @@ typedef struct
 
 PaVisit *PaVisitInit();
 
+/* C99 compat */
+extern void PaVisitAddClient();
+extern int  PaVisitFiles();
+extern void PaVisitFree();
+
 #endif	/* _PATHVISIT_H */

--- a/utils/set.c
+++ b/utils/set.c
@@ -32,6 +32,9 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 #include "database/database.h"
 #include "utils/list.h"
 
+/* C99 compat */
+#include "textio/textio.h"
+
 
 /*
  * ----------------------------------------------------------------------------

--- a/utils/signals.h
+++ b/utils/signals.h
@@ -54,6 +54,9 @@ extern void SigSetTimer();
 extern void SigTimerInterrupts();
 extern void SigTimerDisplay();
 
+/* C99 compat */
+extern void SigRemoveTimer();
+
 extern sigRetVal sigOnInterrupt();
 
 #endif /* _MAGSIGNAL_H */

--- a/utils/tech.c
+++ b/utils/tech.c
@@ -25,6 +25,12 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 #include <stdarg.h>
 #include <ctype.h>
 
+/*
+ * C99 compat
+ * Mind: tcltk/tclmagic.h must be included prior to all the other headers
+ */
+#include "tcltk/tclmagic.h"
+
 #include "database/database.h"
 #include "utils/magic.h"
 #include "utils/geometry.h"
@@ -33,6 +39,23 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 #include "textio/textio.h"
 #include "windows/windows.h"
 #include "utils/malloc.h"
+
+/* C99 compat */
+#include "utils/heap.h"
+#include "cif/cif.h"
+#include "cif/cif.h"
+#include "drc/drc.h"
+#include "mzrouter/mzrouter.h"
+#include "wiring/wiring.h"
+#include "lef/lef.h"
+#include "router/router.h"
+#include "irouter/irouter.h"
+#include "garouter/garouter.h"
+#include "extract/extract.h"
+#include "plow/plow.h"
+
+/* Cannot include tcltk/tclmagic.h for a clash with utils/magic.h
+extern int Tcl_printf(FILE *, char *, va_list); */
 
 global int  TechFormatVersion;
 global bool TechOverridesDefault;

--- a/utils/tech.h
+++ b/utils/tech.h
@@ -55,4 +55,9 @@ extern void TechError(char *, ...);
 extern void TechAddClient();
 extern void TechAddAlias();
 
+/* C99 compat */
+extern SectionID TechSectionGetMask();
+extern void TechInit();
+extern int  techGetTokens();
+
 #endif /* _TECH_H */

--- a/utils/undo.c
+++ b/utils/undo.c
@@ -34,6 +34,9 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 #include "utils/malloc.h"
 #include "utils/undo.h"
 
+/* C99 compat */
+#include "textio/textio.h"
+
 /* ------------------------------------------------------------------------ */
 
 /*

--- a/utils/utils.h
+++ b/utils/utils.h
@@ -74,6 +74,7 @@ extern int  PaEnum();
 extern int  paVisitProcess();
 extern void SetNoisyInt();
 extern void SetNoisyDI();
+extern bool ParsSplit();
 
 #ifdef HAVE_ZLIB
 extern gzFile PaZOpen(char *, char *, char *, char *, char *, char **);

--- a/utils/utils.h
+++ b/utils/utils.h
@@ -56,6 +56,25 @@ extern bool StrIsWhite(char *, bool);
 extern bool StrIsInt(char *);
 extern bool StrIsNumeric(char *);
 
+/* C99 compat */
+extern void PaAppend(char **, char *);
+extern void ReduceFraction(int *, int *);
+extern bool TechLoad(char *, SectionID);
+extern void UndoFlush();
+extern int  GeoTransAngle();
+extern int  GeoTransOrient();
+extern void GeoTransPointDelta();
+extern int  FindGCF();
+extern int  GetRect();
+extern void niceabort();
+extern void ShowRect();
+extern void FindDisplay();
+extern void ForkChildAdd();
+extern int  PaEnum();
+extern int  paVisitProcess();
+extern void SetNoisyInt();
+extern void SetNoisyDI();
+
 #ifdef HAVE_ZLIB
 extern gzFile PaZOpen(char *, char *, char *, char *, char *, char **);
 #endif

--- a/windows/windCmdSZ.c
+++ b/windows/windCmdSZ.c
@@ -43,6 +43,9 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 #include "dbwind/dbwind.h"
 #include "graphics/graphics.h"
 
+/* C99 compat */
+#include "commands/commands.h"
+
 
 /*
  * ----------------------------------------------------------------------------

--- a/windows/windInt.h
+++ b/windows/windInt.h
@@ -57,6 +57,10 @@ extern void windDump();
 extern void windClientInit();
 extern MagWindow *windSearchPoint();
 
+/* C99 compat */
+extern void windScreenToFrame();
+extern void WindPrintClientList();
+
 /* ----------------- constants ----------------- */
 
 /* the width of window borders */

--- a/windows/windMain.c
+++ b/windows/windMain.c
@@ -66,6 +66,9 @@ static char rcsid[] __attribute__ ((unused)) = "$Header$";
 #include "utils/utils.h"
 #include "textio/txcommands.h"
 
+/* C99 compat */
+#include "utils/main.h"
+
 /* The type of windows that this package will implement */
 int WindPackageType = WIND_MAGIC_WINDOWS;
 

--- a/windows/windView.c
+++ b/windows/windView.c
@@ -32,6 +32,9 @@ static char rcsid[] __attribute__ ((unused)) = "$Header$";
 #include "textio/textio.h"
 #include "dbwind/dbwind.h"
 
+/* C99 compat */
+#include "database/database.h"
+
 extern void windNewView();
 
 
@@ -274,7 +277,6 @@ void
 WindScale(scalen, scaled)
     int scalen, scaled;
 {
-    extern void DBScalePoint();
     MagWindow *w2;
     Rect newArea;
 

--- a/windows/windows.h
+++ b/windows/windows.h
@@ -292,6 +292,17 @@ extern void WindSeparateRedisplay();
 /* handler for window buttons in the scrollbar/zoom (non-wrapper) frame */
 extern bool WindButtonInFrame();
 
+/* C99 compat */
+extern bool WindDelete();
+extern void WindScale();
+extern void WindTranslate();
+extern void WindUnload();
+extern void WindRedisplay();
+extern void windUnlink();
+extern void windReClip();
+extern void windFree();
+extern int  WindSendCommand();
+
 /* interface variables */
 extern int WindDefaultFlags;	/* Mask of properties applied to new windows */
 extern int WindNewButtons;	/* A mask of the buttons that are down now. */

--- a/wiring/wireOps.c
+++ b/wiring/wireOps.c
@@ -40,6 +40,9 @@ static char rcsid[] __attribute__ ((unused)) = "$Header$";
 #include "textio/txcommands.h"
 #include "utils/styles.h"
 
+/* C99 compat */
+#include "utils/undo.h"
+
 /* The following variables define the state of the wiring interface. */
 
 TileType WireType = TT_SELECTBASE-1; /* Type of material currently selected


### PR DESCRIPTION
Dear Tim,

This diff makes the code (mostly) C99-compatible, enabling to compile it without the -Wno-error=implicit-function-declaration flag. This way, Magic becomes usable on arm64 architectures, specifically on Apple computers with M1/M2 SoC.

The diff is gigantic (more than 150 files modified), but rather simple; I marked each modification with the `/* C99 compat */` comment, to make it easier to review even after committing.

This addresses (and should resolve) #69; I lightly tested Magic on a M1 Macbook and can confirm that all the segmentation faults I was experiencing before have gone away; in particular, I'm now able to compile the Skywater-130 PDK using open_pdks scripts.

Please let me know in case of any doubt.

Cheers

--
Alessandro