### PR TITLE
Use raw strings in preproc.py

### DIFF
--- a/scripts/preproc.py
+++ b/scripts/preproc.py
@@ -59,13 +59,13 @@ import sys
 
 def solve_statement(condition):
 
-    defrex = re.compile('defined[ \t]*\(([^\)]+)\)')
-    orrex = re.compile('(.+)\|\|(.+)')
-    andrex = re.compile('(.+)&&(.+)')
-    notrex = re.compile('!([^&\|]+)')
-    parenrex = re.compile('\(([^\)]+)\)')
-    leadspacerex = re.compile('^[ \t]+(.*)')
-    endspacerex = re.compile('(.*)[ \t]+$')
+    defrex = re.compile(r'defined[ \t]*\(([^\)]+)\)')
+    orrex = re.compile(r'(.+)\|\|(.+)')
+    andrex = re.compile(r'(.+)&&(.+)')
+    notrex = re.compile(r'!([^&\|]+)')
+    parenrex = re.compile(r'\(([^\)]+)\)')
+    leadspacerex = re.compile(r'^[ \t]+(.*)')
+    endspacerex = re.compile(r'(.*)[ \t]+$')
 
     matchfound = True
     while matchfound:
@@ -165,24 +165,24 @@ def sortkeys(keys):
 
 def runpp(keys, keyrex, defines, ccomm, incdirs, inputfile, ofile):
 
-    includerex = re.compile('^[ \t]*#include[ \t]+"*([^ \t\n\r"]+)')
-    definerex = re.compile('^[ \t]*#define[ \t]+([^ \t]+)[ \t]+(.+)')
-    paramrex = re.compile('^([^\(]+)\(([^\)]+)\)')
-    defrex = re.compile('^[ \t]*#define[ \t]+([^ \t\n\r]+)')
-    undefrex = re.compile('^[ \t]*#undef[ \t]+([^ \t\n\r]+)')
-    ifdefrex = re.compile('^[ \t]*#ifdef[ \t]+(.+)')
-    ifndefrex = re.compile('^[ \t]*#ifndef[ \t]+(.+)')
-    ifrex = re.compile('^[ \t]*#if[ \t]+(.+)')
-    elseifrex = re.compile('^[ \t]*#elseif[ \t]+(.+)')
-    elserex = re.compile('^[ \t]*#else')
-    endifrex = re.compile('^[ \t]*#endif')
-    commentrex = re.compile('^###[^#]*$')
-    ccstartrex = re.compile('/\*')		# C-style comment start
-    ccendrex = re.compile('\*/')		# C-style comment end
-    contrex = re.compile('.*\\\\$')		# Backslash continuation line
+    includerex = re.compile(r'^[ \t]*#include[ \t]+"*([^ \t\n\r"]+)')
+    definerex = re.compile(r'^[ \t]*#define[ \t]+([^ \t]+)[ \t]+(.+)')
+    paramrex = re.compile(r'^([^\(]+)\(([^\)]+)\)')
+    defrex = re.compile(r'^[ \t]*#define[ \t]+([^ \t\n\r]+)')
+    undefrex = re.compile(r'^[ \t]*#undef[ \t]+([^ \t\n\r]+)')
+    ifdefrex = re.compile(r'^[ \t]*#ifdef[ \t]+(.+)')
+    ifndefrex = re.compile(r'^[ \t]*#ifndef[ \t]+(.+)')
+    ifrex = re.compile(r'^[ \t]*#if[ \t]+(.+)')
+    elseifrex = re.compile(r'^[ \t]*#elseif[ \t]+(.+)')
+    elserex = re.compile(r'^[ \t]*#else')
+    endifrex = re.compile(r'^[ \t]*#endif')
+    commentrex = re.compile(r'^###[^#]*$')
+    ccstartrex = re.compile(r'/\*')		# C-style comment start
+    ccendrex = re.compile(r'\*/')		# C-style comment end
+    contrex = re.compile(r'.*\\$')		# Backslash continuation line
 
-    badifrex = re.compile('^[ \t]*#if[ \t]*.*')
-    badelserex = re.compile('^[ \t]*#else[ \t]*.*')
+    badifrex = re.compile(r'^[ \t]*#if[ \t]*.*')
+    badelserex = re.compile(r'^[ \t]*#else[ \t]*.*')
 
     # This code is not designed to operate on huge files.  Neither is it designed to be
     # efficient.
@@ -414,16 +414,16 @@ def runpp(keys, keyrex, defines, ccomm, incdirs, inputfile, ofile):
                 # parentheses;  e.g., "def(a, b, (c1,c2))".  This is NOT
                 # handled.
 
-                pcondition = condition + '\('
+                pcondition = condition + r'\('
                 for param in parameters[0:-1]:
-                    pcondition += '(.*),'
-                pcondition += '(.*)\)'
+                    pcondition += r'(.*),'
+                pcondition += r'(.*)\)'
 
                 # Generate the substitution string with group substitutions
                 pvalue = pmatch.group(2)
                 idx = 1
                 for param in parameters:
-                    pvalue = pvalue.replace(param, '\g<' + str(idx) + '>')
+                    pvalue = pvalue.replace(param, r'\g<' + str(idx) + r'>')
                     idx = idx + 1
 
                 defines[condition] = pvalue


### PR DESCRIPTION
When Python 3.12 is used to build magic, these warnings appear:

```
magic/../scripts/preproc.py:62: SyntaxWarning: invalid escape sequence '\('
  defrex = re.compile('defined[ \t]*\(([^\)]+)\)')
magic/../scripts/preproc.py:63: SyntaxWarning: invalid escape sequence '\|'
  orrex = re.compile('(.+)\|\|(.+)')
magic/../scripts/preproc.py:65: SyntaxWarning: invalid escape sequence '\|'
  notrex = re.compile('!([^&\|]+)')
magic/../scripts/preproc.py:66: SyntaxWarning: invalid escape sequence '\('
  parenrex = re.compile('\(([^\)]+)\)')
magic/../scripts/preproc.py:170: SyntaxWarning: invalid escape sequence '\('
  paramrex = re.compile('^([^\(]+)\(([^\)]+)\)')
magic/../scripts/preproc.py:180: SyntaxWarning: invalid escape sequence '\*'
  ccstartrex = re.compile('/\*')                # C-style comment start
magic/../scripts/preproc.py:181: SyntaxWarning: invalid escape sequence '\*'
  ccendrex = re.compile('\*/')          # C-style comment end
magic/../scripts/preproc.py:417: SyntaxWarning: invalid escape sequence '\('
  pcondition = condition + '\('
magic/../scripts/preproc.py:420: SyntaxWarning: invalid escape sequence '\)'
  pcondition += '(.*)\)'
magic/../scripts/preproc.py:426: SyntaxWarning: invalid escape sequence '\g'
  pvalue = pvalue.replace(param, '\g<' + str(idx) + '>')
```

I've fixed it by using raw strings. See https://docs.python.org/3/library/re.html:

> The solution is to use Python’s raw string notation for regular expression patterns; backslashes are not handled in any special way in a string literal prefixed with `'r'`. So `r"\n"` is a two-character string containing `'\'` and `'n'`, while `"\n"` is a one-character string containing a newline. Usually patterns will be expressed in Python code using this raw string notation.

I've run the build four times: with Python 3.11 (with and without my patch) and Python 3.12 (with and without my patch). The output of preproc.py (proto.magicrc) is identical in all four runs, but with my patch Python 3.12 no longer produces warnings. And presumably in some future version of Python the warning will become an error.