### PR TITLE
add wasm target

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Build
         run: |
           source ./emsdk/emsdk_env.sh
-          emconfigure ./configure --without-cairo --without-opengl --without-x --disable-readline
+          emconfigure ./configure --without-cairo --without-opengl --without-x --disable-readline --target=asmjs-unknown-emscripten
           emmake make
       - name: archive wasm bundle
         uses: actions/upload-artifact@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,6 +35,28 @@ jobs:
           ./configure
           make database/database.h
           make -j$(nproc)
+  simple_build_wasm:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Get Dependencies
+        run: |
+          sudo apt-get install -y csh
+          git clone https://github.com/emscripten-core/emsdk.git
+          cd emsdk
+          ./emsdk install latest
+          ./emsdk activate latest
+      - name: Build
+        run: |
+          source ./emsdk/emsdk_env.sh
+          emconfigure ./configure --without-cairo --without-opengl --without-x --disable-readline
+          emmake make
+      - name: archive wasm bundle
+        uses: actions/upload-artifact@v3
+        with:
+          name: magic-wasm-bundle
+          path: |
+            ${{ github.workspace }}/magic/magic.wasm
   # simple_build_mac:
   #   runs-on: macos-11
   #   steps:

--- a/calma/CalmaRead.c
+++ b/calma/CalmaRead.c
@@ -28,6 +28,12 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 
 #include <netinet/in.h>
 
+/*
+ * C99 compat
+ * Mind: tcltk/tclmagic.h must be included prior to all the other headers
+ */
+#include "tcltk/tclmagic.h"
+
 #include "utils/magic.h"
 #include "utils/geometry.h"
 #include "tiles/tile.h"

--- a/calma/CalmaRead.c
+++ b/calma/CalmaRead.c
@@ -445,6 +445,9 @@ void CalmaReadError(char *format, ...)
         {
             TxError("Error while reading cell \"%s\" ", cifReadCellDef->cd_name);
 	    TxError("(byte position %"DLONG_PREFIX"d): ", (dlong)filepos);
+	    va_start(args, format);	    
+	    TxErrorV(format, args);
+	    va_end(args);	    
         }
     }
     else if ((calmaTotalErrors == 100) && (CIFWarningLevel == CIF_WARN_LIMIT))

--- a/calma/CalmaRead.c
+++ b/calma/CalmaRead.c
@@ -20,6 +20,7 @@
 static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/calma/CalmaRead.c,v 1.3 2010/06/24 12:37:15 tim Exp $";
 #endif  /* not lint */
 
+#include <stdarg.h>
 #include <stdio.h>
 #include <string.h>
 #include <sys/types.h>
@@ -409,12 +410,9 @@ calmaParseUnits()
  * ----------------------------------------------------------------------------
  */
 
-void
-    /*VARARGS1*/
-CalmaReadError(format, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10)
-    char *format;
-    char *a1, *a2, *a3, *a4, *a5, *a6, *a7, *a8, *a9, *a10;
+void CalmaReadError(char *format, ...)
 {
+    va_list args;
     OFFTYPE filepos;
 
     calmaTotalErrors++;
@@ -432,15 +430,15 @@ CalmaReadError(format, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10)
                                 cifReadCellDef->cd_name);
 		fprintf(calmaErrorFile, "(byte position %"DLONG_PREFIX"d): ",
 				(dlong)filepos);
-                fprintf(calmaErrorFile, format, a1, a2, a3, a4, a5, a6, a7,
-                                a8, a9, a10);
+		va_start(args, format);
+		Vfprintf(calmaErrorFile, format, args);
+		va_end(args);
             }
         }
         else
         {
             TxError("Error while reading cell \"%s\" ", cifReadCellDef->cd_name);
 	    TxError("(byte position %"DLONG_PREFIX"d): ", (dlong)filepos);
-            TxError(format, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10);
         }
     }
     else if ((calmaTotalErrors == 100) && (CIFWarningLevel == CIF_WARN_LIMIT))

--- a/calma/CalmaWrite.c
+++ b/calma/CalmaWrite.c
@@ -27,7 +27,7 @@ static char rcsid[] __attribute__ ((unused)) ="$Header: /usr/cvsroot/magic-8.0/c
 #include <ctype.h>
 #include <sys/types.h>
 #include <arpa/inet.h>	/* for htons() */
-#ifdef	SYSV
+#if defined(SYSV) || defined(EMSCRIPTEN)
 #include <time.h>
 #else
 #include <sys/time.h>

--- a/calma/CalmaWriteZ.c
+++ b/calma/CalmaWriteZ.c
@@ -37,7 +37,7 @@ static char rcsid[] __attribute__ ((unused)) ="$Header: /usr/cvsroot/magic-8.0/c
 #include <ctype.h>
 #include <sys/types.h>
 #include <arpa/inet.h>	/* for htons() */
-#ifdef	SYSV
+#if defined(SYSV) || defined(EMSCRIPTEN)
 #include <time.h>
 #else
 #include <sys/time.h>

--- a/calma/calma.h
+++ b/calma/calma.h
@@ -63,10 +63,9 @@ extern bool CalmaWrite();
 extern void CalmaReadFile();
 extern void CalmaTechInit();
 extern bool CalmaGenerateArray();
-extern void CalmaReadError();
+extern void CalmaReadError(char *format, ...);
 
 /* C99 compat */
-extern void CalmaReadError();
 extern int  calmaAddSegment();
 extern void calmaDelContacts();
 extern void calmaElementBoundary();

--- a/cif/CIFrdpoly.c
+++ b/cif/CIFrdpoly.c
@@ -243,7 +243,7 @@ CIFPolyToRects(path, plane, resultTbl, ui, isCalma)
     if ((tail->cifp_x != path->cifp_x) || (tail->cifp_y != path->cifp_y))
     {
 	if (isCalma)
-	    CalmaReadError("Boundary is not closed.\n" );
+	    CalmaReadError("Boundary is not closed.\n");
 
 	p = (CIFPath *) mallocMagic ((unsigned) sizeof (CIFPath));
 	p->cifp_x = path->cifp_x;

--- a/cif/CIFrdpoly.c
+++ b/cif/CIFrdpoly.c
@@ -243,7 +243,7 @@ CIFPolyToRects(path, plane, resultTbl, ui, isCalma)
     if ((tail->cifp_x != path->cifp_x) || (tail->cifp_y != path->cifp_y))
     {
 	if (isCalma)
-	    CalmaReadError("Boundary is not closed.\n");
+	    CalmaReadError("Boundary is not closed.\n" );
 
 	p = (CIFPath *) mallocMagic ((unsigned) sizeof (CIFPath));
 	p->cifp_x = path->cifp_x;

--- a/commands/CmdLQ.c
+++ b/commands/CmdLQ.c
@@ -1046,7 +1046,7 @@ CmdPaintEraseButton(w, refPoint, isPaint, isScreen)
     else
     {
 	DBEraseValid(EditCellUse->cu_def, &editRect, &mask, 0);
-	DBEraseLabel(EditCellUse->cu_def, &editRect, &mask);
+	DBEraseLabel(EditCellUse->cu_def, &editRect, &mask, NULL);
     }
     SelectClear();
     DBAdjustLabels(EditCellUse->cu_def, &editRect);

--- a/configure
+++ b/configure
@@ -9,4 +9,4 @@
 # script itself.  It also sets up CFLAGS without the default optimizer
 # flag (-O2).
 
-( CFLAGS="-g"; export CFLAGS; cd scripts ; ./configure "$@" )
+( CFLAGS="-g -Wno-int-conversion -Wno-implicit-int"; export CFLAGS; cd scripts ; ./configure "$@" )

--- a/configure
+++ b/configure
@@ -9,4 +9,4 @@
 # script itself.  It also sets up CFLAGS without the default optimizer
 # flag (-O2).
 
-( CFLAGS="-g -Wno-int-conversion -Wno-implicit-int"; export CFLAGS; cd scripts ; ./configure "$@" )
+( CFLAGS="-g"; export CFLAGS; cd scripts ; ./configure "$@" )

--- a/extract/ExtTimes.c
+++ b/extract/ExtTimes.c
@@ -25,7 +25,7 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 #include <sys/types.h>
 #include <sys/time.h>
 #include <sys/resource.h>
-#ifdef SYSV
+#if defined(SYSV) || defined(EMSCRIPTEN)
 #include <sys/param.h>
 #include <sys/times.h>
 #endif
@@ -780,7 +780,7 @@ extTimeProc(proc, def, tv)
 {
     int secs, usecs, i;
 
-#ifdef SYSV
+#if defined(SYSV) || defined(EMSCRIPTEN)
     tv->tv_sec = 0;
     tv->tv_usec = 0;
 #else

--- a/plot/plotInt.h
+++ b/plot/plotInt.h
@@ -28,7 +28,7 @@
 #define VERSATEC		/* Add this for HP plotter support */
 
 /* system V machines lack vfont.h, so include the defs below. */
-#if  !defined(SYSV) && !defined(__FreeBSD__) && !defined(__NetBSD__) && !defined(CYGWIN) && !defined(__APPLE__) && !defined(__DragonFly__) && !defined(__OpenBSD__)
+#if  !defined(SYSV) && !defined(__FreeBSD__) && !defined(__NetBSD__) && !defined(CYGWIN) && !defined(__APPLE__) && !defined(__DragonFly__) && !defined(__OpenBSD__) && !defined(EMSCRIPTEN)
 #include <vfont.h>
 #else
 struct header {

--- a/plow/PlowMain.c
+++ b/plow/PlowMain.c
@@ -47,7 +47,7 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 #include "select/select.h"
 #include "graphics/graphics.h"
 
-#if defined(SYSV) || defined(__APPLE__)
+#if defined(SYSV) || defined(__APPLE__) || defined(EMSCRIPTEN)
 # define	NO_RUSAGE
 #endif
 

--- a/plow/PlowRandom.c
+++ b/plow/PlowRandom.c
@@ -30,7 +30,7 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 #include <sys/types.h>
 #include <sys/file.h>
 #include <sys/stat.h>
-#ifdef	SYSV
+#if defined(SYSV) || defined(EMSCRIPTEN)
 #include <fcntl.h>
 #endif
 
@@ -262,7 +262,7 @@ plowGenRandom(lo, hi)
     int lo, hi;		/* Inclusive bounds for the integer we'll generate */
 {
     int range = hi - lo + 1;
-#ifdef	SYSV
+#if defined(SYSV) || defined(EMSCRIPTEN)
     int r = rand();
 #else
     int r = random();

--- a/scripts/configure
+++ b/scripts/configure
@@ -7773,12 +7773,12 @@ fi
 case $target in
   *-linux*)
     $as_echo "#define linux 1" >>confdefs.h
-
+    $as_echo "#define SYSV 1" >>confdefs.h
         $as_echo "#define ISC 1" >>confdefs.h
 
         case $target in
 	*x86_64*)
-	    CFLAGS="${CFLAGS} -fPIC -Werror=implicit-function-declaration"
+	    CFLAGS="${CFLAGS} -m64 -fPIC -Werror=implicit-function-declaration"
 	    ;;
     esac
     if test $usingOGL ; then
@@ -7789,6 +7789,10 @@ case $target in
     elif test -f /usr/lib/libbsd.a ; then
       gr_libs="$gr_libs -lbsd"
     fi
+    ;;
+  *-emscripten*)
+    $as_echo "#define linux 1" >>confdefs.h
+    CFLAGS="${CFLAGS} -fPIC -Werror=implicit-function-declaration -Wno-int-conversion -Wno-implicit-int"
     ;;
   *solaris*)
     $as_echo "#define SYSV 1" >>confdefs.h

--- a/scripts/configure
+++ b/scripts/configure
@@ -7773,7 +7773,9 @@ fi
 case $target in
   *-linux*)
     $as_echo "#define linux 1" >>confdefs.h
+
     $as_echo "#define SYSV 1" >>confdefs.h
+
         $as_echo "#define ISC 1" >>confdefs.h
 
         case $target in

--- a/scripts/configure
+++ b/scripts/configure
@@ -7774,13 +7774,11 @@ case $target in
   *-linux*)
     $as_echo "#define linux 1" >>confdefs.h
 
-    $as_echo "#define SYSV 1" >>confdefs.h
-
         $as_echo "#define ISC 1" >>confdefs.h
 
         case $target in
 	*x86_64*)
-	    CFLAGS="${CFLAGS} -m64 -fPIC -Werror=implicit-function-declaration"
+	    CFLAGS="${CFLAGS} -fPIC -Werror=implicit-function-declaration"
 	    ;;
     esac
     if test $usingOGL ; then

--- a/scripts/configure.in
+++ b/scripts/configure.in
@@ -1353,6 +1353,7 @@ dnl ----------------------------------------------------------------
 case $target in
   *-linux*)
     AC_DEFINE(linux)
+    AC_DEFINE(SYSV)
     dnl Defining "ISC" prevents compiler failure on redefinition of "wchar_t"
     AC_DEFINE(ISC)
     dnl 64-bit support for AMD Opteron
@@ -1370,6 +1371,10 @@ case $target in
       gr_libs="$gr_libs -lbsd"
     fi
     ;; 
+  *-emscripten*)
+    AC_DEFINE(linux)
+    CFLAGS="${CFLAGS} -fPIC -Werror=implicit-function-declaration -Wno-int-conversion -Wno-implicit-int"
+    ;;
   *solaris*)
     AC_DEFINE(SYSV)
     ;;

--- a/scripts/configure.in
+++ b/scripts/configure.in
@@ -1353,13 +1353,12 @@ dnl ----------------------------------------------------------------
 case $target in
   *-linux*)
     AC_DEFINE(linux)
-    AC_DEFINE(SYSV)
     dnl Defining "ISC" prevents compiler failure on redefinition of "wchar_t"
     AC_DEFINE(ISC)
     dnl 64-bit support for AMD Opteron
     case $target in
 	*x86_64*)
-	    CFLAGS="${CFLAGS} -m64 -fPIC -Werror=implicit-function-declaration"
+	    CFLAGS="${CFLAGS} -fPIC -Werror=implicit-function-declaration"
 	    ;;
     esac
     if test $usingOGL ; then

--- a/scripts/configure.in
+++ b/scripts/configure.in
@@ -1359,7 +1359,7 @@ case $target in
     dnl 64-bit support for AMD Opteron
     case $target in
 	*x86_64*)
-	    CFLAGS="${CFLAGS} -fPIC -Werror=implicit-function-declaration"
+	    CFLAGS="${CFLAGS} -m64 -fPIC -Werror=implicit-function-declaration"
 	    ;;
     esac
     if test $usingOGL ; then

--- a/sim/SimRsim.c
+++ b/sim/SimRsim.c
@@ -213,7 +213,7 @@ SimStartRsim(argv)
 
     FORK(child);
 /*
-#ifdef SYSV
+#if defined(SYSV)
     child = fork();
 #else
     child = vfork();

--- a/textio/textio.h
+++ b/textio/textio.h
@@ -69,6 +69,7 @@ extern void TxStopMore();
 
 /* printing procedures with variable arguments lists */
 extern void TxError(char *, ...);
+extern void TxErrorV(char *, va_list args);
 extern void TxPrintf(char *, ...);
 extern char *TxPrintString(char *, ...);
 

--- a/textio/textioInt.h
+++ b/textio/textioInt.h
@@ -41,7 +41,7 @@ typedef struct {
 #define TX_CMD_PROMPT	":"
 
 /* all of the state associated with a tty terminal */
-#if !defined(SYSV) && !defined(CYGWIN) && !defined(__OpenBSD__)
+#if !defined(SYSV) && !defined(CYGWIN) && !defined(__OpenBSD__) && !defined(EMSCRIPTEN)
 typedef struct {
     struct sgttyb tx_i_sgtty;
     struct tchars tx_i_tchars;

--- a/textio/txInput.c
+++ b/textio/txInput.c
@@ -1218,7 +1218,7 @@ txGetTermState(buf)
     ioctl( fileno( stdin ), TCGETA, buf);
 }
 
-#elif defined (__OpenBSD__)
+#elif defined (__OpenBSD__) || defined(EMSCRIPTEN)
 
 void
 txGetTermState(buf)
@@ -1259,7 +1259,7 @@ void
 txSetTermState(buf)
 #if defined(SYSV) || defined(CYGWIN)
     struct termio *buf;
-#elif defined(__OpenBSD__)
+#elif defined (__OpenBSD__) || defined(EMSCRIPTEN)
     struct termios *buf;
 #else
     txTermState *buf;
@@ -1267,7 +1267,7 @@ txSetTermState(buf)
 {
 #if defined(SYSV) || defined(CYGWIN)
     ioctl( fileno(stdin), TCSETAF, buf );
-#elif defined (__OpenBSD__)
+#elif defined (__OpenBSD__) || defined(EMSCRIPTEN)
     (void) tcsetattr( fileno(stdin), TCSANOW, buf );
 #else
     /* set the current terminal characteristics */
@@ -1298,13 +1298,13 @@ void
 txInitTermRec(buf)
 #if defined(SYSV) || defined(CYGWIN)
     struct termio *buf;
-#elif defined(__OpenBSD__)
+#elif defined (__OpenBSD__) || defined(EMSCRIPTEN)
     struct termios *buf;
 #else
     txTermState *buf;
 #endif /* SYSV */
 {
-#if defined(SYSV) || defined(CYGWIN) || defined(__OpenBSD__)
+#if defined(SYSV) || defined(CYGWIN) || defined(__OpenBSD__) || defined(EMSCRIPTEN)
     buf->c_lflag = ISIG;    /* raw: no echo and no processing, allow signals */
     buf->c_cc[ VMIN ] = 1;
     buf->c_cc[ VTIME ] = 0;
@@ -1321,7 +1321,7 @@ txInitTermRec(buf)
 
 #if defined(SYSV) || defined(CYGWIN)
 struct termio closeTermState;
-#elif defined(__OpenBSD__)
+#elif defined (__OpenBSD__) || defined(EMSCRIPTEN)
 struct termios closeTermState;
 #else
 static txTermState closeTermState;
@@ -1355,7 +1355,7 @@ txSaveTerm()
     TxEOFChar = closeTermState.c_cc[VEOF];
     TxInterruptChar = closeTermState.c_cc[VINTR];
     haveCloseState = TRUE;
-#elif defined(__OpenBSD__)
+#elif defined (__OpenBSD__) || defined(EMSCRIPTEN)
     (void) tcgetattr( fileno( stdin ), &closeTermState);
     txEraseChar = closeTermState.c_cc[VERASE];
     txKillChar =  closeTermState.c_cc[VKILL];
@@ -1398,7 +1398,7 @@ TxSetTerminal()
 {
 #if defined(SYSV) || defined(CYGWIN)
     struct termio buf;
-#elif defined(__OpenBSD__)
+#elif defined (__OpenBSD__) || defined(EMSCRIPTEN)
     struct termios buf;
 #else
     txTermState buf;

--- a/textio/txOutput.c
+++ b/textio/txOutput.c
@@ -305,6 +305,7 @@ void
 TxError(char *fmt, ...) {
     va_list args;
     va_start(args, fmt);
+    TxErrorV(fmt, args);
     va_end(args);
 }
 

--- a/textio/txOutput.c
+++ b/textio/txOutput.c
@@ -302,9 +302,15 @@ TxFlush()
  */
 
 void
-TxError(char *fmt, ...)
-{
+TxError(char *fmt, ...) {
     va_list args;
+    va_start(args, fmt);
+    va_end(args);
+}
+
+void
+TxErrorV(char *fmt, va_list args)
+{
     FILE *f;
 
     TxFlushOut();
@@ -312,7 +318,6 @@ TxError(char *fmt, ...)
 	f = TxMoreFile;
     else
 	f = stderr;
-    va_start(args, fmt);
     if (txHavePrompt)
     {
 	TxUnPrompt();
@@ -322,7 +327,6 @@ TxError(char *fmt, ...)
     else {
 	Vfprintf(f, fmt, args);
     }
-    va_end(args);
     TxFlushErr();
 }
 

--- a/utils/magsgtty.h
+++ b/utils/magsgtty.h
@@ -34,7 +34,7 @@
 
 #include <sys/ioctl.h>
 
-#if defined(__OpenBSD__)
+#if defined(__OpenBSD__) || defined(EMSCRIPTEN)
 #include <termios.h>
 #else
 #include <sys/ioctl_compat.h>

--- a/utils/malloc.c
+++ b/utils/malloc.c
@@ -54,7 +54,7 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 
 /* Imports */
 
-extern void TxError();
+extern void TxError(char *, ...);
 extern char *TxGetLine();
 
 /*

--- a/utils/netlist.c
+++ b/utils/netlist.c
@@ -367,7 +367,9 @@ NLNetName(net)
     NLNet *net;
 {
     static char tempId[100];
-#if defined(linux) || defined(CYGWIN)
+#if defined(EMSCRIPTEN)
+ int etext;    
+#elif defined(linux) || defined(CYGWIN)
     extern int etext asm("etext");
 #elif defined(__APPLE__)
  int etext;

--- a/utils/signals.c
+++ b/utils/signals.c
@@ -54,7 +54,7 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 #define SIGIOT SIGABRT	/* io-trap signal redefined */
 #endif
 
-#ifdef	linux
+#if defined(linux) || defined(EMSCRIPTEN)
 #if SIGBUS == SIGUNUSED
 #undef SIGBUS
 #define SIGBUS SIGUSR1
@@ -547,7 +547,7 @@ sigCrash(signum)
     char *msg;
     extern bool AbortFatal;
 
-#ifndef	linux
+#if !defined(linux) && !defined(EMSCRIPTEN)
     if (magicNumber == 1239987) {
 	/* Things aren't screwed up that badly, try to reset the terminal */
 	magicNumber = 0;

--- a/utils/signals.c
+++ b/utils/signals.c
@@ -348,7 +348,7 @@ SigWatchFile(filenum, filename)
     if (!mainDebug)
     {
 	/* turn on FASYNC */
-#ifndef SYSV
+#if !defined(SYSV) && !defined(EMSCRIPTEN)
 #ifdef F_SETOWN
 	if (!iswindow)
 	{

--- a/utils/signals.c
+++ b/utils/signals.c
@@ -665,7 +665,7 @@ SigInit(batchmode)
 #endif
     }
 
-#if !defined(SYSV) && !defined(CYGWIN)
+#if !defined(SYSV) && !defined(CYGWIN) && !defined(EMSCRIPTEN)
     sigsetmask(0);
 #endif
 }
@@ -673,7 +673,7 @@ SigInit(batchmode)
 void
 sigSetAction(int signo, sigRetVal (*handler)(int))
 {
-#if defined(SYSV) || defined(CYGWIN) || defined(__NetBSD__)
+#if defined(SYSV) || defined(CYGWIN) || defined(__NetBSD__) || defined(EMSCRIPTEN)
     struct sigaction sa;
 
     sa.sa_handler = handler;


### PR DESCRIPTION
- add new `asmjs-unknown-emscripten` target
- add `defined(EMSCRIPTEN)` guards
- use `va_list` for variadic function call forwarding
- fix fatal function arguments inconsistency
- add `simple_build_wasm` CI job and store main `magic` wasm bundle as an artefact

Note: currently building with `--without-cairo --without-opengl --without-x --disable-readline` and bundle is already quite big (10M), any idea on how to trim things further?

/cc @urish since this might be relevant for https://github.com/wokwi/siliwiz

