### PR TITLE
cif/CIFgen.c: fix incorrect type bool -> int

### DIFF
--- a/cif/CIFgen.c
+++ b/cif/CIFgen.c
@@ -2086,7 +2086,7 @@ cifCloseFunc(
 {
     Rect area, newarea;
     int atotal;
-    int cifGatherFunc(Tile *tile, int *atotal, bool mode);
+    int cifGatherFunc(Tile *tile, int *atotal, int mode);
 
     /* If tile is marked, then it has been handled, so ignore it */
     if (tile->ti_client != (ClientData)CIF_UNPROCESSED) return 0;
@@ -2118,7 +2118,7 @@ int
 cifGatherFunc(
     Tile *tile,
     int *atotal,
-    bool mode)
+    int mode)
 {
     Tile *tp;
     TileType type;


### PR DESCRIPTION
There are 3 states for CLOSE_xxxxxx with 3 different values.

Issue introduced from 2f7f76bf9 merged since tag:8.3.509

This affected the scenarios using non-zero non-one values such as:
  #define CLOSE_DONE   2

This looks the result of an original bug where the forward declaration
 had a type mismatch with the real method, so the method implementation
 prototype was taken as the correct one.  The forward decl was rewritten
 with the correct prototype signature.
Maybe this is the cause of CIF data once drawn into view does not always
 seem to always erase after disabling and a redraw ?