### PR TITLE
`style drc`: add `print` keyword to ouput `drc why` as `lambda` or `microns`

### DIFF
--- a/drc/DRCmain.c
+++ b/drc/DRCmain.c
@@ -184,7 +184,7 @@ drcSubstitute (cptr)
     DRCCookie * cptr;  		/* Design rule violated */
 {
     static char *why_out = NULL;
-    char *whyptr, *sptr, *wptr;
+    char *whyptr, *sptr, *wptr, *unit;
     int subscnt = 0, whylen;
     float oscale, value;
     extern float CIFGetOutputScale();
@@ -203,10 +203,20 @@ drcSubstitute (cptr)
     why_out = (char *)mallocMagic(whylen * sizeof(char));
     strcpy(why_out, whyptr);
 
-    if (cptr->drcc_flags & DRC_CIFRULE)
-	oscale = CIFGetScale(100);	/* 100 = microns to centimicrons */
+    if (DRCPrintConvert)
+    {
+	unit = "um";
+	if (cptr->drcc_flags & DRC_CIFRULE)
+	    oscale = CIFGetScale(100);	/* 100 = microns to centimicrons */
+	else
+	    oscale = CIFGetOutputScale(1000);   /* 1000 for conversion to um */
+    }
     else
-	oscale = CIFGetOutputScale(1000);   /* 1000 for conversion to um */
+    {
+	unit = "lambda";
+	oscale = 1;
+    }
+
     wptr = why_out;
 
     while ((sptr = strchr(whyptr, '%')) != NULL)
@@ -218,21 +228,21 @@ drcSubstitute (cptr)
 	switch (*(sptr + 1))
 	{
 	    case 'd':
-		/* Replace with "dist" value in microns */
+		/* Replace with "dist" value in microns or lambda */
 		value = (float)cptr->drcc_dist * oscale;
-		snprintf(wptr, 20, "%01.3gum", value);
+		snprintf(wptr, 20, "%01.3g%s", value, unit);
 		wptr += strlen(wptr);
 		break;
 	    case 'c':
-		/* Replace with "cdist" value in microns */
+		/* Replace with "cdist" value in microns or lambda */
 		value = (float)cptr->drcc_cdist * oscale;
-		snprintf(wptr, 20, "%01.3gum", value);
+		snprintf(wptr, 20, "%01.3g%s", value, unit);
 		wptr += strlen(wptr);
 		break;
 	    case 'a':
-		/* Replace with "cdist" value in microns squared */
+		/* Replace with "cdist" value in microns or lambda squared */
 		value = (float)cptr->drcc_cdist * oscale * oscale;
-		snprintf(wptr, 20, "%01.4gum^2", value);
+		snprintf(wptr, 20, "%01.4g%s^2", value, unit);
 		wptr += strlen(wptr);
 		break;
 	    default:

--- a/drc/DRCtech.c
+++ b/drc/DRCtech.c
@@ -60,6 +60,9 @@ global int DRCStepSize;
 
 global int DRCRuleOptimization = TRUE;
 
+/* Whether we are converting units printed from lambda to microns */
+global bool DRCPrintConvert;
+
 /* The following variables count how many rules were specified by
  * the technology file and how many edge rules were optimized away.
  */
@@ -554,6 +557,9 @@ DRCTechStyleInit()
     drcRulesOptimized = 0;
     drcRulesSpecified = 0;
 
+    /* default to printing in microns */
+    DRCPrintConvert = TRUE;
+
     if (DRCCurStyle == NULL)
     {
 	DRCCurStyle = (DRCStyle *) mallocMagic(sizeof(DRCStyle));
@@ -847,6 +853,19 @@ DRCTechLine(sectionName, argc, argv)
     if ((DRCCurStyle->ds_status != TECH_PENDING) &&
 		(DRCCurStyle->ds_status != TECH_SUSPENDED))
 	return TRUE;
+
+    /* Process "print" line next (if any) */
+
+    if (strcmp(argv[0], "print") == 0)
+    {
+	if (!strcmp(argv[1], "microns"))
+	    DRCPrintConvert = TRUE;
+	else if (!strcmp(argv[1], "um"))
+	    DRCPrintConvert = TRUE;
+	else if (strcmp(argv[1], "lambda"))
+	    TechError("print must be microns or lambda.  Using the "
+	            "default value (microns).\n");
+    }
 
     /* Process "scalefactor" line next (if any) */
 

--- a/drc/drc.h
+++ b/drc/drc.h
@@ -219,6 +219,7 @@ extern int  DRCstatVRulesHisto[DRC_MAXRULESHISTO];
 
 extern int DRCTechHalo;		/* Current halo being used */
 extern int DRCStepSize;		/* Current step size being used */
+extern bool DRCPrintConvert;    /* print as lambda or microns */
 extern DRCPendingCookie * DRCPendingRoot;
 
 extern unsigned char DRCBackGround;	/* global flag to enable/disable


### PR DESCRIPTION
This change adds the ability to print the `drc why` output in units of `lambda`. In other words, it skips the conversion if requested in the technology file.