### PR TITLE
Added CmdFlush_NoConfirm option to disable flush prompt

### DIFF
--- a/commands/CmdFI.c
+++ b/commands/CmdFI.c
@@ -943,6 +943,7 @@ CmdFlush(w, cmd)
     static char *actionNames[] = { "no", "yes", 0 };
     char *prompt;
     bool dereference = FALSE;
+    char *strNoConfirm;
 
     if (!strncmp(cmd->tx_argv[cmd->tx_argc - 1], "-deref", 6))
     {
@@ -973,13 +974,19 @@ CmdFlush(w, cmd)
 	}
     }
 
-    if (def->cd_flags & (CDMODIFIED|CDSTAMPSCHANGED|CDBOXESCHANGED))
-    {
-	prompt = TxPrintString("Really throw away all changes made"
-			" to cell %s? ", def->cd_name);
-	action = TxDialog(prompt, actionNames, 0);
-	if (action == 0)	/* No */
-	    return;
+    strNoConfirm = (char *)Tcl_GetVar(magicinterp, "CmdFlush_NoConfirm", TCL_GLOBAL_ONLY);
+
+    if(strNoConfirm){
+        TxPrintf("CmdFlush_NoConfirm set, skipping prompt.\n");
+    }else{
+        if (def->cd_flags & (CDMODIFIED|CDSTAMPSCHANGED|CDBOXESCHANGED))
+        {
+            prompt = TxPrintString("Really throw away all changes made"
+                                   " to cell %s? ", def->cd_name);
+            action = TxDialog(prompt, actionNames, 0);
+            if (action == 0)	/* No */
+                return;
+        }
     }
 
     cmdFlushCell(def, dereference);


### PR DESCRIPTION
In commands/CmdFI.c.

To ignore prompt
```tcl
set CmdFlush_NoConfirm 1
```

To enable prompt again
```tcl
unset CmdFlush_NoConfirm 
```