### PR TITLE
PR#340 alternative ?  flush -noconfirm .. exit exit_status -noconfirm

### DIFF
--- a/commands/CmdFI.c
+++ b/commands/CmdFI.c
@@ -943,6 +943,7 @@ CmdFlush(w, cmd)
     static char *actionNames[] = { "no", "yes", 0 };
     char *prompt;
     bool dereference = FALSE;
+    bool noprompt = FALSE; /* no interactive confirm when changed */
 
     if (!strncmp(cmd->tx_argv[cmd->tx_argc - 1], "-deref", 6))
     {
@@ -950,9 +951,15 @@ CmdFlush(w, cmd)
 	cmd->tx_argc--;
     }
 
+    if (!strcmp(cmd->tx_argv[cmd->tx_argc - 1], "-noprompt"))
+    {
+        noprompt = TRUE;
+        cmd->tx_argc--;
+    }
+
     if (cmd->tx_argc > 2)
     {
-	TxError("Usage: flush [cellname] [dereference]\n");
+	TxError("Usage: flush [cellname] [-noprompt] [-dereference]\n");
 	return;
     }
 
@@ -973,7 +980,9 @@ CmdFlush(w, cmd)
 	}
     }
 
-    if (def->cd_flags & (CDMODIFIED|CDSTAMPSCHANGED|CDBOXESCHANGED))
+    bool has_changes = (def->cd_flags & (CDMODIFIED|CDSTAMPSCHANGED|CDBOXESCHANGED)) != 0;
+
+    if (!noprompt && has_changes)
     {
 	prompt = TxPrintString("Really throw away all changes made"
 			" to cell %s? ", def->cd_name);
@@ -984,7 +993,7 @@ CmdFlush(w, cmd)
 
     cmdFlushCell(def, dereference);
     SelectClear();
-    TxPrintf("[Flushed]\n");
+    TxPrintf("[Flushed%s]\n", has_changes ? " Modifications were Discarded" : "");
 }
 
 

--- a/doc/html/flush.html
+++ b/doc/html/flush.html
@@ -26,7 +26,7 @@ last saved version.
 
 <H3>Usage:</H3>
    <BLOCKQUOTE>
-      <B>flush</B> [<I>cellname</I>] [<B>-dereference</B>]<BR><BR>
+      <B>flush</B> [<I>cellname</I>] [<B>-noprompt</B>] [<B>-dereference</B>]<BR><BR>
       <BLOCKQUOTE>
          where <I>cellname</I> is the name of a cell definition to be
 	 flushed.
@@ -42,6 +42,10 @@ last saved version.
 
       The effects of the <B>flush</B> command are irrevocable; the
       command cannot be undone with an <B>undo</B> command. <P>
+
+      With the <B>-noprompt</B> option, no interactive confirmation is
+      presented if there are unsaved changes.  Those changes will be
+      flushed.
 
       With the <B>-dereference</B> option, any file path that has been
       associated with the cell is discarded, and the cell is reloaded

--- a/doc/html/quit.html
+++ b/doc/html/quit.html
@@ -31,7 +31,7 @@ Exit magic
 
 <H3>Usage:</H3>
    <BLOCKQUOTE>
-      <B>quit</B> <BR><BR>
+      <B>quit</B> [<B>-noprompt</B>]<BR><BR>
    </BLOCKQUOTE>
 
 <H3>Summary:</H3>
@@ -45,6 +45,9 @@ Exit magic
       and the Tcl <B>exit</B> command is required to quit the program.
       The Tcl <B>exit</B> command will <I>always</I> exit <B>magic</B>
       immediately, without prompting or cleanup or any other niceties. <P>
+
+      With the <B>-noprompt</B> option, the interactive confirm prompt
+      does not occur so any changes will be discarded.
    </BLOCKQUOTE>
 
 <H3>Implementation Notes:</H3>

--- a/doc/html/quit.html
+++ b/doc/html/quit.html
@@ -31,7 +31,7 @@ Exit magic
 
 <H3>Usage:</H3>
    <BLOCKQUOTE>
-      <B>quit</B> [<B>-noprompt</B>]<BR><BR>
+      <B>quit</B> [<B>exit_status</B>] [<B>-noprompt</B>]<BR><BR>
    </BLOCKQUOTE>
 
 <H3>Summary:</H3>
@@ -46,8 +46,12 @@ Exit magic
       The Tcl <B>exit</B> command will <I>always</I> exit <B>magic</B>
       immediately, without prompting or cleanup or any other niceties. <P>
 
+      The <B>exit_status</B> option allows an exit status number in
+      the range 0 to 255 to be indicated to the parent process. The
+      default exit_status is 0 indicating success.<P>
+
       With the <B>-noprompt</B> option, the interactive confirm prompt
-      does not occur so any changes will be discarded.
+      does not occur so any changes will be discarded. <P>
    </BLOCKQUOTE>
 
 <H3>Implementation Notes:</H3>

--- a/windows/windCmdNR.c
+++ b/windows/windCmdNR.c
@@ -265,15 +265,28 @@ windQuitCmd(w, cmd)
     bool checkfirst = TRUE;
 
     if (cmd->tx_argc == 2)
+    {
 	if (!strcmp(cmd->tx_argv[1], "-noprompt"))
+	{
 	    checkfirst = FALSE;
+	    cmd->tx_argc--;
+        }
+    }
+
+    if (cmd->tx_argc > 1)
+    {
+        TxError("Usage: quit [-noprompt]\n");
+        return;
+    }
 
     if (checkfirst)
+    {
 	for (cr = windFirstClientRec; cr != (clientRec *) NULL;
 		cr = cr->w_nextClient)
 	    if (cr->w_exit != NULL)
 		if (!(*(cr->w_exit))())
 		    return;
+    }
 
     MainExit(0);
 }

--- a/windows/windCmdNR.c
+++ b/windows/windCmdNR.c
@@ -263,10 +263,11 @@ windQuitCmd(w, cmd)
 {
     clientRec *cr;
     bool checkfirst = TRUE;
+    int exit_status = 0;
 
-    if (cmd->tx_argc == 2)
+    if (cmd->tx_argc > 1)
     {
-	if (!strcmp(cmd->tx_argv[1], "-noprompt"))
+	if (!strcmp(cmd->tx_argv[cmd->tx_argc - 1], "-noprompt"))
 	{
 	    checkfirst = FALSE;
 	    cmd->tx_argc--;
@@ -275,7 +276,21 @@ windQuitCmd(w, cmd)
 
     if (cmd->tx_argc > 1)
     {
-        TxError("Usage: quit [-noprompt]\n");
+        int tmp;
+        if (sscanf(cmd->tx_argv[cmd->tx_argc - 1], "%d", &tmp) == 1 && exit_status >= 0 && exit_status <= 255)
+        {
+            exit_status = tmp;
+            cmd->tx_argc--;
+        }
+        else
+        {
+            TxError("Invalid exit_status: %s\n", cmd->tx_argv[cmd->tx_argc - 1]);
+        }
+    }
+
+    if (cmd->tx_argc > 1)
+    {
+        TxError("Usage: quit [exit_status] [-noprompt]\n");
         return;
     }
 
@@ -288,7 +303,7 @@ windQuitCmd(w, cmd)
 		    return;
     }
 
-    MainExit(0);
+    MainExit(exit_status);
 }
 
 


### PR DESCRIPTION
@wulffern please advise, test as alternative to PR#340

Documented hidden/secret `exit [-noconfirm]` option to disable exit prompt
Added `exit [exit_status]` option to send exit_status number
Added `flush -noconfirm` option to disable flush prompt

I have tested the 'exit' patches.

I have not yet tested the 'flush' patch.  Still comment back when testing complete on my side but would appreciate feedback if it closes your concern.
