### PR TITLE
Add PlowShowTime prototype when NO_RUSAGE isn't defined

### DIFF
--- a/plow/PlowMain.c
+++ b/plow/PlowMain.c
@@ -2249,6 +2249,7 @@ plowYankCreate()
 }
 
 #ifndef	NO_RUSAGE
+void
 plowShowTime(t1, t2, nqueued, nprocessed, nmoved)
     struct rusage *t1, *t2;
     int nqueued, nprocessed, nmoved;

--- a/plow/plowInt.h
+++ b/plow/plowInt.h
@@ -280,6 +280,10 @@ extern void plowTechShow();
 extern void plowUpdateLabels();
 extern void plowYankCreate();
 
+#ifndef NO_RUSAGE
+extern void plowShowTime();
+#endif
+
 /* ------------------------- Debugging flags -------------------------- */
 
 /*


### PR DESCRIPTION
Hello Tim,

This commit adds a missing function prototype in plow module; while there, I changed the function type from (implicit) int to void, since it doesn't return any value.

It should address #199 (only compiled on OpenBSD, no real test done).

--
Alessandro