### PR TITLE
Github Action Maintenance update

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -3,7 +3,7 @@ on:
     tags:
       - "*"
 
-name: CI
+name: CI-appimage
 
 jobs:
   build_appimage:

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Get the version
         id: get_version
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,7 +51,7 @@ jobs:
           emconfigure ./configure --without-cairo --without-opengl --without-x --disable-readline --target=asmjs-unknown-emscripten
           emmake make
       - name: archive wasm bundle
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: magic-wasm-bundle
           path: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
   simple_build_linux:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Get Dependencies
         run: |
           sudo apt-get install -y tcl-dev tk-dev libcairo-dev
@@ -38,7 +38,7 @@ jobs:
   simple_build_wasm:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Get Dependencies
         run: |
           git clone https://github.com/emscripten-core/emsdk.git
@@ -59,7 +59,7 @@ jobs:
   # simple_build_mac:
   #   runs-on: macos-11
   #   steps:
-  #     - uses: actions/checkout@v2
+  #     - uses: actions/checkout@v4
   #     - name: Get Dependencies
   #       run: |
   #         brew install --cask xquartz

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Build
         run: |
           source ./emsdk/emsdk_env.sh
-          emconfigure ./configure --without-cairo --without-opengl --without-x --disable-readline --target=asmjs-unknown-emscripten
+          emconfigure ./configure --without-cairo --without-opengl --without-x --disable-readline --disable-compression --target=asmjs-unknown-emscripten
           emmake make
       - name: archive wasm bundle
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Should remove CI deprecation warnings.
Deduplicate the workflow names (currently 2 exist both called CI, this renames one of them)
Use --disable-compression for WASM build