### PR TITLE
Allow Python 3 to not be in PATH, Fix `clean` re-building dependencies

### DIFF
--- a/INSTALL_MacOS.md
+++ b/INSTALL_MacOS.md
@@ -3,7 +3,7 @@
 Get [Homebrew](https://brew.sh).
 
 ```sh
-brew install cairo tcl-tk
+brew install cairo tcl-tk python3
 brew install --cask xquartz
 ./scripts/configure_mac
 make database/database.h

--- a/rules.mak
+++ b/rules.mak
@@ -46,10 +46,15 @@ ${DESTDIR}${BINDIR}/${MODULE}${EXEEXT}: ${MODULE}${EXEEXT}
 	${RM} ${DESTDIR}${BINDIR}/${MODULE}${EXEEXT}
 	${CP} ${MODULE}${EXEEXT} ${DESTDIR}${BINDIR}
 
+.PHONY: clean
 clean:
 	${RM} ${CLEANS}
 
 tags: ${SRCS} ${LIB_SRCS}
 	ctags ${SRCS} ${LIB_SRCS}
 
+# If "include" is unqualified, it will attempt to build all targets of "include"
+# So, we gate the include, only running it if "clean" is not the target
+ifneq ($(MAKECMDGOALS),clean)
 include ${DEPEND_FILE}
+endif

--- a/scripts/.gitignore
+++ b/scripts/.gitignore
@@ -1,1 +1,2 @@
 autom4te.cache/
+makedbh

--- a/scripts/configure
+++ b/scripts/configure
@@ -722,7 +722,6 @@ infodir
 docdir
 oldincludedir
 includedir
-runstatedir
 localstatedir
 sharedstatedir
 sysconfdir
@@ -828,7 +827,6 @@ datadir='${datarootdir}'
 sysconfdir='${prefix}/etc'
 sharedstatedir='${prefix}/com'
 localstatedir='${prefix}/var'
-runstatedir='${localstatedir}/run'
 includedir='${prefix}/include'
 oldincludedir='/usr/include'
 docdir='${datarootdir}/doc/${PACKAGE}'
@@ -1081,15 +1079,6 @@ do
   | -silent | --silent | --silen | --sile | --sil)
     silent=yes ;;
 
-  -runstatedir | --runstatedir | --runstatedi | --runstated \
-  | --runstate | --runstat | --runsta | --runst | --runs \
-  | --run | --ru | --r)
-    ac_prev=runstatedir ;;
-  -runstatedir=* | --runstatedir=* | --runstatedi=* | --runstated=* \
-  | --runstate=* | --runstat=* | --runsta=* | --runst=* | --runs=* \
-  | --run=* | --ru=* | --r=*)
-    runstatedir=$ac_optarg ;;
-
   -sbindir | --sbindir | --sbindi | --sbind | --sbin | --sbi | --sb)
     ac_prev=sbindir ;;
   -sbindir=* | --sbindir=* | --sbindi=* | --sbind=* | --sbin=* \
@@ -1227,7 +1216,7 @@ fi
 for ac_var in	exec_prefix prefix bindir sbindir libexecdir datarootdir \
 		datadir sysconfdir sharedstatedir localstatedir includedir \
 		oldincludedir docdir infodir htmldir dvidir pdfdir psdir \
-		libdir localedir mandir runstatedir
+		libdir localedir mandir
 do
   eval ac_val=\$$ac_var
   # Remove trailing slashes.
@@ -1380,7 +1369,6 @@ Fine tuning of the installation directories:
   --sysconfdir=DIR        read-only single-machine data [PREFIX/etc]
   --sharedstatedir=DIR    modifiable architecture-independent data [PREFIX/com]
   --localstatedir=DIR     modifiable single-machine data [PREFIX/var]
-  --runstatedir=DIR       modifiable per-process data [LOCALSTATEDIR/run]
   --libdir=DIR            object code libraries [EPREFIX/lib]
   --includedir=DIR        C header files [PREFIX/include]
   --oldincludedir=DIR     C header files for non-gcc [/usr/include]
@@ -8266,6 +8254,8 @@ fi
 
 ac_config_files="$ac_config_files defs.mak"
 
+ac_config_files="$ac_config_files makedbh"
+
 cat >confcache <<\_ACEOF
 # This file is a shell script that caches the results of configure
 # tests run on this system so they can be shared between configure
@@ -8974,6 +8964,7 @@ for ac_config_target in $ac_config_targets
 do
   case $ac_config_target in
     "defs.mak") CONFIG_FILES="$CONFIG_FILES defs.mak" ;;
+    "makedbh") CONFIG_FILES="$CONFIG_FILES makedbh" ;;
 
   *) as_fn_error $? "invalid argument: \`$ac_config_target'" "$LINENO" 5;;
   esac
@@ -9392,6 +9383,11 @@ which seems to be undefined.  Please make sure it is defined" >&2;}
 
   esac
 
+
+  case $ac_file$ac_mode in
+    "makedbh":F) chmod +x makedbh ;;
+
+  esac
 done # for ac_tag
 
 

--- a/scripts/configure.in
+++ b/scripts/configure.in
@@ -1822,7 +1822,9 @@ AC_SUBST(OA_LIBS)
 AC_SUBST(ALL_TARGET)
 AC_SUBST(INSTALL_TARGET)
 
-AC_OUTPUT(defs.mak)
+AC_CONFIG_FILES([defs.mak])
+AC_CONFIG_FILES([makedbh], [chmod +x makedbh])
+AC_OUTPUT
 
 dnl 
 dnl Print configuration and report problems

--- a/scripts/makedbh.in
+++ b/scripts/makedbh.in
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!@PYTHON3@
 
 # makes the "database.h" (1st argument, $1) file from "database.h.in"
 # (2nd argument, $2), setting various mask operation definitions


### PR DESCRIPTION
* Adds Python 3 to macOS requirements
* Gate include of `DEPEND_FILE` in `rules.mak` on whether the target is `clean` or not (the include isn't pre-processed; it will attempt to build everything in the include otherwise)
* Make `makedbh` a configurable file- the shebang now uses the discovered path for Python3

---
Resolves #265 