### PR TITLE
use-after-free/double-free concern CIFFreePath() non-invalidation

### DIFF
--- a/resis/ResMain.c
+++ b/resis/ResMain.c
@@ -1087,11 +1087,11 @@ ResExtractNet(node, goodies, cellname)
 		    resMakeDevFunc, (ClientData)thisDev);
 	if (result == 0)
 	{
-	    freeMagic(thisDev);
 	    TxError("No device of type %s found at location %d,%d\n",
 		    DBTypeLongNameTbl[thisDev->type],
 		    tptr->thisDev->location.p_x,
 		    tptr->thisDev->location.p_y);
+	    freeMagic(thisDev);
 	    continue;
 	}
 	thisDev->nextDev = DevTiles;


### PR DESCRIPTION
The CodeQL analyser call graph of the theoretical use-after-free/double-free (due to non-invalidation) looks like:

```
1       pointer to free output argument         CIFrdutils.c:1343:12
2       path [Return]           CIFrdutils.c:1339:14
3       pointer to CIFFreePath output argument          CalmaRdpt.c:1160:18
4       *pathheadpp [Return]            CalmaRdpt.c:1113:15
5       calmaReadPath output argument           CalmaRdpt.c:240:24
6       pathheadp               CalmaRdpt.c:288:17
7       path            CIFrdutils.c:1339:14
8       path            CIFrdutils.c:1344:9
```

This is indicating the potential for `CIFFreePath()` will be called twice for the same memory block via this call graph (line numbers related to code pre-patch, might need to fuzz a little)


The other patch is a minor re-order (as this shows up now as a use-after-free when the freeMagic() delay-by-one-dealloc feature is disabled)