### PR TITLE
K&R calma/**

### DIFF
--- a/calma/CalmaRdcl.c
+++ b/calma/CalmaRdcl.c
@@ -96,8 +96,8 @@ typedef struct {
  */
 
 OFFTYPE
-calmaSetPosition(sname)
-    char *sname;
+calmaSetPosition(
+    char *sname)
 {
     OFFTYPE originalPos = 0, currentPos = 0;
     int nbytes, rtype;
@@ -188,7 +188,7 @@ calmaSetPosition(sname)
  */
 
 void
-calmaNextCell()
+calmaNextCell(void)
 {
     int nbytes, rtype;
 
@@ -240,7 +240,7 @@ calmaNextCell()
  */
 
 Plane **
-calmaExact()
+calmaExact(void)
 {
     int pNum;
     Plane *newplane;
@@ -298,9 +298,9 @@ calmaExact()
  */
 
 int
-calmaFlattenPolygonFunc(use, parent)
-    CellUse *use;
-    CellDef *parent;
+calmaFlattenPolygonFunc(
+    CellUse *use,
+    CellDef *parent)
 {
     int i;
     CellUse dummy;
@@ -347,8 +347,8 @@ calmaFlattenPolygonFunc(use, parent)
  */
 
 bool
-calmaParseStructure(filename)
-    char *filename;		/* Name of the GDS file read */
+calmaParseStructure(
+    char *filename)		/* Name of the GDS file read */
 {
     static int structs[] = { CALMA_STRCLASS, CALMA_STRTYPE, -1 };
     int nbytes, rtype, nsrefs, osrefs, npaths;
@@ -675,9 +675,10 @@ syntaxerror:
  */
 
 bool
-calmaParseElement(filename, pnsrefs, pnpaths)
-    char *filename;
-    int *pnsrefs, *pnpaths;
+calmaParseElement(
+    char *filename,
+    int *pnsrefs,
+    int *pnpaths)
 {
     static int node[] = { CALMA_ELFLAGS, CALMA_PLEX, CALMA_LAYER,
 			  CALMA_NODETYPE, CALMA_XY, -1 };
@@ -737,9 +738,9 @@ calmaParseElement(filename, pnsrefs, pnpaths)
  */
 
 int
-calmaEnumFunc(tile, plane)
-    Tile *tile;
-    int *plane;
+calmaEnumFunc(
+    Tile *tile,
+    int *plane)
 {
     return 1;
 }
@@ -764,8 +765,8 @@ calmaEnumFunc(tile, plane)
  */
 
 int
-calmaElementSref(filename)
-    char *filename;
+calmaElementSref(
+    char *filename)
 {
     int nbytes, rtype, cols, rows, nref, n, i, savescale;
     int xlo, ylo, xhi, yhi, xsep, ysep;
@@ -1232,9 +1233,9 @@ calmaElementSref(filename)
 /* Callback function for determining if a cell has at least one subcell */
 
 int
-gdsHasUses(use, clientdata)
-    CellUse *use;
-    ClientData clientdata;
+gdsHasUses(
+    CellUse *use,
+    ClientData clientdata)
 {
     return 1;
 }
@@ -1242,9 +1243,9 @@ gdsHasUses(use, clientdata)
 /* Callback function for copying paint from one CIF cell into another */
 
 int
-gdsCopyPaintFunc(tile, gdsCopyRec)
-    Tile *tile;
-    GDSCopyRec *gdsCopyRec;
+gdsCopyPaintFunc(
+    Tile *tile,
+    GDSCopyRec *gdsCopyRec)
 {
     int pNum;
     TileType dinfo;
@@ -1289,8 +1290,8 @@ gdsCopyPaintFunc(tile, gdsCopyRec)
  */
 
 void
-calmaUniqueCell(sname)
-    char *sname;
+calmaUniqueCell(
+    char *sname)
 {
     HashEntry *h;
     CellDef *def, *testdef;
@@ -1349,14 +1350,14 @@ calmaUniqueCell(sname)
  */
 
 CellDef *
-calmaFindCell(name, was_called, predefined)
-    char *name;		/* Name of desired cell */
-    bool *was_called;	/* If this cell is in the hash table, then it
+calmaFindCell(
+    char *name,		/* Name of desired cell */
+    bool *was_called,	/* If this cell is in the hash table, then it
 			 * was instanced before it was defined.  We
 			 * need to know this so as to avoid flattening
 			 * the cell if requested.
 			 */
-    bool *predefined;	/* If this cell was in memory before the GDS
+    bool *predefined)	/* If this cell was in memory before the GDS
 			 * file was read, then this flag gets set.
 			 */
 
@@ -1431,8 +1432,8 @@ calmaFindCell(name, was_called, predefined)
  */
 
 CellDef *
-calmaLookCell(name)
-    char *name;		/* Name of desired cell */
+calmaLookCell(
+    char *name)		/* Name of desired cell */
 {
     HashEntry *h;
 

--- a/calma/CalmaRdcl.c
+++ b/calma/CalmaRdcl.c
@@ -59,9 +59,9 @@ extern HashTable calmaDefInitHash;
 extern int CalmaPolygonCount;
 
 /* forward declarations */
-int  calmaElementSref();
-bool calmaParseElement();
-void calmaUniqueCell();
+int calmaElementSref(char *filename);
+bool calmaParseElement(char *filename, int *pnsrefs, int *pnpaths);
+void calmaUniqueCell(char *sname);
 
 /* Structure used when flattening the GDS hierarchy on read-in */
 
@@ -245,7 +245,7 @@ calmaExact()
     int pNum;
     Plane *newplane;
     Plane **parray;
-    int gdsCopyPaintFunc();	/* Forward reference */
+    int gdsCopyPaintFunc(Tile *tile, GDSCopyRec *gdsCopyRec);	/* Forward reference */
 
     parray = (Plane **)mallocMagic(MAXCIFRLAYERS * sizeof(Plane *));
 
@@ -776,8 +776,8 @@ calmaElementSref(filename)
     Point refarray[3], refunscaled[3], p;
     CellUse *use;
     CellDef *def;
-    int gdsCopyPaintFunc();	/* Forward reference */
-    int gdsHasUses();		/* Forward reference */
+    int gdsCopyPaintFunc(Tile *tile, GDSCopyRec *gdsCopyRec);	/* Forward reference */
+    int gdsHasUses(CellUse *use, ClientData clientdata);		/* Forward reference */
     /* Added by NP */
     char *useid = NULL, *arraystr = NULL;
     int propAttrType;

--- a/calma/CalmaRdio.c
+++ b/calma/CalmaRdio.c
@@ -73,9 +73,9 @@ bool calmaSkipBytes(int nbytes);
  */
 
 bool
-calmaReadTransform(ptrans, name)
-    Transform *ptrans;	/* Fill in this transform */
-    char *name;		/* Name of subcell (for errors) */
+calmaReadTransform(
+    Transform *ptrans,	/* Fill in this transform */
+    char *name)		/* Name of subcell (for errors) */
 {
     int nbytes, rtype, flags, angle;
     double dangle;
@@ -205,9 +205,9 @@ calmaReadTransform(ptrans, name)
  */
 
 bool
-calmaReadI2Record(type, pvalue)
-    int type;		/* Type of record expected */
-    int *pvalue;	/* Store value here */
+calmaReadI2Record(
+    int type,		/* Type of record expected */
+    int *pvalue)	/* Store value here */
 {
     int nbytes, rtype, n;
 
@@ -250,9 +250,9 @@ eof:
  */
 
 bool
-calmaReadI4Record(type, pvalue)
-    int type;		/* Type of record expected */
-    int *pvalue;	/* Store value here */
+calmaReadI4Record(
+    int type,		/* Type of record expected */
+    int *pvalue)	/* Store value here */
 {
     int nbytes, rtype, n;
 
@@ -298,9 +298,9 @@ eof:
  */
 
 bool
-calmaReadStampRecord(type, stampptr)
-    int type;
-    int *stampptr;
+calmaReadStampRecord(
+    int type,
+    int *stampptr)
 {
     int nbytes, rtype;
     struct tm gds_timestamp;
@@ -371,9 +371,9 @@ eof:
  */
 
 bool
-calmaReadStringRecord(type, str)
-    int type;
-    char **str;
+calmaReadStringRecord(
+    int type,
+    char **str)
 {
     int nbytes, rtype;
 
@@ -420,8 +420,8 @@ eof:
  */
 
 bool
-calmaReadR8(pd)
-    double *pd;		/* Store result in *pd */
+calmaReadR8(
+    double *pd)		/* Store result in *pd */
 {
     int i, exponent;
     unsigned char dchars[8];
@@ -489,8 +489,8 @@ calmaReadR8(pd)
  */
 
 void
-calmaSkipSet(skipwhat)
-    int *skipwhat;
+calmaSkipSet(
+    int *skipwhat)
 {
     int *skipp;
     int nbytes, rtype;
@@ -533,8 +533,8 @@ skipit:
  */
 
 bool
-calmaSkipExact(type)
-    int type;
+calmaSkipExact(
+    int type)
 {
     int nbytes, rtype;
 
@@ -579,8 +579,8 @@ eof:
  */
 
 bool
-calmaSkipTo(what)
-    int what;
+calmaSkipTo(
+    int what)
 {
     int nbytes, rtype;
 
@@ -615,8 +615,8 @@ calmaSkipTo(what)
  */
 
 bool
-calmaSkipBytes(nbytes)
-    int nbytes;	/* Skip this many bytes */
+calmaSkipBytes(
+    int nbytes)	/* Skip this many bytes */
 {
     while (nbytes-- > 0)
 	if (FGETC(calmaInputFile) < 0)

--- a/calma/CalmaRdio.c
+++ b/calma/CalmaRdio.c
@@ -50,8 +50,8 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 #include "calma/calma.h"
 
 /* Forward declarations */
-bool calmaReadR8();
-bool calmaSkipBytes();
+bool calmaReadR8(double *pd);
+bool calmaSkipBytes(int nbytes);
 
 
 /*

--- a/calma/CalmaRdpt.c
+++ b/calma/CalmaRdpt.c
@@ -82,8 +82,9 @@ bool calmaReadPath(CIFPath **pathheadpp, int iscale);
  */
 
 void
-calmaInputRescale(n, d)
-    int n, d;
+calmaInputRescale(
+    int n,
+    int d)
 {
     HashEntry *h;
     HashSearch hs;
@@ -135,9 +136,9 @@ calmaInputRescale(n, d)
  */
 
 void
-calmaReadPoint(p, iscale)
-    Point *p;
-    int iscale;
+calmaReadPoint(
+    Point *p,
+    int iscale)
 {
     int rescale;
 
@@ -205,7 +206,7 @@ calmaReadPoint(p, iscale)
  */
 
 void
-calmaElementBoundary()
+calmaElementBoundary(void)
 {
     int dt, layer, ciftype;
     CIFPath *pathheadp;
@@ -406,7 +407,7 @@ calmaElementBoundary()
  */
 
 void
-calmaElementBox()
+calmaElementBox(void)
 {
     int nbytes, rtype, npoints, savescale;
     int dt, layer, ciftype;
@@ -501,7 +502,7 @@ calmaElementBox()
  */
 
 void
-calmaElementPath()
+calmaElementPath(void)
 {
     int nbytes, rtype, extend1, extend2;
     int layer, dt, width, pathtype, ciftype, savescale;
@@ -729,7 +730,7 @@ calmaElementPath()
  */
 
 void
-calmaElementText()
+calmaElementText(void)
 {
     static int ignore[] = { CALMA_PATHTYPE, CALMA_WIDTH, -1 };
     char *textbody = NULL;
@@ -1108,9 +1109,9 @@ calmaElementText()
  */
 
 bool
-calmaReadPath(pathheadpp, iscale)
-    CIFPath **pathheadpp;
-    int iscale;
+calmaReadPath(
+    CIFPath **pathheadpp,
+    int iscale)
 {
     CIFPath path, *pathtailp, *newpathp;
     int nbytes, rtype, npoints, savescale;
@@ -1215,10 +1216,10 @@ calmaReadPath(pathheadpp, iscale)
  */
 
 void
-calmaLayerError(mesg, layer, dt)
-    char *mesg;
-    int layer;
-    int dt;
+calmaLayerError(
+    char *mesg,
+    int layer,
+    int dt)
 {
     CalmaLayerType clt;
     HashEntry *he;

--- a/calma/CalmaRdpt.c
+++ b/calma/CalmaRdpt.c
@@ -57,8 +57,8 @@ extern int CalmaPolygonCount;
 extern int CalmaPathCount;
 extern HashTable calmaDefInitHash;
 
-extern void calmaLayerError();
-bool calmaReadPath();
+extern void calmaLayerError(char *mesg, int layer, int dt);
+bool calmaReadPath(CIFPath **pathheadpp, int iscale);
 
 /*
  * ----------------------------------------------------------------------------

--- a/calma/CalmaRead.c
+++ b/calma/CalmaRead.c
@@ -167,9 +167,9 @@ int calmaElementIgnore[] = { CALMA_ELFLAGS, CALMA_PLEX, -1 };
  */
 
 void
-CalmaReadFile(file, filename)
-    FILETYPE file;			/* File from which to read Calma */
-    char *filename;		/* The real name of the file read */
+CalmaReadFile(
+    FILETYPE file,		/* File from which to read Calma */
+    char *filename)		/* The real name of the file read */
 {
     int k, version;
     char *libname = NULL, *libnameptr;
@@ -343,7 +343,7 @@ done:
  */
 
 bool
-calmaParseUnits()
+calmaParseUnits(void)
 {
     int nbytes, rtype = 0;
     double metersPerDBUnit;
@@ -454,7 +454,8 @@ calmaParseUnits()
  * ----------------------------------------------------------------------------
  */
 
-void CalmaReadError(char *format, ...)
+void
+CalmaReadError(char *format, ...)
 {
     va_list args;
     OFFTYPE filepos;
@@ -511,9 +512,9 @@ void CalmaReadError(char *format, ...)
  */
 
 void
-calmaUnexpected(wanted, got)
-    int wanted;	/* Type of record we wanted */
-    int got;	/* Type of record we got */
+calmaUnexpected(
+    int wanted,	/* Type of record we wanted */
+    int got)	/* Type of record we got */
 {
     CalmaReadError("Unexpected record type in input: \n");
 
@@ -554,8 +555,8 @@ calmaUnexpected(wanted, got)
  */
 
 char *
-calmaRecordName(rtype)
-    int rtype;
+calmaRecordName(
+    int rtype)
 {
     static char numeric[10];
     static char *calmaRecordNames[] =
@@ -603,7 +604,7 @@ calmaRecordName(rtype)
  */
 
 void
-CalmaTechInit()
+CalmaTechInit(void)
 {
     ASSERT(sizeof(FourByteInt)==4, "definition in calmaInt.h");
     ASSERT(sizeof(TwoByteInt)==2, "definition in calmaInt.h");

--- a/calma/CalmaRead.c
+++ b/calma/CalmaRead.c
@@ -299,7 +299,7 @@ done:
 	    windCheckOnlyWindow(&mw, DBWclientID);
 	if (mw != NULL)
 	{
-	    if (calmaLookCell(libnameptr, NULL) != (CellDef *)NULL)
+	    if (calmaLookCell(libnameptr) != (CellDef *)NULL)
 		DBWloadWindow(mw, libnameptr, 0);
 	}
 	freeMagic(libname);

--- a/calma/CalmaRead.c
+++ b/calma/CalmaRead.c
@@ -111,8 +111,8 @@ bool CalmaUnique = FALSE;		/* If TRUE, then if a cell exists in
 					 */
 extern bool CalmaDoLibrary;		/* Also used by GDS write */
 
-extern void calmaUnexpected();
-extern int calmaWriteInitFunc();
+extern void calmaUnexpected(int wanted, int got);
+extern int calmaWriteInitFunc(CellDef *def);
 
 /*
  * Scaling.

--- a/calma/CalmaWrite.c
+++ b/calma/CalmaWrite.c
@@ -290,9 +290,9 @@ static char calmaMapTablePermissive[] =
  */
 
 bool
-CalmaWrite(rootDef, f)
-    CellDef *rootDef;	/* Pointer to CellDef to be written */
-    FILE *f;		/* Open output file */
+CalmaWrite(
+    CellDef *rootDef,	/* Pointer to CellDef to be written */
+    FILE *f)		/* Open output file */
 {
     int oldCount = DBWFeedbackCount, problems, nerr;
     bool good;
@@ -417,11 +417,11 @@ CalmaWrite(rootDef, f)
  */
 
 bool
-calmaDumpStructure(def, outf, calmaDefHash, filename)
-    CellDef *def;
-    FILE *outf;
-    HashTable *calmaDefHash;
-    char *filename;
+calmaDumpStructure(
+    CellDef *def,
+    FILE *outf,
+    HashTable *calmaDefHash,
+    char *filename)
 {
     int nbytes, rtype;
     char *strname = NULL, *newnameptr;
@@ -687,11 +687,11 @@ syntaxerror:
  */
 
 void
-calmaFullDump(def, fi, outf, filename)
-    CellDef *def;
-    FILETYPE fi;
-    FILE *outf;
-    char *filename;
+calmaFullDump(
+    CellDef *def,
+    FILETYPE fi,
+    FILE *outf,
+    char *filename)
 {
     int version, rval;
     char *libname = NULL, *testlib, uniqlibname[4];
@@ -831,8 +831,8 @@ done:
  */
 
 int
-calmaWriteInitFunc(def)
-    CellDef *def;
+calmaWriteInitFunc(
+    CellDef *def)
 {
     def->cd_client = (ClientData) 0;
     return (0);
@@ -862,18 +862,18 @@ calmaWriteInitFunc(def)
  */
 
 int
-calmaProcessUse(use, outf)
-    CellUse *use;	/* Process use->cu_def */
-    FILE *outf;		/* Stream file */
+calmaProcessUse(
+    CellUse *use,	/* Process use->cu_def */
+    FILE *outf)		/* Stream file */
 {
     return (calmaProcessDef(use->cu_def, outf, FALSE));
 }
 
 int
-calmaProcessDef(def, outf, do_library)
-    CellDef *def;	/* Output this def's children, then the def itself */
-    FILE *outf;		/* Stream file */
-    bool do_library;	/* If TRUE, output only children of def, but not def */
+calmaProcessDef(
+    CellDef *def,	/* Output this def's children, then the def itself */
+    FILE *outf,		/* Stream file */
+    bool do_library)	/* If TRUE, output only children of def, but not def */
 {
     char *filename;
     int polyidx;
@@ -1294,10 +1294,10 @@ compport(const void *one, const void *two)
  */
 
 void
-calmaOutFunc(def, f, cliprect)
-    CellDef *def;	/* Pointer to cell def to be written */
-    FILE *f;		/* Open output file */
-    Rect *cliprect;	/* Area to clip to (used for contact cells),
+calmaOutFunc(
+    CellDef *def,	/* Pointer to cell def to be written */
+    FILE *f,		/* Open output file */
+    Rect *cliprect)	/* Area to clip to (used for contact cells),
 			 * in CIF/GDS coordinates.
 			 */
 {
@@ -1489,9 +1489,9 @@ calmaOutFunc(def, f, cliprect)
  */
 
 bool
-calmaIsUseNameDefault(defName, useName)
-    char *defName;
-    char *useName;
+calmaIsUseNameDefault(
+    char *defName,
+    char *useName)
 {
     int idx, slen;
     char *sptr;
@@ -1529,9 +1529,9 @@ calmaIsUseNameDefault(defName, useName)
  */
 
 int
-calmaWriteUseFunc(use, f)
-    CellUse *use;
-    FILE *f;
+calmaWriteUseFunc(
+    CellUse *use,
+    FILE *f)
 {
     /*
      * r90, r180, and r270 are Calma 8-byte real representations
@@ -1744,10 +1744,10 @@ calmaWriteUseFunc(use, f)
  */
 
 void
-calmaOutStructName(type, def, f)
-    int type;
-    CellDef *def;
-    FILE *f;
+calmaOutStructName(
+    int type,
+    CellDef *def,
+    FILE *f)
 {
     char *defname;
     unsigned char c;
@@ -1817,9 +1817,9 @@ bad:
  */
 
 CellDef *
-calmaGetContactCell(type, lookOnly)
-    TileType type;		/* magic contact tile type */
-    bool lookOnly;		/* if true, don't generate any new cells */
+calmaGetContactCell(
+    TileType type,		/* magic contact tile type */
+    bool lookOnly)		/* if true, don't generate any new cells */
 {
     TileType j;
     char contactCellName[100];
@@ -1870,14 +1870,16 @@ calmaGetContactCell(type, lookOnly)
  */
 
 bool
-CalmaGenerateArray(f, type, llx, lly, pitch, cols, rows)
-    FILE *f;		/* GDS output file */
-    TileType type;	/* Magic tile type of contact */
-    int llx, lly;	/* Lower-left hand coordinate of the array
+CalmaGenerateArray(
+    FILE *f,		/* GDS output file */
+    TileType type,	/* Magic tile type of contact */
+    int llx,
+    int lly,		/* Lower-left hand coordinate of the array
 			 * (centered on contact cut)
 			 */
-    int pitch;		/* Pitch of the array elements */
-    int cols, rows;	/* Number of array elements in X and Y */
+    int pitch,		/* Pitch of the array elements */
+    int cols,
+    int rows)		/* Number of array elements in X and Y */
 {
     CellDef *child;	/* Cell definition of the contact cell */
     int xxlate, yxlate;
@@ -1939,8 +1941,8 @@ CalmaGenerateArray(f, type, llx, lly, pitch, cols, rows)
  */
 
 void
-calmaWriteContacts(f)
-    FILE *f;
+calmaWriteContacts(
+    FILE *f)
 {
     TileType type;
     TileTypeBitMask tMask, *rMask;
@@ -2025,7 +2027,7 @@ calmaWriteContacts(f)
  */
 
 void
-calmaDelContacts()
+calmaDelContacts(void)
 {
     TileType type;
     CellDef *def;
@@ -2063,10 +2065,13 @@ calmaDelContacts()
  */
 
 int
-calmaAddSegment(lbptr, poly_edge, p1x, p1y, p2x, p2y)
-    LinkedBoundary **lbptr;
-    bool poly_edge;
-    int p1x, p1y, p2x, p2y;
+calmaAddSegment(
+    LinkedBoundary **lbptr,
+    bool poly_edge,
+    int p1x,
+    int p1y,
+    int p2x,
+    int p2y)
 {
     LinkedBoundary *newseg, *curseg, *stopseg;
     bool startmatch = FALSE;
@@ -2138,8 +2143,8 @@ calmaAddSegment(lbptr, poly_edge, p1x, p1y, p2x, p2y)
  */
 
 void
-calmaRemoveDegenerate(blist)
-    BoundaryTop *blist;
+calmaRemoveDegenerate(
+    BoundaryTop *blist)
 {
     bool segfound;
     LinkedBoundary *stopseg, *curseg, *lastseg;
@@ -2195,8 +2200,8 @@ calmaRemoveDegenerate(blist)
  */
 
 void
-calmaRemoveColinear(blist)
-    BoundaryTop *blist;
+calmaRemoveColinear(
+    BoundaryTop *blist)
 {
     LinkedBoundary *stopseg, *curseg, *lastseg;
     BoundaryTop *bounds;
@@ -2293,10 +2298,10 @@ calmaRemoveColinear(blist)
  */
 
 void
-calmaMergeSegments(edge, blist, num_points)
-    LinkedBoundary *edge;
-    BoundaryTop **blist;
-    int num_points;
+calmaMergeSegments(
+    LinkedBoundary *edge,
+    BoundaryTop **blist,
+    int num_points)
 {
     LinkedBoundary *stopseg, *curseg, *lastseg;
     LinkedBoundary *compstop, *compseg, *complast;
@@ -2379,9 +2384,9 @@ make_new_bound:
  */
 
 void
-calmaProcessBoundary(blist, cos)
-    BoundaryTop *blist;
-    calmaOutputStruct *cos;
+calmaProcessBoundary(
+    BoundaryTop *blist,
+    calmaOutputStruct *cos)
 {
     FILE *f = cos->f;
     LinkedBoundary *listtop, *lbref, *lbstop, *lbfree;
@@ -2489,9 +2494,9 @@ calmaProcessBoundary(blist, cos)
  */
 
 int
-calmaMergePaintFunc(tile, cos)
-    Tile *tile;			/* Tile to be written out. */
-    calmaOutputStruct *cos;	/* Information needed by algorithm */
+calmaMergePaintFunc(
+    Tile *tile,			/* Tile to be written out. */
+    calmaOutputStruct *cos)	/* Information needed by algorithm */
 {
     FILE *f = cos->f;
     Rect *clipArea = cos->area;
@@ -2812,9 +2817,9 @@ done_searches:
  */
 
 int
-calmaWritePaintFunc(tile, cos)
-    Tile *tile;			/* Tile to be written out. */
-    calmaOutputStruct *cos;	/* File for output and clipping area */
+calmaWritePaintFunc(
+    Tile *tile,			/* Tile to be written out. */
+    calmaOutputStruct *cos)	/* File for output and clipping area */
 {
     FILE *f = cos->f;
     Rect *clipArea = cos->area;
@@ -2917,13 +2922,13 @@ calmaWritePaintFunc(tile, cos)
  */
 
 void
-calmaWriteLabelFunc(lab, ltype, type, f)
-    Label *lab;	/* Label to output */
-    int ltype;	/* CIF layer number to use for TEXT record */
-    int type;	/* CIF layer number to use for BOUNDARY record,
+calmaWriteLabelFunc(
+    Label *lab,	/* Label to output */
+    int ltype,	/* CIF layer number to use for TEXT record */
+    int type,	/* CIF layer number to use for BOUNDARY record,
 		 * or -1 if not attached to a layer
 		 */
-    FILE *f;	/* Stream file */
+    FILE *f)	/* Stream file */
 {
     Point p;
     int calmanum, calmatype;
@@ -3088,9 +3093,9 @@ calmaWriteLabelFunc(lab, ltype, type, f)
  */
 
 int
-calmaPaintLabelFunc(tile, cos)
-    Tile *tile;			/* Tile contains area for label. */
-    calmaOutputStruct *cos;	/* File for output and clipping area */
+calmaPaintLabelFunc(
+    Tile *tile,			/* Tile contains area for label. */
+    calmaOutputStruct *cos)	/* File for output and clipping area */
 {
     FILE *f = cos->f;
     Rect *clipArea = cos->area;
@@ -3149,9 +3154,9 @@ calmaPaintLabelFunc(tile, cos)
  */
 
 void
-calmaOutHeader(rootDef, f)
-    CellDef *rootDef;
-    FILE *f;
+calmaOutHeader(
+    CellDef *rootDef,
+    FILE *f)
 {
     static double useru = 0.001;
     static double mum = 1.0e-9;
@@ -3210,9 +3215,9 @@ calmaOutHeader(rootDef, f)
  */
 
 void
-calmaOutDate(t, f)
-    time_t t;	/* Time (UNIX format) to be output */
-    FILE *f;	/* Stream file */
+calmaOutDate(
+    time_t t,	/* Time (UNIX format) to be output */
+    FILE *f)	/* Stream file */
 {
     struct tm *datep = localtime(&t);
 
@@ -3245,10 +3250,10 @@ calmaOutDate(t, f)
  */
 
 void
-calmaOutStringRecord(type, str, f)
-    int type;		/* Type of this record (data type is ASCII string) */
-    char *str;	/* String to be output */
-    FILE *f;	/* Stream file */
+calmaOutStringRecord(
+    int type,		/* Type of this record (data type is ASCII string) */
+    char *str,	/* String to be output */
+    FILE *f)	/* Stream file */
 {
     int len;
     unsigned char c;
@@ -3346,9 +3351,9 @@ calmaOutStringRecord(type, str, f)
  */
 
 void
-calmaOutR8(d, f)
-    double d;	/* Double value to write to output */
-    FILE *f;	/* Stream file */
+calmaOutR8(
+    double d,	/* Double value to write to output */
+    FILE *f)	/* Stream file */
 {
     int c, i, sign, expon;
 
@@ -3421,9 +3426,9 @@ calmaOutR8(d, f)
  */
 
 void
-calmaOut8(str, f)
-    char *str;	/* 8-byte string to be output */
-    FILE *f;	/* Stream file */
+calmaOut8(
+    char *str,	/* 8-byte string to be output */
+    FILE *f)	/* Stream file */
 {
     int i;
 

--- a/calma/CalmaWrite.c
+++ b/calma/CalmaWrite.c
@@ -97,7 +97,6 @@ extern void calmaOutStringRecord();
 extern void calmaOut8();
 extern void calmaOutR8();
 extern void calmaProcessBoundary();
-extern void calmaMergeBoundaries();
 extern void calmaRemoveColinear();
 extern void calmaRemoveDegenerate();
 

--- a/calma/CalmaWrite.c
+++ b/calma/CalmaWrite.c
@@ -82,7 +82,6 @@ int  CalmaCompression = 0;	/* Output file compression level (0 = uncompressed) *
 
     /* Forward declarations */
 extern int calmaWriteInitFunc();
-extern int calmaWriteMarkFunc();
 extern int calmaWritePaintFunc();
 extern int calmaMergePaintFunc();
 extern int calmaWriteUseFunc();

--- a/calma/CalmaWrite.c
+++ b/calma/CalmaWrite.c
@@ -27,9 +27,8 @@ static char rcsid[] __attribute__ ((unused)) ="$Header: /usr/cvsroot/magic-8.0/c
 #include <ctype.h>
 #include <sys/types.h>
 #include <arpa/inet.h>	/* for htons() */
-#if defined(SYSV) || defined(EMSCRIPTEN)
-#include <time.h>
-#else
+#include <time.h>       /* since C89 */
+#ifdef HAVE_SYS_TIME_H
 #include <sys/time.h>
 #endif
 
@@ -162,9 +161,6 @@ int calmaPaintLayerType;
 HashTable calmaLibHash;
 HashTable calmaPrefixHash;
 HashTable calmaUndefHash;
-
-/* Imports */
-extern time_t time();
 
 
 /* -------------------------------------------------------------------- */

--- a/calma/CalmaWrite.c
+++ b/calma/CalmaWrite.c
@@ -80,24 +80,24 @@ int  CalmaCompression = 0;	/* Output file compression level (0 = uncompressed) *
 #endif
 
     /* Forward declarations */
-extern int calmaWriteInitFunc();
-extern int calmaWritePaintFunc();
-extern int calmaMergePaintFunc();
-extern int calmaWriteUseFunc();
-extern int calmaPaintLabelFunc();
-extern void calmaWriteContacts();
-extern void calmaDelContacts();
-extern void calmaOutFunc();
-extern void calmaOutStructName();
-extern void calmaWriteLabelFunc();
-extern void calmaOutHeader();
-extern void calmaOutDate();
-extern void calmaOutStringRecord();
-extern void calmaOut8();
-extern void calmaOutR8();
-extern void calmaProcessBoundary();
-extern void calmaRemoveColinear();
-extern void calmaRemoveDegenerate();
+extern int calmaWriteInitFunc(CellDef *def);
+extern int calmaWritePaintFunc(Tile *tile, calmaOutputStruct *cos);
+extern int calmaMergePaintFunc(Tile *tile, calmaOutputStruct *cos);
+extern int calmaWriteUseFunc(CellUse *use, FILE *f);
+extern int calmaPaintLabelFunc(Tile *tile, calmaOutputStruct *cos);
+extern void calmaWriteContacts(FILE *f);
+extern void calmaDelContacts(void);
+extern void calmaOutFunc(CellDef *def, FILE *f, Rect *cliprect);
+extern void calmaOutStructName(int type, CellDef *def, FILE *f);
+extern void calmaWriteLabelFunc(Label *lab, int ltype, int type, FILE *f);
+extern void calmaOutHeader(CellDef *rootDef, FILE *f);
+extern void calmaOutDate(time_t t, FILE *f);
+extern void calmaOutStringRecord(int type, char *str, FILE *f);
+extern void calmaOut8(char *str, FILE *f);
+extern void calmaOutR8(double d, FILE *f);
+extern void calmaProcessBoundary(BoundaryTop *blist, calmaOutputStruct *cos);
+extern void calmaRemoveColinear(BoundaryTop *blist);
+extern void calmaRemoveDegenerate(BoundaryTop *blist);
 
 /* Structure used by calmaWritePaintFunc() */
 

--- a/calma/CalmaWrite.c
+++ b/calma/CalmaWrite.c
@@ -121,22 +121,6 @@ extern void calmaRemoveDegenerate(BoundaryTop *blist);
 	STACKPUSH((ClientData) (tp), SegStack); \
     }
 
-#define LB_EXTERNAL	0	/* Polygon external edge	*/
-#define LB_INTERNAL	1	/* Polygon internal edge	*/
-#define LB_INIT		2	/* Data not yet valid		*/
-
-typedef struct LB1 {
-    char lb_type;		/* Boundary Type (external or internal) */
-    Point lb_start;		/* Start point */
-    struct LB1 *lb_next;	/* Next point record */
-} LinkedBoundary;
-
-typedef struct BT1 {
-    LinkedBoundary *bt_first;   /* Polygon list */
-    int bt_points;		/* Number of points in this list */
-    struct BT1 *bt_next;	/* Next polygon record */
-} BoundaryTop;
-
 /*--------------------------------------------------------------*/
 
 /* Number assigned to each cell */

--- a/calma/CalmaWrite.c
+++ b/calma/CalmaWrite.c
@@ -79,6 +79,14 @@ bool CalmaMergeTiles = FALSE;	 /* If TRUE, merge tiles into polygons in output. 
 int  CalmaCompression = 0;	/* Output file compression level (0 = uncompressed) */
 #endif
 
+/* Structure used by calmaWritePaintFunc() */
+
+typedef struct {
+   FILE *f;		/* File stream for output		*/
+   Rect *area;		/* Clipping area, in GDS coordinates	*/
+   int type;		/* Layer index				*/
+} calmaOutputStruct;
+
     /* Forward declarations */
 extern int calmaWriteInitFunc(CellDef *def);
 extern int calmaWritePaintFunc(Tile *tile, calmaOutputStruct *cos);
@@ -98,14 +106,6 @@ extern void calmaOutR8(double d, FILE *f);
 extern void calmaProcessBoundary(BoundaryTop *blist, calmaOutputStruct *cos);
 extern void calmaRemoveColinear(BoundaryTop *blist);
 extern void calmaRemoveDegenerate(BoundaryTop *blist);
-
-/* Structure used by calmaWritePaintFunc() */
-
-typedef struct {
-   FILE *f;		/* File stream for output		*/
-   Rect *area;		/* Clipping area, in GDS coordinates	*/
-   int type;		/* Layer index				*/
-} calmaOutputStruct;
 
 /*--------------------------------------------------------------*/
 /* Structures used by the tile merging algorithm 		*/

--- a/calma/CalmaWriteZ.c
+++ b/calma/CalmaWriteZ.c
@@ -90,7 +90,6 @@ extern int calmaPaintLayerType;
 
     /* External functions from CalmaWrite.c */
 extern int calmaWriteInitFunc();
-extern int calmaWriteMarkFunc();
 
     /* Forward declarations */
 extern int calmaWritePaintFuncZ();

--- a/calma/CalmaWriteZ.c
+++ b/calma/CalmaWriteZ.c
@@ -270,9 +270,9 @@ static char calmaMapTablePermissive[] =
  */
 
 bool
-CalmaWriteZ(rootDef, f)
-    CellDef *rootDef;	/* Pointer to CellDef to be written */
-    gzFile f;		/* Open compressed output file */
+CalmaWriteZ(
+    CellDef *rootDef,	/* Pointer to CellDef to be written */
+    gzFile f)		/* Open compressed output file */
 {
     int oldCount = DBWFeedbackCount, problems, nerr;
     bool good;
@@ -398,11 +398,11 @@ CalmaWriteZ(rootDef, f)
  */
 
 bool
-calmaDumpStructureZ(def, outf, calmaDefHash, filename)
-    CellDef *def;
-    gzFile outf;
-    HashTable *calmaDefHash;
-    char *filename;
+calmaDumpStructureZ(
+    CellDef *def,
+    gzFile outf,
+    HashTable *calmaDefHash,
+    char *filename)
 {
     int nbytes, rtype;
     char *strname = NULL, *newnameptr;
@@ -668,11 +668,11 @@ syntaxerror:
  */
 
 void
-calmaFullDumpZ(def, fi, outf, filename)
-    CellDef *def;
-    gzFile fi;
-    gzFile outf;
-    char *filename;
+calmaFullDumpZ(
+    CellDef *def,
+    gzFile fi,
+    gzFile outf,
+    char *filename)
 {
     int version, rval;
     char *libname = NULL, *testlib, uniqlibname[4];
@@ -816,18 +816,18 @@ done:
  */
 
 int
-calmaProcessUseZ(use, outf)
-    CellUse *use;	/* Process use->cu_def */
-    gzFile outf;	/* Stream file */
+calmaProcessUseZ(
+    CellUse *use,	/* Process use->cu_def */
+    gzFile outf)	/* Stream file */
 {
     return (calmaProcessDefZ(use->cu_def, outf, FALSE));
 }
 
 int
-calmaProcessDefZ(def, outf, do_library)
-    CellDef *def;	/* Output this def's children, then the def itself */
-    gzFile outf;		/* Stream file */
-    bool do_library;	/* If TRUE, output only children of def, but not def */
+calmaProcessDefZ(
+    CellDef *def,	/* Output this def's children, then the def itself */
+    gzFile outf,		/* Stream file */
+    bool do_library)	/* If TRUE, output only children of def, but not def */
 {
     char *filename;
     int polyidx;
@@ -1175,10 +1175,10 @@ calmaProcessDefZ(def, outf, do_library)
  */
 
 void
-calmaOutFuncZ(def, f, cliprect)
-    CellDef *def;	/* Pointer to cell def to be written */
-    gzFile f;		/* Open output file */
-    Rect *cliprect;	/* Area to clip to (used for contact cells),
+calmaOutFuncZ(
+    CellDef *def,	/* Pointer to cell def to be written */
+    gzFile f,		/* Open output file */
+    Rect *cliprect)	/* Area to clip to (used for contact cells),
 			 * in CIF/GDS coordinates.
 			 */
 {
@@ -1370,9 +1370,9 @@ calmaOutFuncZ(def, f, cliprect)
  */
 
 int
-calmaWriteUseFuncZ(use, f)
-    CellUse *use;
-    gzFile f;
+calmaWriteUseFuncZ(
+    CellUse *use,
+    gzFile f)
 {
     /*
      * r90, r180, and r270 are Calma 8-byte real representations
@@ -1585,10 +1585,10 @@ calmaWriteUseFuncZ(use, f)
  */
 
 void
-calmaOutStructNameZ(type, def, f)
-    int type;
-    CellDef *def;
-    gzFile f;
+calmaOutStructNameZ(
+    int type,
+    CellDef *def,
+    gzFile f)
 {
     char *defname;
     unsigned char c;
@@ -1654,14 +1654,16 @@ bad:
  */
 
 bool
-CalmaGenerateArrayZ(f, type, llx, lly, pitch, cols, rows)
-    gzFile f;		/* GDS output file */
-    TileType type;	/* Magic tile type of contact */
-    int llx, lly;	/* Lower-left hand coordinate of the array
+CalmaGenerateArrayZ(
+    gzFile f,		/* GDS output file */
+    TileType type,	/* Magic tile type of contact */
+    int llx,
+    int lly,		/* Lower-left hand coordinate of the array
 			 * (centered on contact cut)
 			 */
-    int pitch;		/* Pitch of the array elements */
-    int cols, rows;	/* Number of array elements in X and Y */
+    int pitch,		/* Pitch of the array elements */
+    int cols,
+    int rows)		/* Number of array elements in X and Y */
 {
     CellDef *child;	/* Cell definition of the contact cell */
     int xxlate, yxlate;
@@ -1722,8 +1724,8 @@ CalmaGenerateArrayZ(f, type, llx, lly, pitch, cols, rows)
  */
 
 void
-calmaWriteContactsZ(f)
-    gzFile f;
+calmaWriteContactsZ(
+    gzFile f)
 {
     TileType type;
     TileTypeBitMask tMask, *rMask;
@@ -1805,9 +1807,9 @@ calmaWriteContactsZ(f)
  */
 
 void
-calmaProcessBoundaryZ(blist, cos)
-    BoundaryTop *blist;
-    calmaOutputStructZ *cos;
+calmaProcessBoundaryZ(
+    BoundaryTop *blist,
+    calmaOutputStructZ *cos)
 {
     gzFile f = cos->f;
     LinkedBoundary *listtop, *lbref, *lbstop, *lbfree;
@@ -1885,9 +1887,9 @@ calmaProcessBoundaryZ(blist, cos)
  */
 
 int
-calmaMergePaintFuncZ(tile, cos)
-    Tile *tile;			/* Tile to be written out. */
-    calmaOutputStructZ *cos;	/* Information needed by algorithm */
+calmaMergePaintFuncZ(
+    Tile *tile,			/* Tile to be written out. */
+    calmaOutputStructZ *cos)	/* Information needed by algorithm */
 {
     gzFile f = cos->f;
     Rect *clipArea = cos->area;
@@ -2208,9 +2210,9 @@ done_searches:
  */
 
 int
-calmaWritePaintFuncZ(tile, cos)
-    Tile *tile;			/* Tile to be written out. */
-    calmaOutputStructZ *cos;	/* File for output and clipping area */
+calmaWritePaintFuncZ(
+    Tile *tile,			/* Tile to be written out. */
+    calmaOutputStructZ *cos)	/* File for output and clipping area */
 {
     gzFile f = cos->f;
     Rect *clipArea = cos->area;
@@ -2313,13 +2315,13 @@ calmaWritePaintFuncZ(tile, cos)
  */
 
 void
-calmaWriteLabelFuncZ(lab, ltype, type, f)
-    Label *lab;	/* Label to output */
-    int ltype;	/* CIF layer number to use for TEXT record */
-    int type;	/* CIF layer number to use for BOUNDARY record,
+calmaWriteLabelFuncZ(
+    Label *lab,	/* Label to output */
+    int ltype,	/* CIF layer number to use for TEXT record */
+    int type,	/* CIF layer number to use for BOUNDARY record,
 		 * or -1 if not attached to a layer
 		 */
-    gzFile f;	/* Stream file */
+    gzFile f)	/* Stream file */
 {
     Point p;
     int calmanum, calmatype;
@@ -2484,9 +2486,9 @@ calmaWriteLabelFuncZ(lab, ltype, type, f)
  */
 
 int
-calmaPaintLabelFuncZ(tile, cos)
-    Tile *tile;			/* Tile contains area for label. */
-    calmaOutputStructZ *cos;	/* File for output and clipping area */
+calmaPaintLabelFuncZ(
+    Tile *tile,			/* Tile contains area for label. */
+    calmaOutputStructZ *cos)	/* File for output and clipping area */
 {
     gzFile f = cos->f;
     Rect *clipArea = cos->area;
@@ -2545,9 +2547,9 @@ calmaPaintLabelFuncZ(tile, cos)
  */
 
 void
-calmaOutHeaderZ(rootDef, f)
-    CellDef *rootDef;
-    gzFile f;
+calmaOutHeaderZ(
+    CellDef *rootDef,
+    gzFile f)
 {
     static double useru = 0.001;
     static double mum = 1.0e-9;
@@ -2606,9 +2608,9 @@ calmaOutHeaderZ(rootDef, f)
  */
 
 void
-calmaOutDateZ(t, f)
-    time_t t;	/* Time (UNIX format) to be output */
-    gzFile f;	/* Stream file */
+calmaOutDateZ(
+    time_t t,	/* Time (UNIX format) to be output */
+    gzFile f)	/* Stream file */
 {
     struct tm *datep = localtime(&t);
 
@@ -2641,10 +2643,10 @@ calmaOutDateZ(t, f)
  */
 
 void
-calmaOutStringRecordZ(type, str, f)
-    int type;	/* Type of this record (data type is ASCII string) */
-    char *str;	/* String to be output */
-    gzFile f;	/* Compressed stream file */
+calmaOutStringRecordZ(
+    int type,	/* Type of this record (data type is ASCII string) */
+    char *str,	/* String to be output */
+    gzFile f)	/* Compressed stream file */
 {
     int len;
     unsigned char c;
@@ -2742,9 +2744,9 @@ calmaOutStringRecordZ(type, str, f)
  */
 
 void
-calmaOutR8Z(d, f)
-    double d;	/* Double value to write to output */
-    gzFile f;	/* Stream file */
+calmaOutR8Z(
+    double d,	/* Double value to write to output */
+    gzFile f)	/* Stream file */
 {
     int c, i, sign, expon;
 
@@ -2817,9 +2819,9 @@ calmaOutR8Z(d, f)
  */
 
 void
-calmaOut8Z(str, f)
-    char *str;	/* 8-byte string to be output */
-    gzFile f;	/* Compressed stream file */
+calmaOut8Z(
+    char *str,	/* 8-byte string to be output */
+    gzFile f)	/* Compressed stream file */
 {
     int i;
 

--- a/calma/CalmaWriteZ.c
+++ b/calma/CalmaWriteZ.c
@@ -89,22 +89,22 @@ extern int calmaPaintLayerNumber;
 extern int calmaPaintLayerType;
 
     /* External functions from CalmaWrite.c */
-extern int calmaWriteInitFunc();
+extern int calmaWriteInitFunc(CellDef *def);
 
     /* Forward declarations */
-extern int calmaWritePaintFuncZ();
-extern int calmaMergePaintFuncZ();
-extern int calmaWriteUseFuncZ();
-extern int calmaPaintLabelFuncZ();
-extern void calmaWriteContactsZ();
-extern void calmaOutFuncZ();
-extern void calmaOutStructNameZ();
-extern void calmaWriteLabelFuncZ();
-extern void calmaOutHeaderZ();
-extern void calmaOutDateZ();
-extern void calmaOutStringRecordZ();
-extern void calmaOut8Z();
-extern void calmaOutR8Z();
+extern int calmaWritePaintFuncZ(Tile *tile, calmaOutputStructZ *cos);
+extern int calmaMergePaintFuncZ(Tile *tile, calmaOutputStructZ *cos);
+extern int calmaWriteUseFuncZ(CellUse *use, gzFile f);
+extern int calmaPaintLabelFuncZ(Tile *tile, calmaOutputStructZ *cos);
+extern void calmaWriteContactsZ(gzFile f);
+extern void calmaOutFuncZ(CellDef *def, gzFile f, Rect *cliprect);
+extern void calmaOutStructNameZ(int type, CellDef *def, gzFile f);
+extern void calmaWriteLabelFuncZ(Label *lab, int ltype, int type, gzFile f);
+extern void calmaOutHeaderZ(CellDef *rootDef, gzFile f);
+extern void calmaOutDateZ(time_t t, gzFile f);
+extern void calmaOutStringRecordZ(int type, char *str, gzFile f);
+extern void calmaOut8Z(char *str, gzFile f);
+extern void calmaOutR8Z(double d, gzFile f);
 
 /* Structure used by calmaWritePaintFuncZ() and others */
 
@@ -1190,7 +1190,7 @@ calmaOutFuncZ(def, f, cliprect)
     calmaOutputStructZ cos;
     bool propfound;
     char *propvalue;
-    extern int compport();	/* Forward declaration */
+    extern int compport(const void *one, const void *two);	/* Forward declaration */
 
     cos.f = f;
     cos.area = (cliprect == &TiPlaneRect) ? NULL : cliprect;

--- a/calma/CalmaWriteZ.c
+++ b/calma/CalmaWriteZ.c
@@ -91,6 +91,14 @@ extern int calmaPaintLayerType;
     /* External functions from CalmaWrite.c */
 extern int calmaWriteInitFunc(CellDef *def);
 
+/* Structure used by calmaWritePaintFuncZ() and others */
+
+typedef struct {
+   gzFile f;		/* Compressed file stream for output	*/
+   Rect *area;		/* Clipping area, in GDS coordinates	*/
+   int type;		/* Layer index				*/
+} calmaOutputStructZ;
+
     /* Forward declarations */
 extern int calmaWritePaintFuncZ(Tile *tile, calmaOutputStructZ *cos);
 extern int calmaMergePaintFuncZ(Tile *tile, calmaOutputStructZ *cos);
@@ -105,14 +113,6 @@ extern void calmaOutDateZ(time_t t, gzFile f);
 extern void calmaOutStringRecordZ(int type, char *str, gzFile f);
 extern void calmaOut8Z(char *str, gzFile f);
 extern void calmaOutR8Z(double d, gzFile f);
-
-/* Structure used by calmaWritePaintFuncZ() and others */
-
-typedef struct {
-   gzFile f;		/* Compressed file stream for output	*/
-   Rect *area;		/* Clipping area, in GDS coordinates	*/
-   int type;		/* Layer index				*/
-} calmaOutputStructZ;
 
 /*--------------------------------------------------------------*/
 /* Structures used by the tile merging algorithm                */

--- a/calma/CalmaWriteZ.c
+++ b/calma/CalmaWriteZ.c
@@ -128,22 +128,6 @@ extern void calmaOutR8Z(double d, gzFile f);
         STACKPUSH((ClientData) (tp), SegStack); \
     }
 
-#define LB_EXTERNAL     0       /* Polygon external edge        */
-#define LB_INTERNAL     1       /* Polygon internal edge        */
-#define LB_INIT         2       /* Data not yet valid           */
-
-typedef struct LB1 {
-    char lb_type;               /* Boundary Type (external or internal) */
-    Point lb_start;             /* Start point */
-    struct LB1 *lb_next;        /* Next point record */
-} LinkedBoundary;
-
-typedef struct BT1 {
-    LinkedBoundary *bt_first;   /* Polygon list */
-    int bt_points;              /* Number of points in this list */
-    struct BT1 *bt_next;        /* Next polygon record */
-} BoundaryTop;
-
 /* -------------------------------------------------------------------- */
 
 /*

--- a/calma/calma.h
+++ b/calma/calma.h
@@ -77,7 +77,9 @@ extern void calmaElementText(void);
 extern bool calmaIsUseNameDefault(char *defName, char *useName);
 extern bool calmaParseStructure(char *filename);
 extern int calmaProcessDef(CellDef *def, FILE *outf, bool do_library);
+#ifdef HAVE_ZLIB
 extern int calmaProcessDefZ(CellDef *def, gzFile outf, bool do_library);
+#endif
 extern bool calmaReadI2Record(int type, int *pvalue);
 extern bool calmaReadI4Record(int type, int *pvalue);
 extern void calmaReadPoint(Point *p, int iscale);

--- a/calma/calma.h
+++ b/calma/calma.h
@@ -68,7 +68,6 @@ extern bool CalmaGenerateArray(FILE *f, TileType type, int llx, int lly, int pit
 extern void CalmaReadError(char *format, ...);
 
 /* C99 compat */
-extern int calmaAddSegment(LinkedBoundary **lbptr, int poly_edge, int p1x, int p1y, int p2x, int p2y);
 extern void calmaDelContacts(void);
 extern void calmaElementBoundary(void);
 extern void calmaElementBox(void);
@@ -92,9 +91,6 @@ extern bool calmaSkipBytes(int nbytes);
 extern bool calmaSkipExact(int type);
 extern bool calmaSkipTo(int what);
 extern void calmaUnexpected(int wanted, int got);
-extern void calmaMergeSegments(LinkedBoundary *edge, BoundaryTop **blist, int num_points);
-extern void calmaRemoveDegenerate(BoundaryTop *blist);
-extern void calmaRemoveColinear(BoundaryTop *blist);
 
 #ifdef HAVE_ZLIB
 extern bool CalmaWriteZ(CellDef *rootDef, gzFile f);

--- a/calma/calma.h
+++ b/calma/calma.h
@@ -61,42 +61,42 @@ extern bool CalmaAllowAbstract;
 #define CALMA_POLYGON_KEEP	2
 
 /* Externally-visible procedures: */
-extern bool CalmaWrite();
-extern void CalmaReadFile();
-extern void CalmaTechInit();
-extern bool CalmaGenerateArray();
+extern bool CalmaWrite(CellDef *rootDef, FILE *f);
+extern void CalmaReadFile(FILETYPE file, char *filename);
+extern void CalmaTechInit(void);
+extern bool CalmaGenerateArray(FILE *f, TileType type, int llx, int lly, int pitch, int cols, int rows);
 extern void CalmaReadError(char *format, ...);
 
 /* C99 compat */
-extern int  calmaAddSegment();
-extern void calmaDelContacts();
-extern void calmaElementBoundary();
-extern void calmaElementBox();
-extern void calmaElementPath();
-extern void calmaElementText();
-extern bool calmaIsUseNameDefault();
-extern bool calmaParseStructure();
-extern int  calmaProcessDef();
-extern int  calmaProcessDefZ();
-extern bool calmaReadI2Record();
-extern bool calmaReadI4Record();
-extern void calmaReadPoint();
-extern bool calmaReadR8();
-extern bool calmaReadStampRecord();
-extern bool calmaReadStringRecord();
-extern bool calmaReadStringRecord();
-extern bool calmaReadTransform();
-extern bool calmaSkipBytes();
-extern bool calmaSkipExact();
-extern bool calmaSkipTo();
-extern void calmaUnexpected();
-extern void calmaMergeSegments();
-extern void calmaRemoveDegenerate();
-extern void calmaRemoveColinear();
+extern int calmaAddSegment(LinkedBoundary **lbptr, int poly_edge, int p1x, int p1y, int p2x, int p2y);
+extern void calmaDelContacts(void);
+extern void calmaElementBoundary(void);
+extern void calmaElementBox(void);
+extern void calmaElementPath(void);
+extern void calmaElementText(void);
+extern bool calmaIsUseNameDefault(char *defName, char *useName);
+extern bool calmaParseStructure(char *filename);
+extern int calmaProcessDef(CellDef *def, FILE *outf, bool do_library);
+extern int calmaProcessDefZ(CellDef *def, gzFile outf, bool do_library);
+extern bool calmaReadI2Record(int type, int *pvalue);
+extern bool calmaReadI4Record(int type, int *pvalue);
+extern void calmaReadPoint(Point *p, int iscale);
+extern bool calmaReadR8(double *pd);
+extern bool calmaReadStampRecord(int type, int *stampptr);
+extern bool calmaReadStringRecord(int type, char **str);
+extern bool calmaReadStringRecord(int type, char **str);
+extern bool calmaReadTransform(Transform *ptrans, char *name);
+extern bool calmaSkipBytes(int nbytes);
+extern bool calmaSkipExact(int type);
+extern bool calmaSkipTo(int what);
+extern void calmaUnexpected(int wanted, int got);
+extern void calmaMergeSegments(LinkedBoundary *edge, BoundaryTop **blist, int num_points);
+extern void calmaRemoveDegenerate(BoundaryTop *blist);
+extern void calmaRemoveColinear(BoundaryTop *blist);
 
 #ifdef HAVE_ZLIB
-extern bool CalmaWriteZ();
-extern bool CalmaGenerateArrayZ();
+extern bool CalmaWriteZ(CellDef *rootDef, gzFile f);
+extern bool CalmaGenerateArrayZ(gzFile f, TileType type, int llx, int lly, int pitch, int cols, int rows);
 #endif
 
 #endif /* _CALMA_H */

--- a/calma/calmaInt.h
+++ b/calma/calmaInt.h
@@ -227,19 +227,19 @@ typedef struct portlabel
 /* Other commonly used globals */
 extern HashTable calmaLayerHash;
 extern int calmaElementIgnore[];
-extern CellDef *calmaFindCell();
+extern CellDef *calmaFindCell(char *name, bool *was_called, bool *predefined);
 
 /* (Added by Nishit, 8/18/2004--8/24/2004) */
-extern CellDef *calmaLookCell();
-extern void calmaWriteContacts();
-extern CellDef *calmaGetContactCell();
+extern CellDef *calmaLookCell(char *name);
+extern void calmaWriteContacts(FILE *f);
+extern CellDef *calmaGetContactCell(TileType type, bool lookOnly);
 extern bool calmaIsContactCell;
 
-extern char *calmaRecordName();
-extern void calmaSkipSet();
-extern bool calmaParseUnits();
+extern char *calmaRecordName(int rtype);
+extern void calmaSkipSet(int *skipwhat);
+extern bool calmaParseUnits(void);
 
-extern int compport();
+extern int compport(const void *one, const void *two);
 
 /* ------------------- Imports from CIF reading ----------------------- */
 

--- a/calma/calmaInt.h
+++ b/calma/calmaInt.h
@@ -231,7 +231,7 @@ extern CellDef *calmaFindCell();
 
 /* (Added by Nishit, 8/18/2004--8/24/2004) */
 extern CellDef *calmaLookCell();
-extern void calmaWriteContact();
+extern void calmaWriteContacts();
 extern CellDef *calmaGetContactCell();
 extern bool calmaIsContactCell;
 

--- a/calma/calmaInt.h
+++ b/calma/calmaInt.h
@@ -241,6 +241,28 @@ extern bool calmaParseUnits(void);
 
 extern int compport(const void *one, const void *two);
 
+
+#define LB_EXTERNAL	0	/* Polygon external edge	*/
+#define LB_INTERNAL	1	/* Polygon internal edge	*/
+#define LB_INIT		2	/* Data not yet valid		*/
+
+typedef struct LB1 {
+    char lb_type;		/* Boundary Type (external or internal) */
+    Point lb_start;		/* Start point */
+    struct LB1 *lb_next;	/* Next point record */
+} LinkedBoundary;
+
+typedef struct BT1 {
+    LinkedBoundary *bt_first;   /* Polygon list */
+    int bt_points;		/* Number of points in this list */
+    struct BT1 *bt_next;	/* Next polygon record */
+} BoundaryTop;
+
+extern int calmaAddSegment(LinkedBoundary **lbptr, bool poly_edge, int p1x, int p1y, int p2x, int p2y);
+extern void calmaMergeSegments(LinkedBoundary *edge, BoundaryTop **blist, int num_points);
+extern void calmaRemoveDegenerate(BoundaryTop *blist);
+extern void calmaRemoveColinear(BoundaryTop *blist);
+
 /* ------------------- Imports from CIF reading ----------------------- */
 
 extern CellDef *cifReadCellDef;

--- a/scripts/configure
+++ b/scripts/configure
@@ -4952,6 +4952,19 @@ fi
 done
 
 
+for ac_header in sys/time.h
+do :
+  ac_fn_c_check_header_mongrel "$LINENO" "sys/time.h" "ac_cv_header_sys_time_h" "$ac_includes_default"
+if test "x$ac_cv_header_sys_time_h" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_SYS_TIME_H 1
+_ACEOF
+
+fi
+
+done
+
+
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for va_copy" >&5
 $as_echo_n "checking for va_copy... " >&6; }
 if ${ac_cv_c_va_copy+:} false; then :

--- a/scripts/configure.in
+++ b/scripts/configure.in
@@ -150,6 +150,9 @@ AC_CHECK_HEADERS(param.h)
 dnl Check for <paths.h>
 AC_CHECK_HEADERS(paths.h)
 
+dnl Check for <sys/time.h>
+AC_CHECK_HEADERS(sys/time.h)
+
 dnl Check for va_copy
 AC_CACHE_CHECK([for va_copy], ac_cv_c_va_copy,
  AC_TRY_LINK(


### PR DESCRIPTION
This series converts the calma module into ANSI function prototype syntax.

Please feedback if the method and commit breakdown helps the review process (for example github has single character change highlight, the code style adopted is to help get through review, a future commit could make just style cleanup/white-space only change which can be reviewed better via diff -b)

There are 2 subsequent change set behind this one (calma/** .rodata cleanup, ATTR_FORMAT_PRINTF - reminder to self)