### PR TITLE
clang18 default warnings and build fix

### DIFF
--- a/calma/CalmaWrite.c
+++ b/calma/CalmaWrite.c
@@ -24,6 +24,7 @@ static char rcsid[] __attribute__ ((unused)) ="$Header: /usr/cvsroot/magic-8.0/c
 #include <stdint.h>
 #include <stdlib.h>	/* for random() */
 #include <string.h>
+#include <strings.h>
 #include <ctype.h>
 #include <sys/types.h>
 #include <arpa/inet.h>	/* for htons() */

--- a/calma/CalmaWriteZ.c
+++ b/calma/CalmaWriteZ.c
@@ -34,6 +34,7 @@ static char rcsid[] __attribute__ ((unused)) ="$Header: /usr/cvsroot/magic-8.0/c
 #include <stdint.h>
 #include <stdlib.h>	/* for random() */
 #include <string.h>
+#include <strings.h>
 #include <ctype.h>
 #include <sys/types.h>
 #include <arpa/inet.h>	/* for htons() */

--- a/commands/CmdCD.c
+++ b/commands/CmdCD.c
@@ -23,6 +23,7 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <strings.h>
 
 #include "tcltk/tclmagic.h"
 #include "utils/magic.h"

--- a/commands/CmdRS.c
+++ b/commands/CmdRS.c
@@ -23,6 +23,7 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <strings.h>
 #include <ctype.h>
 #include <time.h>
 

--- a/database/DBio.c
+++ b/database/DBio.c
@@ -2311,7 +2311,7 @@ dbReadProperties(cellDef, line, len, f, scalen, scaled)
     int scalen;		/* Scale up by this factor */
     int scaled;		/* Scale down by this factor */
 {
-    char propertyname[128], propertyvalue[2048], *storedvalue;
+    char propertyname[128], propertyvalue[2049], *storedvalue;
     char *pvalueptr;
     int ntok;
     unsigned int noeditflag;

--- a/database/DBlabel.c
+++ b/database/DBlabel.c
@@ -24,6 +24,7 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <strings.h>
 #include <math.h>	/* For sin(), cos(), and round() functions */
 #include <ctype.h>
 

--- a/ext2sim/ext2sim.c
+++ b/ext2sim/ext2sim.c
@@ -19,6 +19,7 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 #include <stdio.h>
 #include <stdlib.h>	/* for atof() */
 #include <string.h>
+#include <strings.h>
 #include <ctype.h>
 #include <math.h>	/* for sqrt() in bipolar L,W calculation */
 

--- a/ext2spice/ext2spice.c
+++ b/ext2spice/ext2spice.c
@@ -20,6 +20,7 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 #include <stdint.h>
 #include <stdlib.h>		/* for atof() */
 #include <string.h>
+#include <strings.h>
 #include <ctype.h>
 #include <math.h>		/* for fabs() */
 

--- a/extflat/EFbuild.c
+++ b/extflat/EFbuild.c
@@ -24,6 +24,7 @@ static char rcsid[] __attribute__ ((unused)) = "$Header$";
 #include <stdio.h>
 #include <stdlib.h>		/* for atof() */
 #include <string.h>
+#include <strings.h>
 
 #include "utils/magic.h"
 #include "utils/geometry.h"

--- a/extract/ExtBasic.c
+++ b/extract/ExtBasic.c
@@ -1022,7 +1022,7 @@ extFindDuplicateLabels(def, nreg)
 			    {
 				r.r_ll = r.r_ur = ll2->ll_label->lab_rect.r_ll;
 				r.r_xbot--, r.r_ybot--, r.r_xtop++, r.r_ytop++;
-				extMakeNodeNumPrint(name, np2);
+				extMakeNodeNumPrint(name, (LabRegion *)np2);
 				(void) sprintf(message, badmesg, text, name);
 				DBWFeedbackAdd(&r, message, def,
 					    1, STYLE_PALEHIGHLIGHTS);
@@ -2288,7 +2288,7 @@ extOutputDevices(def, transList, outFile)
 	if (!TTMaskIsZero(&devptr->exts_deviceSubstrateTypes)
 		&& (subsNode = extTransRec.tr_subsnode))
 	{
-	    subsName = extNodeName(subsNode);
+	    subsName = extNodeName((LabRegion *)subsNode);
 	}
 
 #ifdef MAGIC_WRAPPER
@@ -2332,11 +2332,11 @@ extOutputDevices(def, transList, outFile)
 
 	    /* gate */
 	    node = (NodeRegion *)extGetRegion(reg->treg_tile);
-	    fprintf(outFile, "\"%s\" ", extNodeName(node));
+	    fprintf(outFile, "\"%s\" ", extNodeName((LabRegion *)node));
 
 	    /* First non-gate terminal */
 	    node = (NodeRegion *)extTransRec.tr_termnode[0];
-	    fprintf(outFile, "\"%s\"\n", extNodeName(node));
+	    fprintf(outFile, "\"%s\"\n", extNodeName((LabRegion *)node));
 
 	    continue;
 	}

--- a/extract/ExtTech.c
+++ b/extract/ExtTech.c
@@ -25,6 +25,7 @@ static char sccsid[] = "@(#)ExtTech.c	4.8 MAGIC (Berkeley) 10/26/85";
 #include <stdio.h>
 #include <stdlib.h>		/* for strtod() */
 #include <string.h>
+#include <strings.h>
 #include <math.h>
 #include <ctype.h>		/* for isspace() */
 

--- a/irouter/irRoute.c
+++ b/irouter/irRoute.c
@@ -1098,7 +1098,7 @@ irChooseEndPtLayers(routeUse,expansionMask,endPt,argLayers,endPtName)
 	    }
 	    TxPrintf("\n");
 
-	    for(pickedRC=FALSE,l=presentContacts; l && !pickedRC; l=LIST_TAIL(l))
+	    for(pickedRC=NULL,l=presentContacts; l && !pickedRC; l=LIST_TAIL(l))
 	    {
 		rC = (RouteContact *) LIST_FIRST(l);
 		if (!LIST_TAIL(l) && !presentLayers)

--- a/lef/lefCmd.c
+++ b/lef/lefCmd.c
@@ -12,6 +12,7 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <strings.h>
 #include <time.h>
 
 #include "tcltk/tclmagic.h"

--- a/lef/lefRead.c
+++ b/lef/lefRead.c
@@ -21,6 +21,7 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 #include <stdlib.h>
 #include <ctype.h>
 #include <string.h>
+#include <strings.h>
 #include <errno.h>
 #include <stdarg.h>
 #include <sys/time.h>

--- a/netmenu/NMnetlist.c
+++ b/netmenu/NMnetlist.c
@@ -23,6 +23,7 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 
 #include <stdio.h>
 #include <string.h>
+#include <strings.h>
 
 #include "utils/magic.h"
 #include "utils/utils.h"

--- a/plot/plotHP.c
+++ b/plot/plotHP.c
@@ -332,15 +332,15 @@ PlotDumpHPRTL(hpfile, kRaster, cRaster, mRaster, yRaster)
 
 	/* Compress each plane (C, M, and Y) and output */
 
-	size = PlotRTLCompress(c - ipl, obytes, bpl);
+	size = PlotRTLCompress((unsigned char *)(c - ipl), obytes, bpl);
 	fprintf(hpfile, "\033*b%dV", size);
 	fwrite(obytes, size, 1, hpfile);
 
-	size = PlotRTLCompress(m - ipl, obytes, bpl);
+	size = PlotRTLCompress((unsigned char *)(m - ipl), obytes, bpl);
 	fprintf(hpfile, "\033*b%dV", size);
 	fwrite(obytes, size, 1, hpfile);
 
-	size = PlotRTLCompress(y - ipl, obytes, bpl);
+	size = PlotRTLCompress((unsigned char *)(y - ipl), obytes, bpl);
 	fprintf(hpfile, "\033*b%dW", size);
 	fwrite(obytes, size, 1, hpfile);
     }

--- a/resis/ResRex.c
+++ b/resis/ResRex.c
@@ -6,6 +6,7 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <strings.h>
 #include <ctype.h>
 #include <math.h>
 #include <float.h>

--- a/utils/macros.c
+++ b/utils/macros.c
@@ -22,6 +22,7 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 
 #include <stdio.h>
 #include <string.h>
+#include <strings.h>
 #include <signal.h>
 #include <ctype.h>
 #ifdef XLIB

--- a/utils/main.c
+++ b/utils/main.c
@@ -25,6 +25,7 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <strings.h>
 
 #include <sys/types.h>
 #include <sys/times.h>

--- a/utils/netlist.c
+++ b/utils/netlist.c
@@ -369,6 +369,8 @@ NLNetName(net)
     static char tempId[100];
 #if defined(EMSCRIPTEN)
  int etext;    
+#elif defined(linux) && defined(__clang__)
+    extern char etext;
 #elif defined(linux) || defined(CYGWIN)
     extern int etext asm("etext");
 #elif defined(__APPLE__)


### PR DESCRIPTION
These changes not modify application behaviour, they address clang18 warnings.

one commit fixes building with clang18 concerning etext symbol use.

clang18 was also then put into a stricter standards compliant mode (for some of the concerns) to help highlight issues.