### PR TITLE
post K&R data to rodata segment

### DIFF
--- a/calma/CalmaRdcl.c
+++ b/calma/CalmaRdcl.c
@@ -18,7 +18,7 @@
  */
 
 #ifndef lint
-static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/calma/CalmaRdcl.c,v 1.5 2010/06/25 13:59:24 tim Exp $";
+static const char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/calma/CalmaRdcl.c,v 1.5 2010/06/25 13:59:24 tim Exp $";
 #endif  /* not lint */
 
 #include <stdio.h>

--- a/calma/CalmaRdcl.c
+++ b/calma/CalmaRdcl.c
@@ -350,7 +350,7 @@ bool
 calmaParseStructure(
     char *filename)		/* Name of the GDS file read */
 {
-    static int structs[] = { CALMA_STRCLASS, CALMA_STRTYPE, -1 };
+    static const int structs[] = { CALMA_STRCLASS, CALMA_STRTYPE, -1 };
     int nbytes = -1, rtype = 0, nsrefs, osrefs, npaths;
     char *strname = NULL;
     HashEntry *he;
@@ -680,7 +680,7 @@ calmaParseElement(
     int *pnsrefs,
     int *pnpaths)
 {
-    static int node[] = { CALMA_ELFLAGS, CALMA_PLEX, CALMA_LAYER,
+    static const int node[] = { CALMA_ELFLAGS, CALMA_PLEX, CALMA_LAYER,
 			  CALMA_NODETYPE, CALMA_XY, -1 };
     int nbytes, rtype, madeinst;
 
@@ -1351,7 +1351,7 @@ calmaUniqueCell(
 
 CellDef *
 calmaFindCell(
-    char *name,		/* Name of desired cell */
+    const char *name,	/* Name of desired cell */
     bool *was_called,	/* If this cell is in the hash table, then it
 			 * was instanced before it was defined.  We
 			 * need to know this so as to avoid flattening

--- a/calma/CalmaRdio.c
+++ b/calma/CalmaRdio.c
@@ -490,9 +490,9 @@ calmaReadR8(
 
 void
 calmaSkipSet(
-    int *skipwhat)
+    const int *skipwhat)
 {
-    int *skipp;
+    const int *skipp;
     int nbytes, rtype;
 
     for (;;)

--- a/calma/CalmaRdio.c
+++ b/calma/CalmaRdio.c
@@ -18,7 +18,7 @@
  */
 
 #ifndef lint
-static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/calma/CalmaRdio.c,v 1.1.1.1 2008/02/03 20:43:50 tim Exp $";
+static const char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/calma/CalmaRdio.c,v 1.1.1.1 2008/02/03 20:43:50 tim Exp $";
 #endif  /* not lint */
 
 #include <stdio.h>

--- a/calma/CalmaRdpt.c
+++ b/calma/CalmaRdpt.c
@@ -18,7 +18,7 @@
  */
 
 #ifndef lint
-static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/calma/CalmaRdpt.c,v 1.7 2010/08/25 17:33:54 tim Exp $";
+static const char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/calma/CalmaRdpt.c,v 1.7 2010/08/25 17:33:54 tim Exp $";
 #endif  /* not lint */
 
 #include <stdio.h>

--- a/calma/CalmaRdpt.c
+++ b/calma/CalmaRdpt.c
@@ -732,7 +732,7 @@ calmaElementPath(void)
 void
 calmaElementText(void)
 {
-    static int ignore[] = { CALMA_PATHTYPE, CALMA_WIDTH, -1 };
+    static const int ignore[] = { CALMA_PATHTYPE, CALMA_WIDTH, -1 };
     char *textbody = NULL;
     int nbytes = -1, rtype = 0;
     int layer, textt, cifnum, textpres;

--- a/calma/CalmaRdpt.c
+++ b/calma/CalmaRdpt.c
@@ -257,13 +257,13 @@ calmaElementBoundary(void)
     if ((CalmaSubcellPolygons != CALMA_POLYGON_NONE) && (calmaNonManhattan > 0))
     {
 	/* Place the polygon in its own subcell */
-	char newname[] = "polygonXXXXX";
+	char newname[16];
 	HashEntry *he;
 
 	savedef = cifReadCellDef;
 
 	/* Make up name for cell */
-	sprintf(newname + 7, "%05d", ++CalmaPolygonCount);
+	snprintf(newname, sizeof(newname), "polygon%05d", ++CalmaPolygonCount);
 
 	he = HashFind(&calmaDefInitHash, newname);
 	if (!HashGetValue(he))
@@ -663,13 +663,13 @@ calmaElementPath(void)
 	if (CalmaSubcellPaths)
 	{
 	    /* Place the path in its own subcell */
-	    char newname[] = "pathXXXXX";
+	    char newname[16];
 	    HashEntry *he;
 
 	    savedef = cifReadCellDef;
 
 	    /* Make up name for cell */
-	    sprintf(newname + 4, "%05d", ++CalmaPathCount);
+	    snprintf(newname, sizeof(newname), "path%05d", ++CalmaPathCount);
 
 	    he = HashFind(&calmaDefInitHash, newname);
 	    if (!HashGetValue(he))

--- a/calma/CalmaRead.c
+++ b/calma/CalmaRead.c
@@ -147,7 +147,7 @@ HashTable calmaLayerHash;
 HashTable calmaDefInitHash;
 
 /* Common stuff to ignore */
-int calmaElementIgnore[] = { CALMA_ELFLAGS, CALMA_PLEX, -1 };
+const int calmaElementIgnore[] = { CALMA_ELFLAGS, CALMA_PLEX, -1 };
 
 /*
  * ----------------------------------------------------------------------------
@@ -174,11 +174,11 @@ CalmaReadFile(
     int k, version;
     char *libname = NULL, *libnameptr = NULL;
     MagWindow *mw;
-    static int hdrSkip[] = { CALMA_FORMAT, CALMA_MASK, CALMA_ENDMASKS,
-			     CALMA_REFLIBS, CALMA_FONTS, CALMA_ATTRTABLE,
-			     CALMA_STYPTABLE, CALMA_GENERATIONS, -1 };
-    static int skipBeforeLib[] = { CALMA_LIBDIRSIZE, CALMA_SRFNAME,
-				   CALMA_LIBSECUR, -1 };
+    static const int hdrSkip[] = { CALMA_FORMAT, CALMA_MASK, CALMA_ENDMASKS,
+					 CALMA_REFLIBS, CALMA_FONTS, CALMA_ATTRTABLE,
+					 CALMA_STYPTABLE, CALMA_GENERATIONS, -1 };
+    static const int skipBeforeLib[] = { CALMA_LIBDIRSIZE, CALMA_SRFNAME,
+					       CALMA_LIBSECUR, -1 };
 
     if (EditCellUse == (CellUse *)NULL)
     {
@@ -558,12 +558,12 @@ calmaUnexpected(
  * ----------------------------------------------------------------------------
  */
 
-char *
+const char *
 calmaRecordName(
     int rtype)
 {
     static char numeric[10];
-    static char *calmaRecordNames[] =
+    static const char * const calmaRecordNames[] =
     {
 	"HEADER",	"BGNLIB",	"LIBNAME",	"UNITS",
 	"ENDLIB",	"BGNSTR",	"STRNAME",	"ENDSTR",

--- a/calma/CalmaRead.c
+++ b/calma/CalmaRead.c
@@ -17,7 +17,7 @@
  */
 
 #ifndef lint
-static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/calma/CalmaRead.c,v 1.3 2010/06/24 12:37:15 tim Exp $";
+static const char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/calma/CalmaRead.c,v 1.3 2010/06/24 12:37:15 tim Exp $";
 #endif  /* not lint */
 
 #include <stdarg.h>

--- a/calma/CalmaWrite.c
+++ b/calma/CalmaWrite.c
@@ -17,7 +17,7 @@
  */
 
 #ifndef lint
-static char rcsid[] __attribute__ ((unused)) ="$Header: /usr/cvsroot/magic-8.0/calma/CalmaWrite.c,v 1.8 2010/12/22 16:29:06 tim Exp $";
+static const char rcsid[] __attribute__ ((unused)) ="$Header: /usr/cvsroot/magic-8.0/calma/CalmaWrite.c,v 1.8 2010/12/22 16:29:06 tim Exp $";
 #endif  /* not lint */
 
 #include <stdio.h>

--- a/calma/CalmaWrite.c
+++ b/calma/CalmaWrite.c
@@ -102,7 +102,7 @@ extern void calmaWriteLabelFunc(Label *lab, int ltype, int type, FILE *f);
 extern void calmaOutHeader(CellDef *rootDef, FILE *f);
 extern void calmaOutDate(time_t t, FILE *f);
 extern void calmaOutStringRecord(int type, char *str, FILE *f);
-extern void calmaOut8(char *str, FILE *f);
+extern void calmaOut8(const char *str, FILE *f);
 extern void calmaOutR8(double d, FILE *f);
 extern void calmaProcessBoundary(BoundaryTop *blist, calmaOutputStruct *cos);
 extern void calmaRemoveColinear(BoundaryTop *blist);
@@ -199,7 +199,7 @@ HashTable calmaUndefHash;
 	(void) putc(u.u_c[3], f); \
     }
 
-static char calmaMapTableStrict[] =
+static const char calmaMapTableStrict[] =
 {
       0,    0,    0,    0,    0,    0,    0,    0,	/* NUL - BEL */
       0,    0,    0,    0,    0,    0,    0,    0,	/* BS  - SI  */
@@ -219,7 +219,7 @@ static char calmaMapTableStrict[] =
     'x',  'y',  'z',  '_',  '_',  '_',  '_',  0,	/* x   - DEL */
 };
 
-static char calmaMapTablePermissive[] =
+static const char calmaMapTablePermissive[] =
 {
       0,    0,    0,    0,    0,    0,    0,    0,	/* NUL - BEL */
       0,    0,    0,    0,    0,    0,    0,    0,	/* BS  - SI  */
@@ -686,10 +686,10 @@ calmaFullDump(
     HashSearch hs;
     HashEntry *he, *he2;
 
-    static int hdrSkip[] = { CALMA_FORMAT, CALMA_MASK, CALMA_ENDMASKS,
+    static const int hdrSkip[] = { CALMA_FORMAT, CALMA_MASK, CALMA_ENDMASKS,
 		CALMA_REFLIBS, CALMA_FONTS, CALMA_ATTRTABLE,
 		CALMA_STYPTABLE, CALMA_GENERATIONS, -1 };
-    static int skipBeforeLib[] = { CALMA_LIBDIRSIZE, CALMA_SRFNAME,
+    static const int skipBeforeLib[] = { CALMA_LIBDIRSIZE, CALMA_SRFNAME,
 		CALMA_LIBSECUR, -1 };
 
     HashInit(&calmaDefHash, 32, 0);
@@ -1524,10 +1524,10 @@ calmaWriteUseFunc(
      * only 4 possible values, it is faster to have them pre-computed
      * than to format with calmaOutR8().
      */
-    static unsigned char r90[] = { 0x42, 0x5a, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
-    static unsigned char r180[] = { 0x42, 0xb4, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
-    static unsigned char r270[] = { 0x43, 0x10, 0xe0, 0x00, 0x00, 0x00, 0x00, 0x00 };
-    unsigned char *whichangle;
+    static const unsigned char r90[] = { 0x42, 0x5a, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
+    static const unsigned char r180[] = { 0x42, 0xb4, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
+    static const unsigned char r270[] = { 0x43, 0x10, 0xe0, 0x00, 0x00, 0x00, 0x00, 0x00 };
+    const unsigned char *whichangle;
     int x, y, topx, topy, rows, cols, xxlate, yxlate, hdrsize;
     int rectype, stransflags;
     Transform *t;
@@ -1738,7 +1738,7 @@ calmaOutStructName(
     unsigned char c;
     char *cp;
     int calmanum;
-    char *table;
+    const char *table;
 
     if (CIFCurStyle->cs_flags & CWF_PERMISSIVE_LABELS)
     {
@@ -3245,7 +3245,8 @@ calmaOutStringRecord(
 {
     int len;
     unsigned char c;
-    char *table, *locstr, *origstr = NULL;
+    const char *table;
+    char *locstr, *origstr = NULL;
     char *locstrprv; 	/* Added by BSI */
 
     if(CIFCurStyle->cs_flags & CWF_PERMISSIVE_LABELS)
@@ -3415,7 +3416,7 @@ calmaOutR8(
 
 void
 calmaOut8(
-    char *str,	/* 8-byte string to be output */
+    const char *str,	/* 8-byte string to be output */
     FILE *f)	/* Stream file */
 {
     int i;

--- a/calma/CalmaWriteZ.c
+++ b/calma/CalmaWriteZ.c
@@ -112,7 +112,7 @@ extern void calmaWriteLabelFuncZ(Label *lab, int ltype, int type, gzFile f);
 extern void calmaOutHeaderZ(CellDef *rootDef, gzFile f);
 extern void calmaOutDateZ(time_t t, gzFile f);
 extern void calmaOutStringRecordZ(int type, char *str, gzFile f);
-extern void calmaOut8Z(char *str, gzFile f);
+extern void calmaOut8Z(const char *str, gzFile f);
 extern void calmaOutR8Z(double d, gzFile f);
 
 /*--------------------------------------------------------------*/
@@ -180,7 +180,7 @@ extern void calmaOutR8Z(double d, gzFile f);
 	(void) gzputc(f, u.u_c[3]); \
     }
 
-static char calmaMapTableStrict[] =
+static const char calmaMapTableStrict[] =
 {
       0,    0,    0,    0,    0,    0,    0,    0,      /* NUL - BEL */
       0,    0,    0,    0,    0,    0,    0,    0,      /* BS  - SI  */
@@ -200,7 +200,7 @@ static char calmaMapTableStrict[] =
     'x',  'y',  'z',  '_',  '_',  '_',  '_',  0,        /* x   - DEL */
 };
 
-static char calmaMapTablePermissive[] =
+static const char calmaMapTablePermissive[] =
 {
       0,    0,    0,    0,    0,    0,    0,    0,      /* NUL - BEL */
       0,    0,    0,    0,    0,    0,    0,    0,      /* BS  - SI  */
@@ -667,10 +667,10 @@ calmaFullDumpZ(
     HashSearch hs;
     HashEntry *he, *he2;
 
-    static int hdrSkip[] = { CALMA_FORMAT, CALMA_MASK, CALMA_ENDMASKS,
+    static const int hdrSkip[] = { CALMA_FORMAT, CALMA_MASK, CALMA_ENDMASKS,
 		CALMA_REFLIBS, CALMA_FONTS, CALMA_ATTRTABLE,
 		CALMA_STYPTABLE, CALMA_GENERATIONS, -1 };
-    static int skipBeforeLib[] = { CALMA_LIBDIRSIZE, CALMA_SRFNAME,
+    static const int skipBeforeLib[] = { CALMA_LIBDIRSIZE, CALMA_SRFNAME,
 		CALMA_LIBSECUR, -1 };
 
     HashInit(&calmaDefHash, 32, 0);
@@ -1365,10 +1365,10 @@ calmaWriteUseFuncZ(
      * only 4 possible values, it is faster to have them pre-computed
      * than to format with calmaOutR8Z().
      */
-    static unsigned char r90[] = { 0x42, 0x5a, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
-    static unsigned char r180[] = { 0x42, 0xb4, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
-    static unsigned char r270[] = { 0x43, 0x10, 0xe0, 0x00, 0x00, 0x00, 0x00, 0x00 };
-    unsigned char *whichangle;
+    static const unsigned char r90[] = { 0x42, 0x5a, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
+    static const unsigned char r180[] = { 0x42, 0xb4, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
+    static const unsigned char r270[] = { 0x43, 0x10, 0xe0, 0x00, 0x00, 0x00, 0x00, 0x00 };
+    const unsigned char *whichangle;
     int x, y, topx, topy, rows, cols, xxlate, yxlate, hdrsize;
     int rectype, stransflags;
     Transform *t;
@@ -1579,7 +1579,7 @@ calmaOutStructNameZ(
     unsigned char c;
     char *cp;
     int calmanum;
-    char *table;
+    const char *table;
 
     if (CIFCurStyle->cs_flags & CWF_PERMISSIVE_LABELS)
     {
@@ -2638,7 +2638,8 @@ calmaOutStringRecordZ(
 {
     int len;
     unsigned char c;
-    char *table, *locstr, *origstr = NULL;
+    const char *table;
+    char *locstr, *origstr = NULL;
     char *locstrprv;
 
     if(CIFCurStyle->cs_flags & CWF_PERMISSIVE_LABELS)
@@ -2808,7 +2809,7 @@ calmaOutR8Z(
 
 void
 calmaOut8Z(
-    char *str,	/* 8-byte string to be output */
+    const char *str,	/* 8-byte string to be output */
     gzFile f)	/* Compressed stream file */
 {
     int i;

--- a/calma/CalmaWriteZ.c
+++ b/calma/CalmaWriteZ.c
@@ -25,7 +25,7 @@
  */
 
 #ifndef lint
-static char rcsid[] __attribute__ ((unused)) ="$Header: /usr/cvsroot/magic-8.0/calma/CalmaWrite.c,v 1.8 2010/12/22 16:29:06 tim Exp $";
+static const char rcsid[] __attribute__ ((unused)) ="$Header: /usr/cvsroot/magic-8.0/calma/CalmaWrite.c,v 1.8 2010/12/22 16:29:06 tim Exp $";
 #endif  /* not lint */
 
 #ifdef HAVE_ZLIB

--- a/calma/calmaInt.h
+++ b/calma/calmaInt.h
@@ -226,8 +226,8 @@ typedef struct portlabel
 
 /* Other commonly used globals */
 extern HashTable calmaLayerHash;
-extern int calmaElementIgnore[];
-extern CellDef *calmaFindCell(char *name, bool *was_called, bool *predefined);
+extern const int calmaElementIgnore[];
+extern CellDef *calmaFindCell(const char *name, bool *was_called, bool *predefined);
 
 /* (Added by Nishit, 8/18/2004--8/24/2004) */
 extern CellDef *calmaLookCell(char *name);
@@ -235,8 +235,8 @@ extern void calmaWriteContacts(FILE *f);
 extern CellDef *calmaGetContactCell(TileType type, bool lookOnly);
 extern bool calmaIsContactCell;
 
-extern char *calmaRecordName(int rtype);
-extern void calmaSkipSet(int *skipwhat);
+extern const char *calmaRecordName(int rtype);
+extern void calmaSkipSet(const int *skipwhat);
 extern bool calmaParseUnits(void);
 
 extern int compport(const void *one, const void *two);

--- a/cif/CIFgen.c
+++ b/cif/CIFgen.c
@@ -18,7 +18,7 @@
  */
 
 #ifndef lint
-static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/cif/CIFgen.c,v 1.23 2010/06/24 20:35:54 tim Exp $";
+static const char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/cif/CIFgen.c,v 1.23 2010/06/24 20:35:54 tim Exp $";
 #endif  /* not lint */
 
 #include <stdio.h>

--- a/cif/CIFgen.c
+++ b/cif/CIFgen.c
@@ -67,8 +67,8 @@ global Plane *CIFPlanes[MAXCIFLAYERS];
  * have two entries each.
  */
 
-PaintResultType CIFPaintTable[] = {CIF_SOLIDTYPE, CIF_SOLIDTYPE};
-PaintResultType CIFEraseTable[] = {TT_SPACE, TT_SPACE};
+const PaintResultType CIFPaintTable[] = {CIF_SOLIDTYPE, CIF_SOLIDTYPE};
+const PaintResultType CIFEraseTable[] = {TT_SPACE, TT_SPACE};
 
 /* The following local variables are used as a convenience to pass
  * information between CIFGen and the various search functions.
@@ -549,7 +549,7 @@ cifGrowGridFunc(
 int
 cifGrowEuclideanFunc(
     Tile *tile,
-    PaintResultType *table)		/* Table to be used for painting. */
+    const PaintResultType *table)		/* Table to be used for painting. */
 {
     Tile *tp;
     Rect area, rtmp;
@@ -762,7 +762,7 @@ cifGrowEuclideanFunc(
 int
 cifGrowFunc(
     Tile *tile,
-    PaintResultType *table)		/* Table to be used for painting. */
+    const PaintResultType *table)		/* Table to be used for painting. */
 {
     Rect area;
     TileType oldType = TiGetTypeExact(tile);

--- a/cif/CIFhier.c
+++ b/cif/CIFhier.c
@@ -22,7 +22,7 @@
  */
 
 #ifndef lint
-static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/cif/CIFhier.c,v 1.3 2010/06/24 12:37:15 tim Exp $";
+static const char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/cif/CIFhier.c,v 1.3 2010/06/24 12:37:15 tim Exp $";
 #endif  /* not lint */
 
 #include <stdio.h>

--- a/cif/CIFint.h
+++ b/cif/CIFint.h
@@ -374,7 +374,7 @@ extern int CIFHierRects;
 
 /* Tables used for painting and erasing CIF. */
 
-extern PaintResultType CIFPaintTable[], CIFEraseTable[];
+extern const PaintResultType CIFPaintTable[], CIFEraseTable[];
 
 /* Procedures and variables for reporting errors. */
 

--- a/cif/CIFmain.c
+++ b/cif/CIFmain.c
@@ -17,7 +17,7 @@
  */
 
 #ifndef lint
-static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/cif/CIFmain.c,v 1.3 2009/01/15 15:44:34 tim Exp $";
+static const char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/cif/CIFmain.c,v 1.3 2009/01/15 15:44:34 tim Exp $";
 #endif  /* not lint */
 
 #include <stdio.h>

--- a/cif/CIFrdcl.c
+++ b/cif/CIFrdcl.c
@@ -19,7 +19,7 @@
  */
 
 #ifndef lint
-static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/cif/CIFrdcl.c,v 1.5 2010/08/25 17:33:55 tim Exp $";
+static const char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/cif/CIFrdcl.c,v 1.5 2010/08/25 17:33:55 tim Exp $";
 #endif  /* not lint */
 
 #include <stdio.h>

--- a/cif/CIFrdpoly.c
+++ b/cif/CIFrdpoly.c
@@ -234,7 +234,7 @@ LinkedRect *
 CIFPolyToRects(
     CIFPath *path,		/* Path describing a polygon. */
     Plane *plane,		/* Plane to draw on */
-    PaintResultType *resultTbl,
+    const PaintResultType *resultTbl,
     PaintUndoInfo *ui,
     bool isCalma)		/* TRUE for Calma, FALSE for CIF */
 {

--- a/cif/CIFrdpoly.c
+++ b/cif/CIFrdpoly.c
@@ -17,7 +17,7 @@
  */
 
 #ifndef lint
-static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/cif/CIFrdpoly.c,v 1.3 2010/06/24 12:37:15 tim Exp $";
+static const char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/cif/CIFrdpoly.c,v 1.3 2010/06/24 12:37:15 tim Exp $";
 #endif  /* not lint */
 
 #include <stdio.h>

--- a/cif/CIFrdpoly.c
+++ b/cif/CIFrdpoly.c
@@ -55,10 +55,14 @@ static const char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magi
  */
 
 int
-cifLowX(a, b)
-    CIFPath **a, **b;
+cifLowX(
+    const void *aa,
+    const void *bb)
 {
-    Point *p, *q;
+    const CIFPath **a = (const CIFPath **)aa;
+    const CIFPath **b = (const CIFPath **)bb;
+
+    const Point *p, *q;
 
     p = &(*a)->cifp_point;
     q = &(*b)->cifp_point;
@@ -88,9 +92,12 @@ cifLowX(a, b)
  */
 
 int
-cifLowY(a, b)
-    Point **a, **b;
+cifLowY(
+    const void *aa,
+    const void *bb)
 {
+    const Point **a = (const Point **)aa;
+    const Point **b = (const Point **)bb;
     if ((*a)->p_y < (*b)->p_y)
 	return (-1);
     if ((*a)->p_y > (*b)->p_y)

--- a/cif/CIFrdpt.c
+++ b/cif/CIFrdpt.c
@@ -18,7 +18,7 @@
  */
 
 #ifndef lint
-static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/cif/CIFrdpt.c,v 1.2 2010/06/24 12:37:15 tim Exp $";
+static const char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/cif/CIFrdpt.c,v 1.2 2010/06/24 12:37:15 tim Exp $";
 #endif  /* not lint */
 
 #include <stdio.h>

--- a/cif/CIFrdpt.c
+++ b/cif/CIFrdpt.c
@@ -321,7 +321,7 @@ CIFPaintWirePath(
     int width,
     bool endcap,
     Plane *plane,
-    PaintResultType *ptable,
+    const PaintResultType *ptable,
     PaintUndoInfo *ui)
 {
     CIFPath *pathp, *previousp, *nextp, *polypath;

--- a/cif/CIFrdtech.c
+++ b/cif/CIFrdtech.c
@@ -18,7 +18,7 @@
  */
 
 #ifndef lint
-static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/cif/CIFrdtech.c,v 1.4 2010/09/15 15:45:30 tim Exp $";
+static const char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/cif/CIFrdtech.c,v 1.4 2010/09/15 15:45:30 tim Exp $";
 #endif  /* not lint */
 
 #include <stdio.h>

--- a/cif/CIFrdutils.c
+++ b/cif/CIFrdutils.c
@@ -19,7 +19,7 @@
  */
 
 #ifndef lint
-static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/cif/CIFrdutils.c,v 1.4 2010/06/24 12:37:15 tim Exp $";
+static const char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/cif/CIFrdutils.c,v 1.4 2010/06/24 12:37:15 tim Exp $";
 #endif  /* not lint */
 
 #include <stdio.h>

--- a/cif/CIFrdutils.c
+++ b/cif/CIFrdutils.c
@@ -1052,7 +1052,7 @@ void
 CIFMakeManhattanPath(
     CIFPath *pathHead,
     Plane *plane,
-    PaintResultType *resultTbl,
+    const PaintResultType *resultTbl,
     PaintUndoInfo *ui)
 {
     CIFPath *new, *new2, *next, *path;

--- a/cif/CIFread.h
+++ b/cif/CIFread.h
@@ -174,7 +174,7 @@ extern void CIFFreePath(CIFPath *path);
 extern void CIFCleanPath(CIFPath *pathHead);
 extern void CIFReadCellInit(int ptrkeys);
 extern void CIFReadCellCleanup(int filetype);
-extern LinkedRect *CIFPolyToRects(CIFPath *path, Plane *plane, PaintResultType *resultTbl,
+extern LinkedRect *CIFPolyToRects(CIFPath *path, Plane *plane, const PaintResultType *resultTbl,
                                   PaintUndoInfo *ui, bool isCalma);
 extern const Transform *CIFDirectionToTrans(const Point *point);
 extern int CIFReadNameToType(char *name, bool newOK);
@@ -182,8 +182,9 @@ extern int CIFReadNameToType(char *name, bool newOK);
 extern int CIFCalmaLayerToCifLayer(int layer, int datatype, CIFReadStyle *calmaStyle);
 extern void CIFPropRecordPath(CellDef *def, CIFPath *pathheadp, bool iswire, char *propname);
 extern void CIFPaintWirePath(CIFPath *pathheadp, int width, bool endcap, Plane *plane,
-                             PaintResultType *ptable, PaintUndoInfo *ui);
-extern void CIFMakeManhattanPath(CIFPath *pathHead, Plane *plane, PaintResultType *resultTbl, PaintUndoInfo *ui);
+                             const PaintResultType *ptable, PaintUndoInfo *ui);
+extern void CIFMakeManhattanPath(CIFPath *pathHead, Plane *plane, const PaintResultType *resultTbl, PaintUndoInfo *ui);
+
 extern int CIFEdgeDirection(CIFPath *first, CIFPath *last);
 
 /* Variable argument procedures require complete prototype */

--- a/cif/CIFsee.c
+++ b/cif/CIFsee.c
@@ -17,7 +17,7 @@
  */
 
 #ifndef lint
-static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/cif/CIFsee.c,v 1.5 2010/06/24 12:37:15 tim Exp $";
+static const char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/cif/CIFsee.c,v 1.5 2010/06/24 12:37:15 tim Exp $";
 #endif  /* not lint */
 
 #include <stdio.h>

--- a/cif/CIFtech.c
+++ b/cif/CIFtech.c
@@ -18,7 +18,7 @@
  */
 
 #ifndef lint
-static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/cif/CIFtech.c,v 1.7 2010/10/20 20:34:19 tim Exp $";
+static const char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/cif/CIFtech.c,v 1.7 2010/10/20 20:34:19 tim Exp $";
 #endif  /* not lint */
 
 #include <stdio.h>

--- a/cif/CIFwrite.c
+++ b/cif/CIFwrite.c
@@ -17,7 +17,7 @@
  */
 
 #ifndef lint
-static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/cif/CIFwrite.c,v 1.2 2010/06/24 12:37:15 tim Exp $";
+static const char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/cif/CIFwrite.c,v 1.2 2010/06/24 12:37:15 tim Exp $";
 #endif  /* not lint */
 
 #include <stdlib.h>

--- a/cmwind/CMWcmmnds.c
+++ b/cmwind/CMWcmmnds.c
@@ -143,8 +143,8 @@ cmwButtonDown(
     Point *p,
     int button)
 {
-    ColorBar *cb;
-    ColorPump *cp;
+    const ColorBar *cb;
+    const ColorPump *cp;
     Point surfacePoint;
     int x;
     double dx;
@@ -598,8 +598,8 @@ cmwRedisplayFunc(
 				 * color bars in the window.
 				 */
 {
-    ColorBar *cb;
-    ColorPump *cp;
+    const ColorBar *cb;
+    const ColorPump *cp;
     Rect screenR;
     CMWclientRec *cr = (CMWclientRec *) w->w_clientData;
 
@@ -649,7 +649,7 @@ CMWCheckWritten(void)
 {
     bool indx;
     char *prompt;
-    static char *(yesno[]) = {"no", "yes", NULL};
+    static const char * const (yesno[]) = {"no", "yes", NULL};
 
     if (!cmwModified) return TRUE;
     prompt = TxPrintString("The color map has been modified.\n"

--- a/cmwind/CMWcmmnds.c
+++ b/cmwind/CMWcmmnds.c
@@ -17,7 +17,7 @@
  */
 
 #ifndef lint
-static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/cmwind/CMWcmmnds.c,v 1.1.1.1 2008/02/03 20:43:50 tim Exp $";
+static const char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/cmwind/CMWcmmnds.c,v 1.1.1.1 2008/02/03 20:43:50 tim Exp $";
 #endif  /* not lint */
 
 #include <stdio.h>

--- a/cmwind/CMWcmmnds.c
+++ b/cmwind/CMWcmmnds.c
@@ -649,7 +649,7 @@ CMWCheckWritten(void)
 {
     bool indx;
     char *prompt;
-    static const char * const (yesno[]) = {"no", "yes", NULL};
+    static const char * const yesno[] = {"no", "yes", NULL};
 
     if (!cmwModified) return TRUE;
     prompt = TxPrintString("The color map has been modified.\n"

--- a/cmwind/CMWmain.c
+++ b/cmwind/CMWmain.c
@@ -18,7 +18,7 @@
  */
 
 #ifndef lint
-static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/cmwind/CMWmain.c,v 1.1.1.1 2008/02/03 20:43:50 tim Exp $";
+static const char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/cmwind/CMWmain.c,v 1.1.1.1 2008/02/03 20:43:50 tim Exp $";
 #endif  /* not lint */
 
 #include <stdio.h>

--- a/cmwind/CMWmain.c
+++ b/cmwind/CMWmain.c
@@ -89,7 +89,7 @@ extern void CMWundoInit(void);
  * which pump is hit and which mouse button is used to hit it.
  */
 
-ColorBar colorBars[] =
+const ColorBar const colorBars[] =
 {
     {"Red",	CB_RED,		STYLE_RED,	{{ 2000,	8000},	{10000,	 9000}},
 						{{ 2000,	9500},	{10000,	10500}}},
@@ -106,7 +106,7 @@ ColorBar colorBars[] =
     {0}
 };
 
-ColorPump colorPumps[] =
+const ColorPump const colorPumps[] =
 {
     {CB_RED,	-.0078,	{{  500, 8000},	{ 1500,	9000}}},
     {CB_RED,	 .0078,	{{10500, 8000},	{11500,	9000}}},
@@ -123,13 +123,13 @@ ColorPump colorPumps[] =
     {-1}
 };
 
-Rect cmwCurrentColorArea = {{6000, 12000}, {18000, 15000}};
-Rect cmwCurrentColorTextBox = {{6000, 15500}, {18000, 16500}};
-char *cmwCurrentColorText = "Color Being Edited";
+const Rect cmwCurrentColorArea = {{6000, 12000}, {18000, 15000}};
+const Rect cmwCurrentColorTextBox = {{6000, 15500}, {18000, 16500}};
+const char * const cmwCurrentColorText = "Color Being Edited";
 
 /* Bounding rectangle for entire window */
 
-Rect colorWindowRect = {{0, 1500}, {24000, 17000}};
+const Rect colorWindowRect = {{0, 1500}, {24000, 17000}};
 
 /*
  * ----------------------------------------------------------------------------
@@ -250,8 +250,8 @@ CMWredisplay(
     Rect *clipArea)	/* An area on the screen to clip to. */
 {
     CMWclientRec *cr;
-    ColorBar *cb;
-    ColorPump *cp;
+    const ColorBar *cb;
+    const ColorPump *cp;
     Rect rect, screenR;
     Point screenP;
     double values[6], x;

--- a/cmwind/CMWrgbhsv.c
+++ b/cmwind/CMWrgbhsv.c
@@ -18,7 +18,7 @@
  */
 
 #ifndef lint
-static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/cmwind/CMWrgbhsv.c,v 1.1.1.1 2008/02/03 20:43:50 tim Exp $";
+static const char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/cmwind/CMWrgbhsv.c,v 1.1.1.1 2008/02/03 20:43:50 tim Exp $";
 #endif  /* not lint */
 
 #include <stdio.h>

--- a/cmwind/CMWundo.c
+++ b/cmwind/CMWundo.c
@@ -17,7 +17,7 @@
  */
 
 #ifndef lint
-static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/cmwind/CMWundo.c,v 1.1.1.1 2008/02/03 20:43:50 tim Exp $";
+static const char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/cmwind/CMWundo.c,v 1.1.1.1 2008/02/03 20:43:50 tim Exp $";
 #endif  /* not lint */
 
 #include <stdio.h>

--- a/cmwind/cmwind.h
+++ b/cmwind/cmwind.h
@@ -69,11 +69,11 @@ typedef struct
 extern void CMWloadWindow(MagWindow *, int);
 extern void CMWcommand(MagWindow *, TxCommand *);
 
-extern Rect colorWindowRect;
+extern const Rect colorWindowRect;
 extern WindClient CMWclientID;
-extern ColorBar colorBars[];
-extern ColorPump colorPumps[];
-extern Rect cmwCurrentColorArea;
+extern const ColorBar colorBars[];
+extern const ColorPump colorPumps[];
+extern const Rect cmwCurrentColorArea;
 extern void cmwUndoColor(int, int, int, int, int, int, int);
 extern bool CMWCheckWritten(void);
 

--- a/commands/CmdAB.c
+++ b/commands/CmdAB.c
@@ -17,7 +17,7 @@
  */
 
 #ifndef lint
-static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/commands/CmdAB.c,v 1.1.1.1 2008/02/03 20:43:50 tim Exp $";
+static const char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/commands/CmdAB.c,v 1.1.1.1 2008/02/03 20:43:50 tim Exp $";
 #endif  /* not lint */
 
 #include <stdio.h>

--- a/commands/CmdCD.c
+++ b/commands/CmdCD.c
@@ -17,7 +17,7 @@
  */
 
 #ifndef lint
-static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/commands/CmdCD.c,v 1.7 2010/06/24 12:37:15 tim Exp $";
+static const char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/commands/CmdCD.c,v 1.7 2010/06/24 12:37:15 tim Exp $";
 #endif  /* not lint */
 
 #include <stdio.h>

--- a/commands/CmdE.c
+++ b/commands/CmdE.c
@@ -201,7 +201,7 @@ cmdEditRedisplayFunc(
     MagWindow *w,			/* Window containing edit cell. */
     Rect *area)			/* Area to be redisplayed. */
 {
-    static Rect origin = {{-1, -1}, {1, 1}};
+    static const Rect origin = {-1, -1, 1, 1};
     Rect tmp;
     DBWclientRec *crec = (DBWclientRec *) w->w_clientData;
 

--- a/commands/CmdE.c
+++ b/commands/CmdE.c
@@ -17,7 +17,7 @@
  */
 
 #ifndef lint
-static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/commands/CmdE.c,v 1.4 2010/06/17 14:38:33 tim Exp $";
+static const char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/commands/CmdE.c,v 1.4 2010/06/17 14:38:33 tim Exp $";
 #endif  /* not lint */
 
 #include <stdio.h>

--- a/commands/CmdFI.c
+++ b/commands/CmdFI.c
@@ -17,7 +17,7 @@
  */
 
 #ifndef lint
-static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/commands/CmdFI.c,v 1.4 2010/06/24 12:37:15 tim Exp $";
+static const char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/commands/CmdFI.c,v 1.4 2010/06/24 12:37:15 tim Exp $";
 #endif  /* not lint */
 
 #include <stdio.h>

--- a/commands/CmdFI.c
+++ b/commands/CmdFI.c
@@ -942,7 +942,7 @@ CmdFlush(
 {
     CellDef *def;
     int action;
-    static char *actionNames[] = { "no", "yes", 0 };
+    static const char * const actionNames[] = { "no", "yes", 0 };
     char *prompt;
     bool dereference = FALSE;
     char *strNoConfirm;

--- a/commands/CmdLQ.c
+++ b/commands/CmdLQ.c
@@ -17,7 +17,7 @@
  */
 
 #ifndef lint
-static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/commands/CmdLQ.c,v 1.9 2010/06/24 12:37:15 tim Exp $";
+static const char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/commands/CmdLQ.c,v 1.9 2010/06/24 12:37:15 tim Exp $";
 #endif  /* not lint */
 
 #include <stdio.h>

--- a/commands/CmdLQ.c
+++ b/commands/CmdLQ.c
@@ -1566,7 +1566,7 @@ CmdPort(
 	NULL
     };
 
-    static int cmdClassToBitmask[] =
+    static const int cmdClassToBitmask[] =
     {
 	PORT_CLASS_DEFAULT,
 	PORT_CLASS_INPUT,
@@ -1590,7 +1590,7 @@ CmdPort(
 	NULL
     };
 
-    static int cmdUseToBitmask[] =
+    static const int cmdUseToBitmask[] =
     {
 	PORT_USE_DEFAULT,
 	PORT_USE_ANALOG,
@@ -1611,7 +1611,7 @@ CmdPort(
 	NULL
     };
 
-    static int cmdShapeToBitmask[] =
+    static const int cmdShapeToBitmask[] =
     {
 	PORT_SHAPE_DEFAULT,
 	PORT_SHAPE_ABUT,

--- a/commands/CmdRS.c
+++ b/commands/CmdRS.c
@@ -17,7 +17,7 @@
  */
 
 #ifndef lint
-static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/commands/CmdRS.c,v 1.13 2010/06/24 12:37:15 tim Exp $";
+static const char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/commands/CmdRS.c,v 1.13 2010/06/24 12:37:15 tim Exp $";
 #endif  /* not lint */
 
 #include <stdio.h>

--- a/commands/CmdSubrs.c
+++ b/commands/CmdSubrs.c
@@ -720,7 +720,7 @@ cmdCheckNewName(
     bool tryRename,
     bool noninteractive)
 {
-    static char *yesno[] = { "no", "yes", 0 };
+    static const char * const yesno[] = { "no", "yes", 0 };
     char *filename;
     char *prompt;
     char *returnname;
@@ -1076,7 +1076,7 @@ CmdWarnWrite(void)
 {
     int count, code;
     int cmdWarnWriteFunc(CellDef *cellDef, int *pcount);
-    static char *yesno[] = { "no", "yes", 0 };
+    static const char * const yesno[] = { "no", "yes", 0 };
     char *prompt;
 
     count = 0;

--- a/commands/CmdSubrs.c
+++ b/commands/CmdSubrs.c
@@ -18,7 +18,7 @@
  */
 
 #ifndef lint
-static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/commands/CmdSubrs.c,v 1.2 2010/06/24 12:37:15 tim Exp $";
+static const char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/commands/CmdSubrs.c,v 1.2 2010/06/24 12:37:15 tim Exp $";
 #endif  /* not lint */
 
 #include <stdio.h>

--- a/commands/CmdTZ.c
+++ b/commands/CmdTZ.c
@@ -1932,9 +1932,9 @@ cmdWriteallFunc(
 {
     char *prompt, *argv;
     int i, action, cidx = 0;
-    static char *actionNames[] =
+    static const char * const actionNames[] =
         { "write", "flush", "skip", "abort", "autowrite", 0 };
-    static char *explain[] =
+    static const char * const explain[] =
 	{ "", "(bboxes)", "(timestamps)", "(bboxes/timestamps)", 0 };
 
     if (def->cd_flags & CDINTERNAL) return 0;

--- a/commands/CmdTZ.c
+++ b/commands/CmdTZ.c
@@ -17,7 +17,7 @@
  */
 
 #ifndef lint
-static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/commands/CmdTZ.c,v 1.8 2010/06/24 12:37:15 tim Exp $";
+static const char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/commands/CmdTZ.c,v 1.8 2010/06/24 12:37:15 tim Exp $";
 #endif  /* not lint */
 
 #include <stdio.h>

--- a/commands/CmdWizard.c
+++ b/commands/CmdWizard.c
@@ -20,7 +20,7 @@
  */
 
 #ifndef lint
-static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/commands/CmdWizard.c,v 1.2 2008/02/10 19:30:19 tim Exp $";
+static const char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/commands/CmdWizard.c,v 1.2 2008/02/10 19:30:19 tim Exp $";
 #endif  /* not lint */
 
 #include <stdio.h>

--- a/database/DBpaint.c
+++ b/database/DBpaint.c
@@ -240,7 +240,7 @@ int
 DBPaintPlane0(plane, area, resultTbl, undo, method)
     Plane *plane;		/* Plane whose paint is to be modified */
     Rect *area;			/* Area to be changed */
-    PaintResultType *resultTbl;	/* Table, indexed by the type of tile already
+    const PaintResultType *resultTbl;	/* Table, indexed by the type of tile already
 				 * present in the plane, giving the type to
 				 * which the existing tile must change as a
 				 * result of this paint operation.
@@ -766,7 +766,7 @@ void
 DBFracturePlane(plane, area, resultTbl, undo)
     Plane *plane;		/* Plane whose paint is to be modified */
     Rect *area;	/* Area to be changed */
-    PaintResultType *resultTbl;	/* Paint table, to pinpoint those tiles
+    const PaintResultType *resultTbl;	/* Paint table, to pinpoint those tiles
 				 * that interact with the paint type.
 				 */
     PaintUndoInfo *undo;	/* Record containing everything needed to
@@ -1340,7 +1340,7 @@ DBDiagonalProc(oldtype, dinfo)
     TileType old_n, old_s, old_e, old_w;
     TileType new_n, new_s, new_e, new_w;
     TileType newtype;
-    PaintResultType *resultTbl = dinfo->resultTbl;
+    const PaintResultType *resultTbl = dinfo->resultTbl;
 
     /* Disassemble old and new types into four quadrants, find the	*/
     /* paint result for each quadrant, then reassemble the result.	*/
@@ -1457,7 +1457,7 @@ DBNMPaintPlane0(plane, exacttype, area, resultTbl, undo, method)
     Plane *plane;		/* Plane whose paint is to be modified */
     TileType exacttype;		/* diagonal info for tile to be changed */
     Rect *area;	/* Area to be changed */
-    PaintResultType *resultTbl;	/* Table, indexed by the type of tile already
+    const PaintResultType *resultTbl;	/* Table, indexed by the type of tile already
 				 * present in the plane, giving the type to
 				 * which the existing tile must change as a
 				 * result of this paint operation.
@@ -2064,7 +2064,7 @@ void
 DBPaintType(plane, area, resultTbl, client, undo, tileMask)
     Plane *plane;		/* Plane whose paint is to be modified */
     Rect *area;	/* Area to be changed */
-    PaintResultType *resultTbl;	/* Table, indexed by the type of tile already
+    const PaintResultType *resultTbl;	/* Table, indexed by the type of tile already
 				 * present in the plane, giving the type to
 				 * which the existing tile must change as a
 				 * result of this paint operation.
@@ -2555,7 +2555,7 @@ int
 DBPaintPlaneVert(plane, area, resultTbl, undo)
     Plane *plane;		/* Plane whose paint is to be modified */
     Rect *area;	/* Area to be changed */
-    PaintResultType *resultTbl;	/* Table, indexed by the type of tile already
+    const PaintResultType *resultTbl;	/* Table, indexed by the type of tile already
 				 * present in the plane, giving the type to
 				 * which the existing tile must change as a
 				 * result of this paint operation.

--- a/debug/debug.h
+++ b/debug/debug.h
@@ -28,7 +28,7 @@
 
 struct debugClient
 {
-    char		*dc_name;	/* Name of client */
+    const char		*dc_name;	/* Name of client */
     int			 dc_maxflags;	/* Maximum number of flags */
     int			 dc_nflags;	/* Number flags now in array */
     struct debugFlag	*dc_flags;	/* Array of flags */
@@ -36,7 +36,7 @@ struct debugClient
 
 struct debugFlag
 {
-    char	*df_name;	/* Name of debugging flag */
+    const char	*df_name;	/* Name of debugging flag */
     bool	 df_value;	/* Current value of the flag */
 };
 
@@ -71,8 +71,8 @@ extern struct debugClient debugClients[];
 extern void HistCreate(const char *name, int ptrKeys, int low, int step, int bins);
 extern void HistAdd(const char *name, int ptrKeys, int value);
 extern void HistPrint(const char *name);
-extern ClientData DebugAddClient(char *name, int maxflags);
-extern int DebugAddFlag(ClientData clientID, char *name);
+extern ClientData DebugAddClient(const char *name, int maxflags);
+extern int DebugAddFlag(ClientData clientID, const char *name);
 extern void DebugShow(ClientData clientID);
 extern void DebugSet(ClientData clientID, int argc, char *argv[], int value);
 

--- a/debug/debug.h
+++ b/debug/debug.h
@@ -54,7 +54,7 @@ typedef struct histogram
     int		       hi_max;		/* Largest item in the histogram*/
     int		       hi_min;		/* Smallest item in the histogram*/
     int		       hi_cum;		/* Cumulative item total 	*/
-    char             * hi_title;	/* Histogram identifier 	*/
+    const char       * hi_title;	/* Histogram identifier 	*/
     bool	       hi_ptrKeys;	/* TRUE if title is a pointer   */
     int              * hi_data;		/* Buckets for histogram counts	*/
     struct histogram * hi_next;		/* Linked list to next histogram*/
@@ -68,9 +68,9 @@ extern struct debugClient debugClients[];
 #define	DebugIsSet(cid, f)	debugClients[(spointertype) cid].dc_flags[f].df_value
 
 /* procedures */
-extern void HistCreate(char *name, int ptrKeys, int low, int step, int bins);
-extern void HistAdd(char *name, int ptrKeys, int value);
-extern void HistPrint(char *name);
+extern void HistCreate(const char *name, int ptrKeys, int low, int step, int bins);
+extern void HistAdd(const char *name, int ptrKeys, int value);
+extern void HistPrint(const char *name);
 extern ClientData DebugAddClient(char *name, int maxflags);
 extern int DebugAddFlag(ClientData clientID, char *name);
 extern void DebugShow(ClientData clientID);

--- a/debug/debugFlags.c
+++ b/debug/debugFlags.c
@@ -19,7 +19,7 @@
  */
 
 #ifndef lint
-static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/debug/debugFlags.c,v 1.1.1.1 2008/02/03 20:43:50 tim Exp $";
+static const char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/debug/debugFlags.c,v 1.1.1.1 2008/02/03 20:43:50 tim Exp $";
 #endif  /* not lint */
 
 #include <stdio.h>

--- a/debug/debugFlags.c
+++ b/debug/debugFlags.c
@@ -57,7 +57,7 @@ int debugNumClients = 0;
 
 ClientData
 DebugAddClient(name, maxflags)
-    char *name;
+    const char *name;
     int maxflags;
 {
     struct debugClient *dc;
@@ -114,7 +114,7 @@ DebugAddClient(name, maxflags)
 int
 DebugAddFlag(clientID, name)
     ClientData clientID;	/* Client identifier from DebugAddClient */
-    char *name;			/* Name of debugging flag */
+    const char *name;		/* Name of debugging flag */
 {
     int id = (int) clientID;
     struct debugClient *dc;

--- a/debug/hist.c
+++ b/debug/hist.c
@@ -16,7 +16,7 @@
  */
 
 #ifndef lint
-static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/debug/hist.c,v 1.1.1.1 2008/02/03 20:43:50 tim Exp $";
+static const char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/debug/hist.c,v 1.1.1.1 2008/02/03 20:43:50 tim Exp $";
 #endif  /* not lint */
 
 #include <stdio.h>

--- a/debug/hist.c
+++ b/debug/hist.c
@@ -51,7 +51,7 @@ Histogram * hist_list = (Histogram *) NULL;
  */
 Histogram *
 histFind(name, ptrKeys)
-    char * name;
+    const char * name;
     bool ptrKeys;
 {
     Histogram * h;
@@ -82,7 +82,7 @@ histFind(name, ptrKeys)
  */
 void
 HistCreate(name, ptrKeys, low, step, bins)
-    char * name;	/* Name for histogram add and print   */
+    const char * name;	/* Name for histogram add and print   */
     bool   ptrKeys;	/* TRUE if name is a character pointer*/
     int    low;		/* The lowest value for the histogram */
     int    step;	/* The increment for each bin         */
@@ -135,7 +135,7 @@ HistCreate(name, ptrKeys, low, step, bins)
  */
 void
 HistAdd(name, ptrKeys, value)
-    char * name;	/* Identifier for the histogram */
+    const char * name;	/* Identifier for the histogram */
     bool   ptrKeys;	/* TRUE if the name is a pointer*/
     int    value;	/* Value to index the column	*/
 {
@@ -177,7 +177,7 @@ HistAdd(name, ptrKeys, value)
  */
 void
 HistPrint(name)
-    char * name;
+    const char * name;
 {
     FILE * fp, * fopen();
     Histogram * h;

--- a/tcltk/tclmagic.c
+++ b/tcltk/tclmagic.c
@@ -794,7 +794,7 @@ _magic_startup(ClientData clientData,
 int
 TxDialog(prompt, responses, defresp)
     char *prompt;
-    char *(responses[]);
+    char *responses[];
     int defresp;
 {
     Tcl_Obj *objPtr;

--- a/textio/txInput.c
+++ b/textio/txInput.c
@@ -324,7 +324,7 @@ TxReprint()
 int
 TxDialog(prompt, responses, deflt)
     char *prompt;
-    char *(responses[]);
+    char *responses[];
     int deflt;
 {
     int code;


### PR DESCRIPTION
Project directories that have received K&R to ANSI conversion have another tier of commits to tidy up globals and some data structures to move data from .data to .rodata segments and provide APIs using const keywords where possible.