### PR TITLE
database/DBio.c: Fix MAGIC_WRAPPER #endif to fix CI WASM build

### DIFF
--- a/database/DBio.c
+++ b/database/DBio.c
@@ -688,8 +688,8 @@ dbCellReadDef(f, cellDef, ignoreTech, dereference)
 			    freeMagic(argv[1]);
 			    freeMagic(argv[0]);
 			}
-#endif
 		    }
+#endif
 		}
 		if (strcmp(DBTechName, tech))
 		{


### PR DESCRIPTION
Misplaced #endif causing the build to break when option enabled error introduced in 3dc5018

Related commits:

commit 68a088943f5534ac356ce8113d3985868b35d03e
Date:   Tue Sep 12 11:12:00 2023 -0400

commit 3dc5018af4994cc23e2c2dbc822927d7897fba93 (tag: 8.3.477)
Date:   Fri May 3 21:43:27 2024 -0400