### PR TITLE
Use offsetof()

### DIFF
--- a/bplane/bpMain.c
+++ b/bplane/bpMain.c
@@ -37,6 +37,7 @@
  */
 
 #include <stdio.h>
+#include <stddef.h>
 #include "utils/utils.h"
 #include "utils/malloc.h"
 #include "database/database.h"
@@ -68,8 +69,8 @@ BPlane *BPNew(void)
 
   /* HASH TABLE */
   new->bp_hashTable = IHashInit(4, /* initial buckets */
-				OFFSET(Element, e_rect), /* key */
-				OFFSET(Element, e_hashLink),
+				offsetof(Element, e_rect), /* key */
+				offsetof(Element, e_hashLink),
 				IHash4WordKeyHash,
 				IHash4WordKeyEq);
 

--- a/bplane/bplane.h
+++ b/bplane/bplane.h
@@ -160,17 +160,6 @@
  *
  */
 
-/* offset of a structure member (used to gen offsets for ihash stuff) */
-#if _MSC_VER
-/* Microsoft compile complains about size of (void*), so must use (char*) */
-/* Could use (char*) in UNIX version too. */
-#define OFFSET(structure,member)   \
-( ((char *) &(((structure *) 0))->member) - ((char *) 0) )
-#else
-#define OFFSET(structure,member)   \
-( ((void *) &(((structure *) 0))->member) - ((void *) 0) )
-#endif
-
 /* data-structures opaque to clients */
 #include "bplane/bpOpaque.h"
 


### PR DESCRIPTION
Magic has an open coded version of offsetof() which clang complains about, because it takes the offset of a null pointer. Use offsetof() instead.