### PR TITLE
appimage/Dockerfile: fix CentOS7 based docker build due to EOL

### DIFF
--- a/appimage/Dockerfile
+++ b/appimage/Dockerfile
@@ -2,6 +2,17 @@ FROM centos/python-38-centos7:20210726-fad62e9
 
 USER root
 
+# CentOS7 went EOL on June 30, 2024 this builds out of vault.centos.org
+RUN ls -l /etc/yum.repos.d/ \
+    && cp /etc/yum.repos.d/CentOS-Base.repo /tmp/CentOS-Base.repo.old \
+    && sed -e 's/mirror.centos.org/vault.centos.org/g' -i /etc/yum.repos.d/*.repo \
+    && sed -e 's/^#.*baseurl=http/baseurl=http/g'      -i /etc/yum.repos.d/*.repo \
+    && sed -e 's/^mirrorlist=http/#mirrorlist=http/g'  -i /etc/yum.repos.d/*.repo \
+    && diff -u /tmp/CentOS-Base.repo.old /etc/yum.repos.d/CentOS-Base.repo; \
+    yum clean all \
+    && yum -y update \
+    && rm -f /tmp/CentOS-Base.repo.old
+
 # Build Dependencies
 RUN yum install -y cairo-devel freeglut-devel gcc make tcsh
 


### PR DESCRIPTION
CentOS7 went EOL on June 30, 2024 this builds out of vault.centos.org