### PR TITLE
gcc: support -Werror=format-security

### DIFF
--- a/ext2spice/ext2spice.c
+++ b/ext2spice/ext2spice.c
@@ -1360,7 +1360,7 @@ spcParseArgs(pargc, pargv)
     int argc = *pargc;
     char *ftmp, *t;
 
-    char usage_text[] = "Usage: ext2spice "
+    const char usage_text[] = "Usage: ext2spice "
 		"[-B] [-o spicefile] [-M|-m] [-J flat|hier]\n"
 		"[-f spice2|spice3|hspice|ngspice] [-M] [-m] "
 		"[file]\n";

--- a/extflat/EFargs.c
+++ b/extflat/EFargs.c
@@ -156,7 +156,7 @@ EFArgs(argc, argv, err_result, argsProc, cdata)
     HierName *hierName;
     FILE *f;
 
-    char usage_text[] =
+    const char usage_text[] =
 	"Standard arguments: [-R] [-C] [-r rthresh] [-c cthresh] [-v]\n"
 		"[-p searchpath] [-s sym=value] [-S symfile] [-t trimchars]\n"
 #ifdef MAGIC_WRAPPER

--- a/windows/windCmdNR.c
+++ b/windows/windCmdNR.c
@@ -158,7 +158,7 @@ windPauseCmd(w, cmd)
 
     for (i = 1; i < cmd->tx_argc; i++)
     {
-	TxPrintf(cmd->tx_argv[i]);
+	TxPrintf("%s", cmd->tx_argv[i]);
 	TxPrintf(" ");
 	if (i+1 == cmd->tx_argc) TxPrintf(" ");
     }


### PR DESCRIPTION
Support gcc -Werror=format-security which is used by default on Fedora.

ext2spice/ext2spice.c: format not a string literal and no format arguments
extflat/EFargs.c: likewise
windows/windCmdNR.c: likewise