### PR TITLE
Always pass TileTypeBitMask by-pointer (not by-value)

### DIFF
--- a/extflat/EFvisit.c
+++ b/extflat/EFvisit.c
@@ -33,7 +33,8 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 #include "utils/malloc.h"
 #include "utils/utils.h"
 #include "extflat/extflat.h"
-#include "extflat/EFint.h"
+#include "database/database.h"  /* before EFint.h for ArrayInfo */
+#include "extflat/EFint.h"      /* also has ArrayInfo */
 #include "tiles/tile.h"
 #include "extract/extract.h"
 

--- a/extract/ExtBasic.c
+++ b/extract/ExtBasic.c
@@ -3250,7 +3250,7 @@ extTransTileFunc(tile, pNum, arg)
     /* The AMD target gcc compile works and the Intel target gcc	*/
     /* compile doesn't!  The following code works the same on both.	*/
 
-    perim = extEnumTilePerim(tile, mask, pNum,
+    perim = extEnumTilePerim(tile, &mask, pNum,
 		extTransPerimFunc, (ClientData)NULL);
     extTransRec.tr_perim += perim;
 
@@ -3876,7 +3876,7 @@ extAnnularTileFunc(tile, pNum)
 
     mask = ExtCurStyle->exts_deviceConn[loctype];
     TTMaskCom(&mask);
-    extEnumTilePerim(tile, mask, pNum, extSpecialPerimFunc, (ClientData) TRUE);
+    extEnumTilePerim(tile, &mask, pNum, extSpecialPerimFunc, (ClientData) TRUE);
     return (0);
 }
 
@@ -3934,7 +3934,7 @@ extResistorTileFunc(tile, pNum)
 	TTMaskSetMask(&mask, &devptr->exts_deviceSDTypes[0]);
 	TTMaskCom(&mask);
 
-	extEnumTilePerim(tile, mask, pNum, extSpecialPerimFunc, (ClientData)FALSE);
+	extEnumTilePerim(tile, &mask, pNum, extSpecialPerimFunc, (ClientData)FALSE);
 
 	if (extSpecialBounds[0] != NULL) break;
 	devptr = devptr->exts_next;

--- a/extract/ExtCouple.c
+++ b/extract/ExtCouple.c
@@ -768,7 +768,7 @@ extBasicCouple(tile, ecs)
     Tile *tile;
     extCapStruct *ecs;
 {
-    (void) extEnumTilePerim(tile, ExtCurStyle->exts_sideEdges[TiGetType(tile)],
+    (void) extEnumTilePerim(tile, &ExtCurStyle->exts_sideEdges[TiGetType(tile)],
 			ecs->plane, extAddCouple, (ClientData) ecs);
     return (0);
 }

--- a/extract/ExtPerim.c
+++ b/extract/ExtPerim.c
@@ -79,13 +79,14 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
  */
 
 int
-extEnumTilePerim(tpIn, mask, pNum, func, cdata)
-    Tile *tpIn;
-    TileTypeBitMask mask;	/* Note: this is not a pointer */
-    int pNum;			/* Plane of perimeter */
-    int (*func)();
-    ClientData cdata;
+extEnumTilePerim(
+    Tile *tpIn,
+    const TileTypeBitMask *maskp,
+    int pNum,			/* Plane of perimeter */
+    int (*func)(),
+    ClientData cdata)
 {
+    TileTypeBitMask mask = *maskp; /* TTMaskCopy(&mask, maskp) */
     TileType origType;
     Tile *tpOut;
     int perimCorrect;

--- a/extract/extract.h
+++ b/extract/extract.h
@@ -106,7 +106,7 @@ extern void ExtGetZAxis();
 
 extern void ExtDumpCaps();
 
-extern int extEnumTilePerim();
+extern int extEnumTilePerim(Tile *tpIn, const TileTypeBitMask *maskp, int pNum, int (*func)(), ClientData cdata);
 extern Plane *extPrepSubstrate();
 
 /* C99 compat */

--- a/extract/extract.h
+++ b/extract/extract.h
@@ -23,6 +23,7 @@
 #define _EXTRACT_H
 
 #include "utils/magic.h"
+#include "database/database.h"  /* TileTypeBitMask */
 
 /* Extractor warnings */
 #define	EXTWARN_DUP	0x01	/* Warn if two nodes have the same name */

--- a/garouter/gaMaze.c
+++ b/garouter/gaMaze.c
@@ -180,27 +180,28 @@ GAMazeInitParms()
  */
 
 bool
-gaMazeRoute(routeUse, terminalLoc, pinPoint, pinLayerMask, side, writeFlag)
-    CellUse *routeUse;		/* Cell to route in - top level cell visible
+gaMazeRoute(
+    CellUse *routeUse,		/* Cell to route in - top level cell visible
 				 * to router and also cell route is painted
 				 * into.  All subcells are treated as expanded
 				 * by the router, i.e. their contents are
 				 * examined.  And routing across the tops of
 				 * subcells is permitted.
 				 */
-    NLTermLoc *terminalLoc;	/* Terminal to connect to - somewhere in
+    NLTermLoc *terminalLoc,	/* Terminal to connect to - somewhere in
 				 * interior of cell */
-    Point *pinPoint;		/* Point to connect from (on edge of cell) */
-    TileTypeBitMask pinLayerMask;	/* layer at pin (no more than one
+    Point *pinPoint,		/* Point to connect from (on edge of cell) */
+    const TileTypeBitMask *pinLayerMaskp,/* layer at pin (no more than one
 					 * bit should correspond to a known
 					 * routing layer)
 					 */
-    int side;			/* side of cell destPoint lies on */
-    bool writeFlag;	        /* If non-null, paint back result (into
+    int side,			/* side of cell destPoint lies on */
+    bool writeFlag)	        /* If non-null, paint back result (into
 				 * routeUse), otherwise just check if
 				 * route is possible.
 				 */
 {
+    TileTypeBitMask pinLayerMask = *pinLayerMaskp; // TTMaskCopy(&pinLayerMask, pinLayerMaskp);
     Rect routeBounds;
     bool done = FALSE;
 

--- a/garouter/gaStem.c
+++ b/garouter/gaStem.c
@@ -731,9 +731,9 @@ hardway:
 	TTMaskSetOnlyType(&polyMask, RtrPolyType);
 	TTMaskSetOnlyType(&metalMask, RtrMetalType);
 
-	if(gaMazeRoute(routeUse, terminalLoc, gridPoint, polyMask, side,
+	if(gaMazeRoute(routeUse, terminalLoc, gridPoint, &polyMask, side,
 		       writeFlag)  &&
-	   gaMazeRoute(routeUse, terminalLoc, gridPoint, metalMask, side,
+	   gaMazeRoute(routeUse, terminalLoc, gridPoint, &metalMask, side,
 		       writeFlag))
 	{
 	    gaNumMazeStem++;
@@ -1123,7 +1123,7 @@ gaStemPaint(routeUse, terminalLoc)
 		goto totalLoss;
 
 
-	if(gaMazeRoute(routeUse, terminalLoc, pinPoint, pinLayerMask, side,
+	if(gaMazeRoute(routeUse, terminalLoc, pinPoint, &pinLayerMask, side,
 		       writeResult))
 	{
 	    gaNumMazePaint++;

--- a/garouter/garouter.h
+++ b/garouter/garouter.h
@@ -22,6 +22,7 @@
 #define _GAROUTER_H
 
 #include "grouter/grouter.h"
+#include "utils/netlist.h"      /* NLTermLoc */
 
 /*
  * The following structure describes "simple stems" -- routes
@@ -88,7 +89,8 @@ extern ClientData gaDebugID;	/* Our identity with the debugging module */
 extern GCRChannel *gaStemContainingChannel();
 extern GCRPin *gaStemCheckPin();
 extern int gaAlwaysOne();
-extern bool gaMazeRoute();
+extern bool gaMazeRoute(CellUse *routeUse, NLTermLoc *terminalLoc, Point *pinPoint,
+                        const TileTypeBitMask *pinLayerMaskp, int side, bool writeFlag);
 
 /* Exported procedures */
 extern int GARoute();

--- a/irouter/irRoute.c
+++ b/irouter/irRoute.c
@@ -881,15 +881,15 @@ irSelectedTileFunc(rect, type, c)
  */
 
 bool
-LayerInTouchingContact(rL,touchingTypes)
-    RouteLayer *rL;
-    TileTypeBitMask touchingTypes;
+LayerInTouchingContact(
+    RouteLayer *rL,
+    const TileTypeBitMask *touchingTypes)
 {
     RouteContact *rC;
 
     for(rC=irRouteContacts; rC!=NULL; rC=rC->rc_next)
     {
-	if(TTMaskHasType(&touchingTypes,rC->rc_routeType.rt_tileType) &&
+	if(TTMaskHasType(touchingTypes,rC->rc_routeType.rt_tileType) &&
 	        (rC->rc_rLayer1==rL || rC->rc_rLayer2==rL))
 	    return(TRUE);
     }
@@ -1012,7 +1012,7 @@ irChooseEndPtLayers(routeUse,expansionMask,endPt,argLayers,endPtName)
 	{
 	    rL = (RouteLayer *) LIST_FIRST(l);
 	    if((TTMaskHasType(&touchingTypes,rL->rl_routeType.rt_tileType) ||
-		    LayerInTouchingContact(rL,touchingTypes)) &&
+		    LayerInTouchingContact(rL,&touchingTypes)) &&
 		    !ListContainsP(rL, presentContactLayers))
 	    {
 		LIST_ADD(rL,presentLayers);

--- a/plow/PlowCmd.c
+++ b/plow/PlowCmd.c
@@ -212,7 +212,7 @@ wrongNumArgs:
 	    layers = cmd->tx_argc == 2 ? "*,l,subcell,space" : cmd->tx_argv[2];
 	    if (!CmdParseLayers(layers, &mask))
 		break;
-	    if (Plow(editDef, &editBox, mask, dir))
+	    if (Plow(editDef, &editBox, &mask, dir))
 		break;
 
 	    TxPrintf("Reduced plow size to stay within the boundary.\n");

--- a/plow/PlowJogs.c
+++ b/plow/PlowJogs.c
@@ -189,12 +189,12 @@ plowProcessJog(edge, area)
      * it returns 1 and aborts.  We must therefore iterate until no more
      * jogs are eliminated.
      */
-    while (plowSrShadowBack(edge->e_pNum, &r, DBSpaceBits,
+    while (plowSrShadowBack(edge->e_pNum, &r, &DBSpaceBits,
 		plowProcessJogFunc, (ClientData) area))
 	/* Nothing */;
 
     /* Scan to next edge between space and material */
-    (void) plowSrShadowBack(edge->e_pNum, &r, DBAllButSpaceBits,
+    (void) plowSrShadowBack(edge->e_pNum, &r, &DBAllButSpaceBits,
 		plowJogPropagateLeft, (ClientData) NULL);
 }
 
@@ -372,7 +372,7 @@ plowProcessJogFunc(edge, area)
 
     ret = 0;
     plowJogEraseList = (LinkedRect *) NULL;
-    if (plowSrShadowBack(newedge.e_pNum, &r, mask,
+    if (plowSrShadowBack(newedge.e_pNum, &r, &mask,
 		plowJogDragLHS, INT2CD(newedge.e_newx - width)) == 0)
     {
 	/* Success: first paint to extend the RHS of the jog */

--- a/plow/PlowJogs.c
+++ b/plow/PlowJogs.c
@@ -353,7 +353,7 @@ plowProcessJogFunc(edge, area)
      * all of the LHS of the jog.
      */
     TTMaskSetOnlyType(&mask, edge->e_ltype);
-    width = plowFindWidthBack(&newedge, mask, area, (Rect *) NULL);
+    width = plowFindWidthBack(&newedge, &mask, area, (Rect *) NULL);
     r.r_xtop = newedge.e_x;
     r.r_xbot = newedge.e_x - width - 1;
     r.r_ytop = newedge.e_ytop;

--- a/plow/PlowJogs.c
+++ b/plow/PlowJogs.c
@@ -278,7 +278,7 @@ plowProcessJogFunc(edge, area)
     startPoint.p_y = edge->e_ytop;
     jogTopPoint = startPoint;
     jogTopDir = J_N;
-    plowSrOutline(edge->e_pNum, &startPoint, mask, GEO_NORTH,
+    plowSrOutline(edge->e_pNum, &startPoint, &mask, GEO_NORTH,
 		GMASK_NORTH|GMASK_WEST|GMASK_EAST,
 		plowJogTopProc, (ClientData) NULL);
 
@@ -287,7 +287,7 @@ plowProcessJogFunc(edge, area)
     startPoint.p_y = edge->e_ybot;
     jogBotPoint = startPoint;
     jogBotDir = J_N;
-    plowSrOutline(edge->e_pNum, &startPoint, mask, GEO_SOUTH,
+    plowSrOutline(edge->e_pNum, &startPoint, &mask, GEO_SOUTH,
 		GMASK_SOUTH|GMASK_WEST|GMASK_EAST,
 		plowJogBotProc, (ClientData) NULL);
 

--- a/plow/PlowMain.c
+++ b/plow/PlowMain.c
@@ -483,13 +483,13 @@ PlowSelection(def, pdistance, direction)
  */
 
 bool
-Plow(def, userRect, layers, direction)
-    CellDef *def;		/* Cell being plowed */
-    Rect *userRect;		/* The plow.  Interpreted as per direction
+Plow(
+    CellDef *def,		/* Cell being plowed */
+    Rect *userRect,		/* The plow.  Interpreted as per direction
 				 * below.
 				 */
-    TileTypeBitMask layers;	/* The initial plow only sees these layers */
-    int direction;		/* One of GEO_NORTH, GEO_SOUTH, GEO_WEST,
+    const TileTypeBitMask *layersp,/* The initial plow only sees these layers */
+    int direction)		/* One of GEO_NORTH, GEO_SOUTH, GEO_WEST,
 				 * or GEO_EAST.
 				 */
 {
@@ -497,6 +497,7 @@ Plow(def, userRect, layers, direction)
     extern int plowWidthNumCalls;
     extern int plowWidthNumChoices;
 #endif	/* COUNTWIDTHCALLS */
+    TileTypeBitMask layers = *layersp; /* TTMaskCopy(&layers, layersp) */
     TileTypeBitMask lc;
     Rect changedArea;
     bool firstTime;

--- a/plow/PlowMain.c
+++ b/plow/PlowMain.c
@@ -150,7 +150,7 @@ int plowInitialPaint(), plowInitialCell();
 int plowUpdatePaintTile(), plowUpdateCell();
 bool plowPastBoundary();
 bool plowPropagateSel();
-bool plowPropagateRect();
+bool plowPropagateRect(CellDef *def, Rect *userRect, const TileTypeBitMask *lcp, Rect *changedArea);
 PlowRule *plowBuildWidthRules();
 
 void plowMergeBottom(Tile *, Plane *);
@@ -519,7 +519,7 @@ Plow(
      */
     firstTime = TRUE;
     TTMaskCom2(&lc, &layers);
-    while (plowPropagateRect(def, userRect, lc, &changedArea))
+    while (plowPropagateRect(def, userRect, &lc, &changedArea))
 	firstTime = FALSE;
 
     if (!GEO_RECTNULL(&changedArea))
@@ -652,12 +652,13 @@ done:
  */
 
 bool
-plowPropagateRect(def, userRect, lc, changedArea)
-    CellDef *def;	/* Def being plowed */
-    Rect *userRect;	/* User-specified plow (we transform this) */
-    TileTypeBitMask lc;	/* Complement of set of layers to plow */
-    Rect *changedArea;	/* Set to bounding box around area modified */
+plowPropagateRect(
+    CellDef *def,	/* Def being plowed */
+    Rect *userRect,	/* User-specified plow (we transform this) */
+    const TileTypeBitMask *lcp,	/* Complement of set of layers to plow */
+    Rect *changedArea)	/* Set to bounding box around area modified */
 {
+    TileTypeBitMask lc = *lcp; /* TTMaskCopy(&lc, lcp) */
     Rect cellPlowRect, plowRect, r;
 #ifndef	NO_RUSAGE
     struct rusage t1, t2;

--- a/plow/PlowMain.c
+++ b/plow/PlowMain.c
@@ -737,7 +737,7 @@ plowPropagateRect(def, userRect, lc, changedArea)
 	/* Add the initial edges */
     for (pNum = PL_TECHDEPBASE; pNum < DBNumPlanes; pNum++)
 	(void) plowSrShadowInitial(pNum, &plowRect,
-		    lc, plowInitialPaint, INT2CD(plowRect.r_xtop));
+		    &lc, plowInitialPaint, INT2CD(plowRect.r_xtop));
 
 	/* Find any subcells crossed by the plow */
     (void) DBSrCellPlaneArea(plowYankDef->cd_cellPlane,

--- a/plow/PlowMain.c
+++ b/plow/PlowMain.c
@@ -1762,7 +1762,7 @@ retry:
     {
 	*prReal = *prMin;
 	prReal->pr_next = prReal + 1;
-	dist = plowFindWidth(edge, prMin->pr_oktypes, bbox, &maxBox);
+	dist = plowFindWidth(edge, &prMin->pr_oktypes, bbox, &maxBox);
 
 	/* Conservative test of whether we need to yank more */
 	if (plowYankMore(&maxBox, 1, 1))

--- a/plow/PlowMain.c
+++ b/plow/PlowMain.c
@@ -1043,7 +1043,7 @@ plowSelPaintPlow(rect, type, distance)
     plowAtomize(DBPlane(type), &plowLHS, plowSelPaintAdd, (ClientData) NULL);
 #endif	/* notdef */
     plowLHS.r_xbot--;
-    plowSrShadow(DBPlane(type), &plowLHS, DBZeroTypeBits,
+    plowSrShadow(DBPlane(type), &plowLHS, &DBZeroTypeBits,
 			plowInitialPaint, INT2CD(plowLHS.r_xtop));
 
     /* Queue the RHS */
@@ -1054,7 +1054,7 @@ plowSelPaintPlow(rect, type, distance)
 #endif	/* notdef */
     plowRHS.r_xbot--;
     TTMaskSetOnlyType(&mask, type);
-    plowSrShadow(DBPlane(type), &plowRHS, mask,
+    plowSrShadow(DBPlane(type), &plowRHS, &mask,
 			plowInitialPaint, INT2CD(plowRHS.r_xtop));
 
     return (0);

--- a/plow/PlowRandom.c
+++ b/plow/PlowRandom.c
@@ -118,7 +118,7 @@ PlowRandomTest(def)
 	dir = plowGenRandom(0, 3);
 	plowDir = dirs[dir];
 	plowGenRect(&def->cd_bbox, &plowRect);
-	(void) Plow(def, &plowRect, DBAllTypeBits, plowDir);
+	(void) Plow(def, &plowRect, &DBAllTypeBits, plowDir);
 	TxPrintf("%s %d %d %d %d\n", dirnames[dir],
 			plowRect.r_xbot, plowRect.r_ybot,
 			plowRect.r_xtop, plowRect.r_ytop);

--- a/plow/PlowRules1.c
+++ b/plow/PlowRules1.c
@@ -231,7 +231,7 @@ prPenumbraTop(edge, rules)
 	ar.ar_rule = pr;
 	ar.ar_clip.p_x = edge->e_newx + pr->pr_dist;
 	ar.ar_clip.p_y = edge->e_ytop + pr->pr_dist;
-	plowSrOutline(edge->e_pNum, &startPoint, pr->pr_ltypes, GEO_NORTH,
+	plowSrOutline(edge->e_pNum, &startPoint, &pr->pr_ltypes, GEO_NORTH,
 		GMASK_WEST|GMASK_NORTH|GMASK_SOUTH,
 		plowPenumbraTopProc, (ClientData) &ar);
     }
@@ -256,7 +256,7 @@ prPenumbraBot(edge, rules)
 	ar.ar_clip.p_x = edge->e_newx + pr->pr_dist;
 	ar.ar_clip.p_y = edge->e_ybot - pr->pr_dist;
 	TTMaskCom2(&insideTypes, &pr->pr_ltypes);
-	plowSrOutline(edge->e_pNum, &startPoint, insideTypes, GEO_SOUTH,
+	plowSrOutline(edge->e_pNum, &startPoint, &insideTypes, GEO_SOUTH,
 		GMASK_WEST|GMASK_NORTH|GMASK_SOUTH,
 		plowPenumbraBotProc, (ClientData) &ar);
     }
@@ -512,7 +512,7 @@ prSliverTop(edge, rules)
 	 */
 	ar.ar_slivtype = (TileType) -1;
 	ar.ar_lastx = ar.ar_mustmove = edge->e_x;
-	plowSrOutline(edge->e_pNum, &startPoint, pr->pr_ltypes, GEO_NORTH,
+	plowSrOutline(edge->e_pNum, &startPoint, &pr->pr_ltypes, GEO_NORTH,
 		GMASK_NORTH|GMASK_EAST|GMASK_SOUTH,
 		plowSliverTopExtent, (ClientData) &ar);
 
@@ -524,7 +524,7 @@ prSliverTop(edge, rules)
 	 * ar_lastx, or ar_clip.
 	 */
 	if (ar.ar_mustmove > edge->e_x)
-	    plowSrOutline(edge->e_pNum, &startPoint, pr->pr_ltypes, GEO_NORTH,
+	    plowSrOutline(edge->e_pNum, &startPoint, &pr->pr_ltypes, GEO_NORTH,
 		    GMASK_SOUTH|GMASK_NORTH,
 		    plowSliverTopMove, (ClientData) &ar);
     }
@@ -568,7 +568,7 @@ prSliverBot(edge, rules)
 	ar.ar_slivtype = (TileType) -1;
 	ar.ar_lastx = ar.ar_mustmove = edge->e_x;
 	TTMaskCom2(&insideTypes, &pr->pr_ltypes);
-	plowSrOutline(edge->e_pNum, &startPoint, insideTypes, GEO_SOUTH,
+	plowSrOutline(edge->e_pNum, &startPoint, &insideTypes, GEO_SOUTH,
 		GMASK_NORTH|GMASK_EAST|GMASK_SOUTH,
 		plowSliverBotExtent, (ClientData) &ar);
 
@@ -580,7 +580,7 @@ prSliverBot(edge, rules)
 	 * ar_lastx, or ar_clip.
 	 */
 	if (ar.ar_mustmove > edge->e_x)
-	    plowSrOutline(edge->e_pNum, &startPoint, insideTypes, GEO_SOUTH,
+	    plowSrOutline(edge->e_pNum, &startPoint, &insideTypes, GEO_SOUTH,
 		    GMASK_SOUTH|GMASK_NORTH,
 		    plowSliverBotMove, (ClientData) &ar);
     }

--- a/plow/PlowRules1.c
+++ b/plow/PlowRules1.c
@@ -87,7 +87,7 @@ prClearUmbra(edge)
     ar.ar_moving = edge;
     ar.ar_rule = (PlowRule *) NULL;
     (void) plowSrShadow(edge->e_pNum, &edge->e_rect,
-		rhsTypes, plowApplyRule, (ClientData) &ar);
+		&rhsTypes, plowApplyRule, (ClientData) &ar);
 }
 
 /*
@@ -138,7 +138,7 @@ prUmbra(edge, rules)
 	ar.ar_rule = pr;
 	searchArea.r_xtop = edge->e_newx + pr->pr_dist;
 	(void) plowSrShadow(pr->pr_pNum, &searchArea,
-			pr->pr_oktypes, plowApplyRule, (ClientData) &ar);
+			&pr->pr_oktypes, plowApplyRule, (ClientData) &ar);
     }
 }
 
@@ -342,7 +342,7 @@ plowPenumbraTopProc(outline, ar)
 	    searchArea.r_ybot = outline->o_rect.r_ytop;
 	    searchArea.r_ytop = ar->ar_clip.p_y;
 	    (void) plowSrShadow(pr->pr_pNum,
-		&searchArea, pr->pr_oktypes, plowPenumbraRule,
+		&searchArea, &pr->pr_oktypes, plowPenumbraRule,
 		(ClientData) ar);
 	}
 	return (1);
@@ -350,7 +350,7 @@ plowPenumbraTopProc(outline, ar)
 
     /* Shadow search to right of this segment of the penumbra boundary */
     (void) plowSrShadow(pr->pr_pNum, &searchArea,
-		pr->pr_oktypes, plowApplyRule, (ClientData) ar);
+		&pr->pr_oktypes, plowApplyRule, (ClientData) ar);
     return (ret);
 }
 
@@ -396,7 +396,7 @@ plowPenumbraBotProc(outline, ar)
 	    searchArea.r_ybot = ar->ar_clip.p_y;
 	    searchArea.r_ytop = outline->o_rect.r_ybot;
 	    (void) plowSrShadow(pr->pr_pNum,
-		&searchArea, pr->pr_oktypes, plowPenumbraRule,
+		&searchArea, &pr->pr_oktypes, plowPenumbraRule,
 		(ClientData) ar);
 	}
 	return (1);
@@ -404,7 +404,7 @@ plowPenumbraBotProc(outline, ar)
 
     /* Shadow search to right of this segment of the penumbra boundary */
     (void) plowSrShadow(pr->pr_pNum, &searchArea,
-		pr->pr_oktypes, plowApplyRule, (ClientData) ar);
+		&pr->pr_oktypes, plowApplyRule, (ClientData) ar);
 
     return (ret);
 }

--- a/plow/PlowRules2.c
+++ b/plow/PlowRules2.c
@@ -231,7 +231,7 @@ prFixedPenumbraTop(edge)
     for ( ; pr; pr = pr->pr_next)
     {
 	searchRect.r_ytop = edge->e_ytop + pr->pr_dist;
-	(void) plowSrShadow(pr->pr_pNum, &searchRect, pr->pr_oktypes,
+	(void) plowSrShadow(pr->pr_pNum, &searchRect, &pr->pr_oktypes,
 		plowApplyRule, (ClientData) &ar);
     }
 }
@@ -261,7 +261,7 @@ prFixedPenumbraBot(edge)
     for ( ; pr; pr = pr->pr_next)
     {
 	searchRect.r_ybot = edge->e_ybot - pr->pr_dist;
-	(void) plowSrShadow(pr->pr_pNum, &searchRect, pr->pr_oktypes,
+	(void) plowSrShadow(pr->pr_pNum, &searchRect, &pr->pr_oktypes,
 		plowApplyRule, (ClientData) &ar);
     }
     return 0;
@@ -493,13 +493,13 @@ prCoverTop(edge)
     for (pr = plowWidthRulesTbl[ltype][rtype]; pr; pr = pr->pr_next)
     {
 	searchArea.r_ytop = edge->e_ytop + pr->pr_dist;
-	(void) plowSrShadow(edge->e_pNum, &searchArea, pr->pr_oktypes,
+	(void) plowSrShadow(edge->e_pNum, &searchArea, &pr->pr_oktypes,
 		plowApplyRule, (ClientData) &ar);
     }
     for (pr = plowSpacingRulesTbl[ltype][rtype]; pr; pr = pr->pr_next)
     {
 	searchArea.r_ytop = edge->e_ytop + pr->pr_dist;
-	(void) plowSrShadow(edge->e_pNum, &searchArea, pr->pr_oktypes,
+	(void) plowSrShadow(edge->e_pNum, &searchArea, &pr->pr_oktypes,
 		plowApplyRule, (ClientData) &ar);
     }
 }
@@ -531,13 +531,13 @@ prCoverBot(edge)
     for (pr = plowWidthRulesTbl[ltype][rtype]; pr; pr = pr->pr_next)
     {
 	searchArea.r_ybot = edge->e_ybot - pr->pr_dist;
-	(void) plowSrShadow(edge->e_pNum, &searchArea, pr->pr_oktypes,
+	(void) plowSrShadow(edge->e_pNum, &searchArea, &pr->pr_oktypes,
 		plowApplyRule, (ClientData) &ar);
     }
     for (pr = plowSpacingRulesTbl[ltype][rtype]; pr; pr = pr->pr_next)
     {
 	searchArea.r_ybot = edge->e_ybot - pr->pr_dist;
-	(void) plowSrShadow(edge->e_pNum, &searchArea, pr->pr_oktypes,
+	(void) plowSrShadow(edge->e_pNum, &searchArea, &pr->pr_oktypes,
 		plowApplyRule, (ClientData) &ar);
     }
     return 0;
@@ -919,7 +919,7 @@ prCell(edge)
 	(void) DBSrPaintArea((Tile *) NULL, plowYankDef->cd_planes[pNum],
 		&ar.ar_search, &DBAllTypeBits,
 		plowCellDragPaint, (ClientData) &ar);
-	(void) plowSrShadow(pNum, &shadowArea, DBZeroTypeBits,
+	(void) plowSrShadow(pNum, &shadowArea, &DBZeroTypeBits,
 		plowCellPushPaint, (ClientData) &ar);
     }
 

--- a/plow/PlowRules2.c
+++ b/plow/PlowRules2.c
@@ -577,7 +577,7 @@ prIllegalTop(edge)
     ar.ar_slivtype = (TileType) -1;
     ar.ar_clip.p_x = edge->e_newx;
 
-    plowSrOutline(edge->e_pNum, &startPoint, insideTypes, GEO_NORTH,
+    plowSrOutline(edge->e_pNum, &startPoint, &insideTypes, GEO_NORTH,
 		GMASK_EAST|GMASK_WEST|GMASK_NORTH|GMASK_SOUTH,
 		plowIllegalTopProc, (ClientData) &ar);
     if (ar.ar_slivtype == (TileType) -1)
@@ -586,7 +586,7 @@ prIllegalTop(edge)
     startPoint.p_x = ar.ar_mustmove;
     TTMaskSetOnlyType(&insideTypes, ar.ar_slivtype);
     TTMaskCom(&insideTypes);
-    plowSrOutline(edge->e_pNum, &startPoint, insideTypes, GEO_NORTH,
+    plowSrOutline(edge->e_pNum, &startPoint, &insideTypes, GEO_NORTH,
 		GMASK_WEST|GMASK_NORTH|GMASK_SOUTH,
 		plowCoverTopProc, (ClientData) &ar);
 }
@@ -606,7 +606,7 @@ prIllegalBot(edge)
     ar.ar_slivtype = (TileType) -1;
     ar.ar_clip.p_x = edge->e_newx;
 
-    plowSrOutline(edge->e_pNum, &startPoint, insideTypes, GEO_SOUTH,
+    plowSrOutline(edge->e_pNum, &startPoint, &insideTypes, GEO_SOUTH,
 		GMASK_EAST|GMASK_WEST|GMASK_NORTH|GMASK_SOUTH,
 		plowIllegalBotProc, (ClientData) &ar);
     if (ar.ar_slivtype == (TileType) -1)
@@ -614,7 +614,7 @@ prIllegalBot(edge)
 
     startPoint.p_x = ar.ar_mustmove;
     TTMaskSetOnlyType(&insideTypes, ar.ar_slivtype);
-    plowSrOutline(edge->e_pNum, &startPoint, insideTypes, GEO_SOUTH,
+    plowSrOutline(edge->e_pNum, &startPoint, &insideTypes, GEO_SOUTH,
 		GMASK_WEST|GMASK_NORTH|GMASK_SOUTH,
 		plowCoverBotProc, (ClientData) &ar);
     return 0;

--- a/plow/PlowRules3.c
+++ b/plow/PlowRules3.c
@@ -248,7 +248,7 @@ scanDown(inarg, type, canMoveInargEdge)
 	ar.ar_moving = movingEdge;
 	ar.ar_rule = (PlowRule *) NULL;
 	plowSrShadow(movingEdge->e_pNum, &shadowRect,
-		DBZeroTypeBits, plowApplyRule, (ClientData) &ar);
+		&DBZeroTypeBits, plowApplyRule, (ClientData) &ar);
     }
 #endif	/* notdef */
     return 0;
@@ -343,7 +343,7 @@ scanUp(inarg, type, canMoveInargEdge)
 	ar.ar_moving = movingEdge;
 	ar.ar_rule = (PlowRule *) NULL;
 	plowSrShadow(movingEdge->e_pNum, &shadowRect,
-		DBZeroTypeBits, plowApplyRule, (ClientData) &ar);
+		&DBZeroTypeBits, plowApplyRule, (ClientData) &ar);
     }
 #endif	/* notdef */
     return 0;

--- a/plow/PlowSearch.c
+++ b/plow/PlowSearch.c
@@ -203,16 +203,17 @@ switch ((o)->o_nextDir) \
  */
 
 int
-plowSrShadow(pNum, area, okTypes, proc, cdata)
-    int pNum;			/* Plane from plowYankDef to search */
-    Rect *area;			/* Area to search.  Edges coincident with the
+plowSrShadow(
+    int pNum,			/* Plane from plowYankDef to search */
+    Rect *area,			/* Area to search.  Edges coincident with the
 				 * right-hand side of this area are not seen;
 				 * they must lie to the left of area->r_xtop.
 				 */
-    TileTypeBitMask okTypes;
-    int (*proc)();		/* Function to apply at each edge */
-    ClientData cdata;		/* Additional argument to pass to (*proc)() */
+    const TileTypeBitMask *okTypesp,
+    int (*proc)(),		/* Function to apply at each edge */
+    ClientData cdata)		/* Additional argument to pass to (*proc)() */
 {
+    TileTypeBitMask okTypes = *okTypesp; /* TTMaskCopy(&okTypes, okTypesp) */
     Plane *plane = plowYankDef->cd_planes[pNum];
     struct shadow s;
     Tile *tp;

--- a/plow/PlowSearch.c
+++ b/plow/PlowSearch.c
@@ -779,26 +779,27 @@ plowAtomize(pNum, rect, proc, cdata)
  */
 
 void
-plowSrOutline(pNum, startPoint, insideTypes, initialDir, dirMask, proc, cdata)
-    int pNum;				/* Plane # in plowYankDef to search */
-    Point *startPoint;			/* Point on boundary; material of types
+plowSrOutline(
+    int pNum,				/* Plane # in plowYankDef to search */
+    Point *startPoint,			/* Point on boundary; material of types
 					 * in insideTypes should be to the
 					 * inside (as determined by initialDir
 					 * below).
 					 */
-    TileTypeBitMask insideTypes;	/* Mask of types inside the region
+    const TileTypeBitMask *insideTypesp,/* Mask of types inside the region
 					 * whose outline is being traced.
 					 */
-    int initialDir;			/* Initial direction to go from the
+    int initialDir,			/* Initial direction to go from the
 					 * starting point.  One of GEO_NORTH,
 					 * or GEO_SOUTH.
 					 */
-    int dirMask;			/* Mask of those directions for which
+    int dirMask,			/* Mask of those directions for which
 					 * we will call the client procedure.
 					 */
-    int (*proc)();			/* Client procedure */
-    ClientData cdata;			/* Argument to client procedure */
+    int (*proc)(),			/* Client procedure */
+    ClientData cdata)			/* Argument to client procedure */
 {
+    TileTypeBitMask insideTypes = *insideTypesp; /* TTMaskCopy(&insideTypes, insideTypesp) */
     Outline outline;
 
     /*

--- a/plow/PlowSearch.c
+++ b/plow/PlowSearch.c
@@ -175,7 +175,7 @@ switch ((o)->o_nextDir) \
  * This is similar to an area search, except we call the procedure with
  * edges instead of tiles:
  *
- *	(*proc)(edge, cdata)
+ *	int (*proc)(edge, cdata)
  *	    Edge *edge;
  *	    ClientData cdata;
  *	{

--- a/plow/PlowSearch.c
+++ b/plow/PlowSearch.c
@@ -512,16 +512,17 @@ plowShadowInitialRHS(tp, s, bottomLeft)
  */
 
 int
-plowSrShadowBack(pNum, area, okTypes, proc, cdata)
-    int pNum;			/* Plane from plowYankDef to search */
-    Rect *area;			/* Area to search.  Edges coincident with the
+plowSrShadowBack(
+    int pNum,			/* Plane from plowYankDef to search */
+    Rect *area,			/* Area to search.  Edges coincident with the
 				 * left-hand side of this area are not seen;
 				 * they must lie to the right of area->r_xbot.
 				 */
-    TileTypeBitMask okTypes;
-    int (*proc)();		/* Function to apply at each edge */
-    ClientData cdata;		/* Additional argument to pass to (*proc)() */
+    const TileTypeBitMask *okTypesp,
+    int (*proc)(),		/* Function to apply at each edge */
+    ClientData cdata)		/* Additional argument to pass to (*proc)() */
 {
+    TileTypeBitMask okTypes = *okTypesp; /* TTMaskCopy(&okTypes, okTypesp) */
     Plane *plane = plowYankDef->cd_planes[pNum];
     struct shadow s;
     Tile *tp;

--- a/plow/PlowSearch.c
+++ b/plow/PlowSearch.c
@@ -357,16 +357,17 @@ plowShadowRHS(tp, s, bottomLeft)
  */
 
 int
-plowSrShadowInitial(pNum, area, okTypes, proc, cdata)
-    int pNum;			/* Plane from plowYankDef to search */
-    Rect *area;			/* Area to search.  Edges coincident with the
+plowSrShadowInitial(
+    int pNum,			/* Plane from plowYankDef to search */
+    Rect *area,			/* Area to search.  Edges coincident with the
 				 * right-hand side of this area are not seen;
 				 * they must lie to the left of area->r_xtop.
 				 */
-    TileTypeBitMask okTypes;
-    int (*proc)();		/* Function to apply at each edge */
-    ClientData cdata;		/* Additional argument to pass to (*proc)() */
+    const TileTypeBitMask *okTypesp,
+    int (*proc)(),		/* Function to apply at each edge */
+    ClientData cdata)		/* Additional argument to pass to (*proc)() */
 {
+    TileTypeBitMask okTypes = *okTypesp; /* TTMaskCopy(&okTypes, okTypesp) */
     Plane *plane = plowYankDef->cd_planes[pNum];
     struct shadow s;
     Tile *tp;

--- a/plow/PlowTest.c
+++ b/plow/PlowTest.c
@@ -44,7 +44,7 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 #include "textio/txcommands.h"
 
 /* Forward declarations */
-extern void plowShowShadow();
+extern int plowShowShadow();
 extern int plowShowOutline();
 extern void plowTestJog();
 extern void plowDebugMore();
@@ -485,6 +485,7 @@ plowDebugInit()
  *
  * Results:
  *	None.
+ *      Returns zero as per plowSrShadowXxx() callback requirements.
  *
  * Side effects:
  *	Leaves feedback.
@@ -492,7 +493,7 @@ plowDebugInit()
  * ----------------------------------------------------------------------------
  */
 
-void
+int
 plowShowShadow(edge, def)
     Edge *edge;
     CellDef *def;
@@ -509,6 +510,7 @@ plowShowShadow(edge, def)
     edgeArea.r_ybot = edge->e_ybot * scaleFactor;
     edgeArea.r_ytop = edge->e_ytop * scaleFactor;
     DBWFeedbackAdd(&edgeArea, mesg, def, scaleFactor, STYLE_SOLIDHIGHLIGHTS);
+    return 0; /* TODO this callback was returning void, but plowSrShadowXxx() uses non-zero for early abort */
 }
 
 /*

--- a/plow/PlowTest.c
+++ b/plow/PlowTest.c
@@ -193,7 +193,7 @@ PlowTest(w, cmd)
 	    }
 	    if (!CmdParseLayers(cmd->tx_argv[3], &okTypes))
 		return;
-	    (void) plowSrOutline(PL_TECHDEPBASE, &editArea.r_ll, okTypes, dir,
+	    (void) plowSrOutline(PL_TECHDEPBASE, &editArea.r_ll, &okTypes, dir,
 			GMASK_NORTH|GMASK_SOUTH|GMASK_EAST|GMASK_WEST,
 			plowShowOutline, (ClientData) &editArea);
 	    break;

--- a/plow/PlowTest.c
+++ b/plow/PlowTest.c
@@ -226,7 +226,7 @@ PlowTest(w, cmd)
 	    saveDef = plowYankDef;
 	    plowYankDef = def;
 	    (void) plowSrShadowBack(PL_TECHDEPBASE, &editArea,
-			okTypes, plowShowShadow, (ClientData) def);
+			&okTypes, plowShowShadow, (ClientData) def);
 	    plowYankDef = saveDef;
 	    break;
 	case PC_SHADOW:

--- a/plow/PlowTest.c
+++ b/plow/PlowTest.c
@@ -273,7 +273,7 @@ PlowTest(w, cmd)
 		editArea.r_ybot, editArea.r_ytop);
 	    saveDef = plowYankDef;
 	    plowYankDef = def;
-	    (void) plowFindWidth(&edge, okTypes, &def->cd_bbox, &editArea);
+	    (void) plowFindWidth(&edge, &okTypes, &def->cd_bbox, &editArea);
 	    plowYankDef = saveDef;
 	    GeoTransRect(&EditToRootTransform, &editArea, &rootBox);
 	    ToolMoveBox(TOOL_BL, &rootBox.r_ll, FALSE, rootBoxDef);

--- a/plow/PlowTest.c
+++ b/plow/PlowTest.c
@@ -240,7 +240,7 @@ PlowTest(w, cmd)
 	    saveDef = plowYankDef;
 	    plowYankDef = def;
 	    (void) plowSrShadow(PL_TECHDEPBASE, &editArea,
-			okTypes, plowShowShadow, (ClientData) def);
+			&okTypes, plowShowShadow, (ClientData) def);
 	    plowYankDef = saveDef;
 	    break;
 	case PC_TECHSHOW:

--- a/plow/PlowTest.c
+++ b/plow/PlowTest.c
@@ -294,7 +294,7 @@ PlowTest(w, cmd)
 		editArea.r_ybot, editArea.r_ytop);
 	    saveDef = plowYankDef;
 	    plowYankDef = def;
-	    (void) plowFindWidthBack(&edge, okTypes, &def->cd_bbox, &editArea);
+	    (void) plowFindWidthBack(&edge, &okTypes, &def->cd_bbox, &editArea);
 	    plowYankDef = saveDef;
 	    GeoTransRect(&EditToRootTransform, &editArea, &rootBox);
 	    ToolMoveBox(TOOL_BL, &rootBox.r_ll, FALSE, rootBoxDef);

--- a/plow/PlowTest.c
+++ b/plow/PlowTest.c
@@ -207,7 +207,7 @@ PlowTest(w, cmd)
 	    okTypes = DBAllTypeBits;
 	    if (cmd->tx_argc > 3 && !CmdParseLayers(cmd->tx_argv[3], &okTypes))
 		return;
-	    if (!Plow(def, &editArea, okTypes, dir))
+	    if (!Plow(def, &editArea, &okTypes, dir))
 	    {
 		TxPrintf("Reduced plow size since we ran into the barrier.\n");
 		GeoTransRect(&EditToRootTransform, &editArea, &rootBox);

--- a/plow/PlowWidth.c
+++ b/plow/PlowWidth.c
@@ -320,13 +320,12 @@ clipright:
  */
 
 int
-plowFindWidthBack(edge, types, bbox, prect)
-    Edge *edge;			/* Edge along the RHS of this material */
-    TileTypeBitMask types;	/* Types whose width is being computed.  Note
-				 * that this set is passed by value.
+plowFindWidthBack(
+    Edge *edge,			/* Edge along the RHS of this material */
+    const TileTypeBitMask *typesp,/* Types whose width is being computed.
 				 */
-    Rect *bbox;			/* Bounding box of the cell */
-    Rect *prect;		/* (Debugging only): if this is non-NULL,
+    Rect *bbox,			/* Bounding box of the cell */
+    Rect *prect)		/* (Debugging only): if this is non-NULL,
 				 * the rectangle it points to is filled
 				 * in with the rectangle found by this
 				 * algorithm to be the largest containing
@@ -334,6 +333,7 @@ plowFindWidthBack(edge, types, bbox, prect)
 				 * set 'types'.
 				 */
 {
+    TileTypeBitMask types = *typesp; /* TTMaskCopy(&types, typesp); */
     Plane *plane = plowYankDef->cd_planes[edge->e_pNum];
     TileTypeBitMask ctypes;
     struct wclip wc;

--- a/plow/PlowWidth.c
+++ b/plow/PlowWidth.c
@@ -62,13 +62,12 @@ int plowWidthNumChoices = 0;
  */
 
 int
-plowFindWidth(edge, types, bbox, prect)
-    Edge *edge;			/* Edge along the LHS of this material */
-    TileTypeBitMask types;	/* Types whose width is being computed.  Note
-				 * that this set is passed by value.
+plowFindWidth(
+    Edge *edge,			/* Edge along the LHS of this material */
+    const TileTypeBitMask *typesp,/* Types whose width is being computed.
 				 */
-    Rect *bbox;			/* Bounding box of the cell */
-    Rect *prect;		/* (Debugging only): if this is non-NULL,
+    Rect *bbox,			/* Bounding box of the cell */
+    Rect *prect)		/* (Debugging only): if this is non-NULL,
 				 * the rectangle it points to is filled
 				 * in with the rectangle found by this
 				 * algorithm to be the largest containing
@@ -76,6 +75,7 @@ plowFindWidth(edge, types, bbox, prect)
 				 * set 'types'.
 				 */
 {
+    TileTypeBitMask types = *typesp; /* TTMaskCopy(&types, typesp); */
     Plane *plane = plowYankDef->cd_planes[edge->e_pNum];
     TileTypeBitMask ctypes;
     struct wclip wc;

--- a/plow/plow.h
+++ b/plow/plow.h
@@ -30,7 +30,7 @@ extern int PlowDRCInit(), PlowDRCFinal();
 extern bool PlowDRCLine();
 
 /* Called by CmdPlow() */
-extern bool Plow();
+extern bool Plow(CellDef *def, Rect *userRect, const TileTypeBitMask *layersp, int direction);
 
 /* Debugging command procedure */
 extern int PlowTest();

--- a/plow/plowInt.h
+++ b/plow/plowInt.h
@@ -258,7 +258,7 @@ extern int  plowAtomize();
 extern void plowCleanupJogs();
 extern void plowDebugEdge();
 extern int  plowFindWidth(Edge *edge, const TileTypeBitMask *typesp, Rect *bbox, Rect *prect);
-extern int  plowFindWidthBack();
+extern int  plowFindWidthBack(Edge *edge, const TileTypeBitMask *typesp, Rect *bbox, Rect *prect);
 extern int  plowGenRandom();
 extern void plowQueueDone();
 extern void plowQueueInit();

--- a/plow/plowInt.h
+++ b/plow/plowInt.h
@@ -265,7 +265,7 @@ extern void plowQueueInit();
 extern int  plowSrFinalArea();
 extern void plowSrOutline(int pNum, Point *startPoint, const TileTypeBitMask *insideTypesp, int initialDir, int dirMask, int (*proc)(), ClientData cdata);
 extern int  plowSrShadow(int pNum, Rect *area, const TileTypeBitMask *okTypesp, int (*proc)(), ClientData cdata);
-extern int  plowSrShadowBack();
+extern int  plowSrShadowBack(int pNum, Rect *area, const TileTypeBitMask *okTypesp, int (*proc)(), ClientData cdata);
 extern int  plowSrShadowInitial();
 extern bool plowYankMore();
 extern void PlowRandomTest();

--- a/plow/plowInt.h
+++ b/plow/plowInt.h
@@ -264,7 +264,7 @@ extern void plowQueueDone();
 extern void plowQueueInit();
 extern int  plowSrFinalArea();
 extern void plowSrOutline(int pNum, Point *startPoint, const TileTypeBitMask *insideTypesp, int initialDir, int dirMask, int (*proc)(), ClientData cdata);
-extern int  plowSrShadow();
+extern int  plowSrShadow(int pNum, Rect *area, const TileTypeBitMask *okTypesp, int (*proc)(), ClientData cdata);
 extern int  plowSrShadowBack();
 extern int  plowSrShadowInitial();
 extern bool plowYankMore();

--- a/plow/plowInt.h
+++ b/plow/plowInt.h
@@ -263,7 +263,7 @@ extern int  plowGenRandom();
 extern void plowQueueDone();
 extern void plowQueueInit();
 extern int  plowSrFinalArea();
-extern void plowSrOutline();
+extern void plowSrOutline(int pNum, Point *startPoint, const TileTypeBitMask *insideTypesp, int initialDir, int dirMask, int (*proc)(), ClientData cdata);
 extern int  plowSrShadow();
 extern int  plowSrShadowBack();
 extern int  plowSrShadowInitial();

--- a/plow/plowInt.h
+++ b/plow/plowInt.h
@@ -50,7 +50,7 @@ typedef struct
     TileTypeBitMask	 rte_rtypes;	/* Apply if RHS type is in this set */
     int			 rte_whichRules;/* See below */
     int		       (*rte_proc)();	/* Procedure implementing rule */
-    char		*rte_name;	/* Name of rule (for debugging) */
+    const char		*rte_name;	/* Name of rule (for debugging) */
 } RuleTableEntry;
 
 #define	MAXRULES	100	/* Ridiculously high */

--- a/plow/plowInt.h
+++ b/plow/plowInt.h
@@ -257,7 +257,7 @@ extern int  plowApplySearchRules();
 extern int  plowAtomize();
 extern void plowCleanupJogs();
 extern void plowDebugEdge();
-extern int  plowFindWidth();
+extern int  plowFindWidth(Edge *edge, const TileTypeBitMask *typesp, Rect *bbox, Rect *prect);
 extern int  plowFindWidthBack();
 extern int  plowGenRandom();
 extern void plowQueueDone();

--- a/plow/plowInt.h
+++ b/plow/plowInt.h
@@ -266,7 +266,7 @@ extern int  plowSrFinalArea();
 extern void plowSrOutline(int pNum, Point *startPoint, const TileTypeBitMask *insideTypesp, int initialDir, int dirMask, int (*proc)(), ClientData cdata);
 extern int  plowSrShadow(int pNum, Rect *area, const TileTypeBitMask *okTypesp, int (*proc)(), ClientData cdata);
 extern int  plowSrShadowBack(int pNum, Rect *area, const TileTypeBitMask *okTypesp, int (*proc)(), ClientData cdata);
-extern int  plowSrShadowInitial();
+extern int  plowSrShadowInitial(int pNum, Rect *area, const TileTypeBitMask *okTypesp, int (*proc)(), ClientData cdata);
 extern bool plowYankMore();
 extern void PlowRandomTest();
 extern void plowDebugInit();

--- a/sim/SimExtract.c
+++ b/sim/SimExtract.c
@@ -486,7 +486,7 @@ SimTransistorTile(tile, pNum, arg)
 	devptr = ExtCurStyle->exts_device[t];
 	for (i = 0; !TTMaskHasType(&devptr->exts_deviceSDTypes[i],
 			TT_SPACE); i++)
-	    extEnumTilePerim(tile, devptr->exts_deviceSDTypes[i], pNum,
+	    extEnumTilePerim(tile, &devptr->exts_deviceSDTypes[i], pNum,
 			SimTransTerms, (ClientData) &transistor );
     }
 


### PR DESCRIPTION
I assume this was to ensure the caller's copy of the mask is never accidentally modified, in the days before `const` and before putting read-only data in `.text` or `.rodata` segments.

No attempt has been made to optimize the receiving function to remove the need to copy it locally into its stack frame, and use the pointer directly (a number of scenarios exist to optimize on this).  I used an idiom that should not change existing behaviour and should work every time.

Just needed a resolution to not pass the large 32-byte wide object by-value (this is technically due to AVX2 data alignment requirements) elicits a GCC warning, also that passing large amounts of data by-value that may not be utilized at all by the receiving function (because a boolean decision skips it for this call) can not optimize the removal of the copy that takes place).