### PR TITLE
More explicit pointer truthiness check

### DIFF
--- a/database/DBio.c
+++ b/database/DBio.c
@@ -1577,7 +1577,7 @@ DBOpenOnly(cellDef, name, setFileName, errptr)
 			 */
     int *errptr;	/* Pointer to int to hold error value */
 {
-    dbReadOpen(cellDef, name, setFileName, FALSE, errptr);
+    dbReadOpen(cellDef, name != NULL, setFileName, FALSE, errptr);
 }
 
 /*


### PR DESCRIPTION
`magic/database/DBio.c::DBOpenOnly` calls `dbReadOpen(CellDef *, bool, bool, int)` with a pointer for the second argument. While technically valid C, newer compilers (Clang 16) have recently frowned upon implicit pointer-to-int conversion, requiring the flag `-Wno-int-conversion` or else an error is raised.

Given that there is one such instance in the codebase, I think fixing it would be the simplest solution.