### PR TITLE
Fix build with Clang 15.

### DIFF
--- a/database/DBpaint.c
+++ b/database/DBpaint.c
@@ -1538,7 +1538,7 @@ DBNMPaintPlane0(plane, exacttype, area, resultTbl, undo, method)
 		}
 
 		oldType = TiGetTypeExact(tile);
-		newType = DBDiagonalProc(oldType, &dinfo);
+		newType = DBDiagonalProc(oldType, (uintptr_t)&dinfo);
 
 		/* Ignore tiles that don't change type.	*/
 


### PR DESCRIPTION
Use a cast to fix the build with Clang 15.

```
DBpaint.c:1542:37: error: incompatible pointer to integer conversion passing 'DiagInfo *' (aka 'struct diag_info *') to parameter of type 'ClientData' (aka 'unsigned long') [-Wint-conversion]
                newType = DBDiagonalProc(oldType, &dinfo);
                                                  ^~~~~~
```