### PR TITLE
Install magic on MacOS using a Homebrew formula

### DIFF
--- a/INSTALL_MacOS.md
+++ b/INSTALL_MacOS.md
@@ -1,14 +1,11 @@
 # Installing Magic on macOS (Tested on Big Sur)
-## With Brew
+## With Brew using a community tap
 Get [Homebrew](https://brew.sh).
 
 ```sh
-brew install cairo tcl-tk python3
 brew install --cask xquartz
-./scripts/configure_mac
-make database/database.h
-make -j$(sysctl -n hw.ncpu)
-make install # may need sudo depending on your setup
+brew tap shaunplee/asic
+brew install shaunplee/asic/magic-vlsi
 ```
 
 ## Without Brew


### PR DESCRIPTION
With help from @gnawhleinad, I put together a Brew/Homebrew formula to install `magic` based on the instructions in the "Without Brew" section. I also created a separate formula to install Tcl/Tk with X11 support so that `magic` can use it:

https://github.com/shaunplee/homebrew-asic/blob/main/Formula/magic-vlsi.rb
https://github.com/shaunplee/homebrew-asic/blob/main/Formula/tcl-tk-with-x.rb

Homebrew calls repositories "taps" and therefore `shaunplee/asic` is the third-party tap that I've created for this purpose.

This formula works on my machine and appears to build correctly in Github's automatic test runner, although @gnawhleinad seems to be having trouble with Tcl/Tk on their machine.

Alternatively, if you would prefer to keep these Brew build formulae within this repository, we can restructure the formulae to do it that way.