### PR TITLE
SUPPORT_DIRECT_MALLOC and SUPPORT_REMOVE_MALLOC_LEGACY

### DIFF
--- a/bplane/bpBins.c
+++ b/bplane/bpBins.c
@@ -93,7 +93,7 @@ static BinArray *bpBinArrayNew(int dx,      /* x diameter of bins */
 
   /* allocate array */
   size = sizeof(BinArray) + numBins*(sizeof(void *));
-  new = (BinArray *)callocMagic(size);
+  new = (BinArray *)callocMagic(1, size);
 
   /* initial */
   new->ba_bbox = *bbox;

--- a/calma/CalmaRdpt.c
+++ b/calma/CalmaRdpt.c
@@ -360,12 +360,14 @@ calmaElementBoundary(void)
     }
 
     /* Paint the rectangles (if any) */
+    free_magic1_t mm1 = freeMagic1_init();
     for (; rp != NULL ; rp = rp->r_next)
     {
 	if (plane)
 	    DBPaintPlane(plane, &rp->r_r, CIFPaintTable, (PaintUndoInfo *)NULL);
-	freeMagic((char *) rp);
+	freeMagic1(&mm1, (char *) rp);
     }
+    freeMagic1_end(&mm1);
 
     if (cifCurReadPlanes == cifEditCellPlanes)
     {

--- a/calma/CalmaWrite.c
+++ b/calma/CalmaWrite.c
@@ -1400,8 +1400,10 @@ calmaOutFunc(
 	    {
 		pllist[i].pl_label = ll->ll_label;
 		pllist[i].pl_port = (unsigned int)ll->ll_attr;
-		freeMagic(ll);
+		free_magic1_t mm1 = freeMagic1_init();
+		freeMagic1(&mm1, ll);
 		ll = ll->ll_next;
+		freeMagic1_end(&mm1);
 		i++;
 	    }	
 
@@ -2422,19 +2424,26 @@ calmaProcessBoundary(
 
 	/* Free the LinkedBoundary list */
 
-	lbref = listtop;
-	while (lbref->lb_next != listtop)
 	{
-	    freeMagic(lbref);
-	    lbref = lbref->lb_next;
+	    free_magic1_t mm1 = freeMagic1_init();
+	    lbref = listtop;
+	    while (lbref->lb_next != listtop)
+	    {
+		freeMagic1(&mm1, lbref);
+		lbref = lbref->lb_next;
+	    }
+	    freeMagic1_end(&mm1);
 	}
-	freeMagic(lbref);
     }
 
     /* Free the BoundaryTop list */
 
-    for (bounds = blist; bounds != NULL; bounds = bounds->bt_next)
-	freeMagic(bounds);
+    {
+	free_magic1_t mm1 = freeMagic1_init();
+	for (bounds = blist; bounds != NULL; bounds = bounds->bt_next)
+	    freeMagic1(&mm1, bounds);
+	freeMagic1_end(&mm1);
+    }
 }
 
 /*
@@ -2500,8 +2509,10 @@ calmaMergePaintFunc(
 		lb = edge;
 		while (lb->lb_next != edge) lb = lb->lb_next;
 		lb->lb_next = edge->lb_next;
-	 	freeMagic(edge);
+		free_magic1_t mm1 = freeMagic1_init();
+		freeMagic1(&mm1, edge);
 		edge = edge->lb_next;
+		freeMagic1_end(&mm1);
 	    }
 	}
 	else
@@ -2720,11 +2731,13 @@ done_searches:
 
 	    if (num_points != 4)
 	    {
+		free_magic1_t mm1 = freeMagic1_init();
 		for (i = 0; i < num_points; i++)
 		{
-		    freeMagic(edge);
+		    freeMagic1(&mm1, edge);
 		    edge = edge->lb_next;
 		}
+		freeMagic1_end(&mm1);
 		edge = NULL;
 	    }
 	    if (!StackEmpty(SegStack))

--- a/calma/CalmaWriteZ.c
+++ b/calma/CalmaWriteZ.c
@@ -1324,8 +1324,10 @@ calmaOutFuncZ(
 	    {
 		pllist[i].pl_label = ll->ll_label;
 		pllist[i].pl_port = (unsigned int)ll->ll_attr;
-		freeMagic(ll);
+		free_magic1_t mm1 = freeMagic1_init();
+		freeMagic1(&mm1, ll);
 		ll = ll->ll_next;
+		freeMagic1_end(&mm1);
 		i++;
 	    }
 
@@ -1857,19 +1859,26 @@ calmaProcessBoundaryZ(
 
 	/* Free the LinkedBoundary list */
 
-	lbref = listtop;
-	while (lbref->lb_next != listtop)
 	{
-	    freeMagic(lbref);
-	    lbref = lbref->lb_next;
+	    free_magic1_t mm1 = freeMagic1_init();
+	    lbref = listtop;
+	    while (lbref->lb_next != listtop)
+	    {
+		freeMagic1(&mm1, lbref);
+		lbref = lbref->lb_next;
+	    }
+	    freeMagic1_end(&mm1);
 	}
-	freeMagic(lbref);
     }
 
     /* Free the BoundaryTop list */
 
-    for (bounds = blist; bounds != NULL; bounds = bounds->bt_next)
-	freeMagic(bounds);
+    {
+	free_magic1_t mm1 = freeMagic1_init();
+	for (bounds = blist; bounds != NULL; bounds = bounds->bt_next)
+	    freeMagic1(&mm1, bounds);
+	freeMagic1_end(&mm1);
+    }
 }
 
 /*
@@ -1935,8 +1944,10 @@ calmaMergePaintFuncZ(
 		lb = edge;
 		while (lb->lb_next != edge) lb = lb->lb_next;
 		lb->lb_next = edge->lb_next;
-	 	freeMagic(edge);
+		free_magic1_t mm1 = freeMagic1_init();
+		freeMagic1(&mm1, edge);
 		edge = edge->lb_next;
+		freeMagic1_end(&mm1);
 	    }
 	}
 	else
@@ -2155,11 +2166,13 @@ done_searches:
 
 	    if (num_points != 4)
 	    {
+		free_magic1_t mm1 = freeMagic1_init();
 		for (i = 0; i < num_points; i++)
 		{
-		    freeMagic(edge);
+		    freeMagic1(&mm1, edge);
 		    edge = edge->lb_next;
 		}
+		freeMagic1_end(&mm1);
 		edge = NULL;
 	    }
 	    if (!StackEmpty(SegStack))

--- a/cif/CIFgen.c
+++ b/cif/CIFgen.c
@@ -2768,8 +2768,10 @@ cifSquaresFillArea(
 
 	DBPaintPlane(plane, &stripList->area, CIFEraseTable,
 		(PaintUndoInfo *) NULL);
-	freeMagic(stripList);
+	free_magic1_t mm1 = freeMagic1_init();
+	freeMagic1(&mm1, stripList);
 	stripList = stripList->strip_next;
+	freeMagic1_end(&mm1);
     }
 
     /* 2nd pass:  Search the plane for unmarked tiles */
@@ -3110,8 +3112,10 @@ cifSlotsFillArea(
 
 	DBPaintPlane(plane, &stripList->area, CIFEraseTable,
 		(PaintUndoInfo *) NULL);
-	freeMagic(stripList);
+	free_magic1_t mm1 = freeMagic1_init();
+	freeMagic1(&mm1, stripList);
 	stripList = stripList->strip_next;
+	freeMagic1_end(&mm1);
     }
 
     /* 2nd pass:  Search the plane for unmarked tiles */

--- a/cif/CIFrdcl.c
+++ b/cif/CIFrdcl.c
@@ -851,9 +851,11 @@ CIFPaintCurrent(
 		    	freeMagic(propstr);
 		    }
 		    propstr = newstr;
-		    freeMagic(lrec);
+		    free_magic1_t mm1 = freeMagic1_init();
+		    freeMagic1(&mm1, lrec);
 		    lrec = lrec->r_next;
-	    	}
+		    freeMagic1_end(&mm1);
+		}
 		/* NOTE: propstr is transferred to the CellDef and should
 		 * not be free'd here.
 		 */

--- a/cif/CIFrdpt.c
+++ b/cif/CIFrdpt.c
@@ -338,18 +338,20 @@ CIFPaintWirePath(
     pathp = pathheadp->cifp_next;
     if (pathp != NULL)
     {
+	free_magic1_t mm1 = freeMagic1_init();
 	while (pathp->cifp_next != NULL)
 	{
 	    if (pathp->cifp_next->cifp_x == pathp->cifp_x &&
 			pathp->cifp_next->cifp_y == pathp->cifp_y)
 	    {
 		previousp->cifp_next = pathp->cifp_next;
-		freeMagic(pathp);
+		freeMagic1(&mm1, pathp);
 	    }
 	    else
 		previousp = pathp;
 	    pathp = pathp->cifp_next;
 	}
+	freeMagic1_end(&mm1);
     }
 
     previousp = pathheadp;
@@ -486,11 +488,13 @@ CIFPaintWirePath(
 	    rectp = CIFPolyToRects(polypath, plane, ptable, ui, FALSE);
 	    CIFFreePath(polypath);
 
+	    free_magic1_t mm1 = freeMagic1_init();
 	    for (; rectp != NULL ; rectp = rectp->r_next)
 	    {
 		DBPaintPlane(plane, &rectp->r_r, ptable, ui);
-		freeMagic((char *) rectp);
+		freeMagic1(&mm1, (char *) rectp);
 	    }
+	    freeMagic1_end(&mm1);
 	    polypath = NULL;
 	}
 	else
@@ -588,11 +592,13 @@ PaintPolygon(
     rectlist = CIFPolyToRects(cifpath, plane, ptable, ui, FALSE);
     CIFFreePath(cifpath);
 
+    free_magic1_t mm1 = freeMagic1_init();
     for (rectp = rectlist; rectp != NULL ; rectp = rectp->r_next)
     {
 	DBPaintPlane(plane, &rectp->r_r, ptable, ui);
-	if (!keep) freeMagic((char *) rectp);
+	if (!keep) freeMagic1(&mm1, (char *) rectp);
     }
+    freeMagic1_end(&mm1);
     return (keep) ? rectlist : (LinkedRect *)NULL;
 }
 
@@ -821,11 +827,13 @@ CIFParsePoly(void)
 	CIFSkipToSemi();
 	return FALSE;
     }
+    free_magic1_t mm1 = freeMagic1_init();
     for (; rectp != NULL ; rectp = rectp->r_next)
     {
 	DBPaintPlane(cifReadPlane, &rectp->r_r, CIFPaintTable,
 		(PaintUndoInfo *) NULL);
-	freeMagic((char *) rectp);
+	freeMagic1(&mm1, (char *) rectp);
     }
+    freeMagic1_end(&mm1);
     return TRUE;
 }

--- a/cif/CIFrdtech.c
+++ b/cif/CIFrdtech.c
@@ -329,8 +329,10 @@ cifNewReadStyle(void)
 	    layer = cifCurReadStyle->crs_layers[i];
 	    if (layer != NULL)
 	    {
+		free_magic1_t mm1 = freeMagic1_init();
 		for (op = layer->crl_ops; op != NULL; op = op->co_next)
-		    freeMagic((char *)op);
+		    freeMagic1(&mm1, (char *)op);
+		freeMagic1_end(&mm1);
 		freeMagic((char *)layer);
 	    }
 	}
@@ -408,11 +410,13 @@ CIFReadTechInit(void)
 
     /* forget the list of styles */
 
+    free_magic1_t mm1 = freeMagic1_init();
     for (style = cifReadStyleList; style != NULL; style = style->crs_next)
     {
         freeMagic(style->crs_name);
-        freeMagic(style);
+        freeMagic1(&mm1, style);
     }
+    freeMagic1_end(&mm1);
     cifReadStyleList = NULL;
 }
 

--- a/cif/CIFrdutils.c
+++ b/cif/CIFrdutils.c
@@ -1338,11 +1338,13 @@ void
 CIFFreePath(
     CIFPath *path)		/* Path to be freed. */
 {
+    free_magic1_t mm1 = freeMagic1_init();
     while (path != NULL)
     {
-	freeMagic((char *) path);
+	freeMagic1(&mm1, (char *) path);
 	path = path->cifp_next;
     }
+    freeMagic1_end(&mm1);
 }
 
 /*

--- a/cif/CIFtech.c
+++ b/cif/CIFtech.c
@@ -100,6 +100,7 @@ cifTechFreeStyle(void)
 	    layer = CIFCurStyle->cs_layers[i];
 	    if (layer != NULL)
 	    {
+		free_magic1_t mm1 = freeMagic1_init();
 		for (op = layer->cl_ops; op != NULL; op = op->co_next)
 		{
 		    if (op->co_client != (ClientData)NULL)
@@ -120,8 +121,9 @@ cifTechFreeStyle(void)
 				break;
 			}
 		    }
-		    freeMagic((char *)op);
+		    freeMagic1(&mm1, (char *)op);
 		}
+		freeMagic1_end(&mm1);
 		freeMagic((char *)layer);
 	    }
 	}
@@ -369,11 +371,13 @@ CIFTechInit(void)
 
     /* forget the list of styles */
 
+    free_magic1_t mm1 = freeMagic1_init();
     for (style = CIFStyleList; style != NULL; style = style->cs_next)
     {
 	freeMagic(style->cs_name);
-	freeMagic(style);
+	freeMagic1(&mm1, style);
     }
+    freeMagic1_end(&mm1);
     CIFStyleList = NULL;
 }
 

--- a/commands/CmdAB.c
+++ b/commands/CmdAB.c
@@ -530,11 +530,15 @@ badusage:
     }
 
 freelist:
-    la = lahead;
-    while (la != NULL)
     {
-	freeMagic((char *)la);
-	la = la->ar_next;
+	la = lahead;
+	while (la != NULL)
+	{
+	    free_magic1_t mm1 = freeMagic1_init();
+	    freeMagic1(&mm1, (char *)la);
+	    la = la->ar_next;
+	    freeMagic1_end(&mm1);
+	}
     }
     return;
 }

--- a/commands/CmdCD.c
+++ b/commands/CmdCD.c
@@ -2455,6 +2455,7 @@ CmdContact(
 
 	    rmask = DBResidueMask(type);
 
+	    free_magic1_t mm1 = freeMagic1_init();
 	    while (lr != NULL)
 	    {
     		GeoClip(&lr->r_r, &area);
@@ -2465,9 +2466,10 @@ CmdContact(
 	    	    if (TTMaskHasType(rmask, rtype))
 			DBPaint(EditCellUse->cu_def, &lr->r_r, rtype);
 
-		freeMagic(lr);
+		freeMagic1(&mm1, lr);
 		lr = lr->r_next;
 	    }
+	    freeMagic1_end(&mm1);
 
 	    /* Refresh the layout drawing */
 	    DBWAreaChanged(EditCellUse->cu_def, &area, DBW_ALLWINDOWS, &smask);
@@ -2504,14 +2506,16 @@ CmdContact(
 	DBSrPaintArea((Tile *) NULL, EditCellUse->cu_def->cd_planes[DBPlane(rtype)],
 		&area, &smask, cmdContactFunc, (ClientData) &ccs);
 
+	free_magic1_t mm1 = freeMagic1_init();
 	while (ccs.lhead != NULL)
 	{
 	    TTMaskSetOnlyType(&smask, type);
 	    TTMaskAndMask(&smask, &DBActiveLayerBits);
 	    DBPaintMask(EditCellUse->cu_def, &ccs.lhead->r_r, &smask);
-	    freeMagic(ccs.lhead);
+	    freeMagic1(&mm1, ccs.lhead);
 	    ccs.lhead = ccs.lhead->r_next;
 	}
+	freeMagic1_end(&mm1);
 
 	/* Refresh the layout drawing */
 	DBWAreaChanged(EditCellUse->cu_def, &area, DBW_ALLWINDOWS, &smask);
@@ -2952,14 +2956,22 @@ CmdCorner(
 
 	    rectp = CIFPolyToRects(cmdPathList.pathlist->pathhead, plane,
 			resultTbl, &ui, FALSE);
-	    for (; rectp != NULL; rectp = rectp->r_next)
 	    {
-		DBPaintPlane(plane, &rectp->r_r, resultTbl, &ui);
-		freeMagic((char *)rectp);
+		free_magic1_t mm1 = freeMagic1_init();
+		for (; rectp != NULL; rectp = rectp->r_next)
+		{
+		    DBPaintPlane(plane, &rectp->r_r, resultTbl, &ui);
+		    freeMagic1(&mm1, (char *)rectp);
+		}
+		freeMagic1_end(&mm1);
 	    }
 	    CIFFreePath(cmdPathList.pathlist->pathhead);
-	    freeMagic((char *)cmdPathList.pathlist);
-	    cmdPathList.pathlist = cmdPathList.pathlist->cpl_next;
+	    {
+		free_magic1_t mm1 = freeMagic1_init();
+		freeMagic1(&mm1, (char *)cmdPathList.pathlist);
+		cmdPathList.pathlist = cmdPathList.pathlist->cpl_next;
+		freeMagic1_end(&mm1);
+	    }
 	}
     }
     else
@@ -2977,14 +2989,16 @@ CmdCorner(
 	/* Now that we've got all the material, scan over the list
 	 * painting the material and freeing up the entries on the list.
 	 */
+	free_magic1_t mm1 = freeMagic1_init();
 	while (cmdCornerList != NULL)
 	{
 	    DBPaint(EditCellUse->cu_def, &cmdCornerList->cca_area,
 			cmdCornerList->cca_type);
-	    freeMagic((char *) cmdCornerList);
+	    freeMagic1(&mm1, (char *) cmdCornerList);
 	    cmdCornerList = cmdCornerList->cca_next;
 	}
-    }
+	freeMagic1_end(&mm1);
+}
 
     SelectClear();
     DBAdjustLabels(EditCellUse->cu_def, &editBox);
@@ -3643,8 +3657,10 @@ cmdBevelFunc(
     GeoClip(&r3, &cmdCornerRootBox);
     if (GEO_RECTNULL(&r2) || GEO_RECTNULL(&r3))
     {
+	free_magic1_t mm1 = freeMagic1_init();
 	for (pptr = pathhead; pptr != NULL; pptr = pptr->cifp_next)
-	    freeMagic((char *)pptr);
+	    freeMagic1(&mm1, (char *)pptr);
+	freeMagic1_end(&mm1);
 	return 0;
     }
 
@@ -4154,6 +4170,7 @@ CmdDrc(
 
 	    rootUse = (CellUse *) window->w_surfaceID;
 	    dcl = DRCCount(rootUse, &rootArea, doforall);
+	    free_magic1_t mm1 = freeMagic1_init();
 	    while (dcl != NULL)
 	    {
 		if (count_total >= 0)
@@ -4183,9 +4200,10 @@ CmdDrc(
 		    }
 #endif
 		}
-		freeMagic((char *)dcl);
+		freeMagic1(&mm1, (char *)dcl);
 		dcl = dcl->dcl_next;
 	    }
+	    freeMagic1_end(&mm1);
 
 #ifdef MAGIC_WRAPPER
 	    if ((count_total >= 0) || (!dolist))
@@ -4334,12 +4352,14 @@ CmdDrc(
 	    }
 	    if (findonly)
 	    {
+		free_magic1_t mm1 = freeMagic1_init();
 		/* Delete temporary rules */
 		while (DRCIgnoreRules != NULL)
 		{
-		    freeMagic(DRCIgnoreRules);
+		    freeMagic1(&mm1, DRCIgnoreRules);
 		    DRCIgnoreRules = DRCIgnoreRules->li_next;
 		}
+		freeMagic1_end(&mm1);
 		/* Replace temporary set of rules */
 		DRCIgnoreRules = DRCSaveRules;
 	    }
@@ -4422,8 +4442,10 @@ CmdDrc(
 	    {
 		while (DRCIgnoreRules != NULL)
 		{
-		    freeMagic(DRCIgnoreRules);
+		    free_magic1_t mm1 = freeMagic1_init();
+		    freeMagic1(&mm1, DRCIgnoreRules);
 		    DRCIgnoreRules = DRCIgnoreRules->li_next;
+		    freeMagic1_end(&mm1);
 		}
 	    }
 	    else

--- a/commands/CmdFI.c
+++ b/commands/CmdFI.c
@@ -581,13 +581,15 @@ CmdFill(
     /* Now that we've got all the material, scan over the list
      * painting the material and freeing up the entries on the list.
      */
+    free_magic1_t mm1 = freeMagic1_init();
     while (cmdFillList != NULL)
     {
 	DBPaint(EditCellUse->cu_def, &cmdFillList->cfa_area,
 		cmdFillList->cfa_type);
-	freeMagic((char *) cmdFillList);
+	freeMagic1(&mm1, (char *) cmdFillList);
 	cmdFillList = cmdFillList->cfa_next;
     }
+    freeMagic1_end(&mm1);
 
     SelectClear();
     DBAdjustLabels(EditCellUse->cu_def, &editBox);

--- a/commands/CmdRS.c
+++ b/commands/CmdRS.c
@@ -1256,15 +1256,17 @@ CmdSelect(
 	    /* of rlist)						*/
 	    SelectClear();
 
+	    free_magic1_t mm1 = freeMagic1_init();
 	    while (rlist != NULL)
 	    {
 		/* Paint rlist back into SelectDef */
 		DBPaint(SelectDef, &rlist->r_r, rlist->r_type);
 
 		/* cleanup as we go */
-		freeMagic(rlist);
+		freeMagic1(&mm1, rlist);
 		rlist = rlist->r_next;
 	    }
+	    freeMagic1_end(&mm1);
 
 	    /* Force erase and redraw of the selection */
 	    DBReComputeBbox(SelectDef);

--- a/commands/CmdTZ.c
+++ b/commands/CmdTZ.c
@@ -1103,11 +1103,13 @@ CmdWhat(
 			}
 #endif
 
-		        while (lid != NULL)
-		        {
-			   freeMagic(lid);
+			free_magic1_t mm1 = freeMagic1_init();
+			while (lid != NULL)
+			{
+			   freeMagic1(&mm1, lid);
 			   lid = lid->lid_next;
 			}
+			freeMagic1_end(&mm1);
 #ifdef MAGIC_WRAPPER
 			if (doListAll)
 			    Tcl_ListObjAppendElement(magicinterp, paintobj,

--- a/database/DBcellname.c
+++ b/database/DBcellname.c
@@ -320,6 +320,7 @@ DBCellDelete(cellname, force)
     /* use.  If so, load the window with (UNNAMED).			*/
 
     UndoDisable();
+    free_magic1_t mm1 = freeMagic1_init();
     for (celluse = celldef->cd_parents; celluse != (CellUse *) NULL;
 	 	celluse = celluse->cu_nextuse)
     {
@@ -328,8 +329,9 @@ DBCellDelete(cellname, force)
 	    WindUnload(celluse);
 	    freeMagic(celluse->cu_id);
 	}
-	freeMagic((char *)celluse);
+	freeMagic1(&mm1, (char *)celluse);
     }
+    freeMagic1_end(&mm1);
     celldef->cd_parents = (CellUse *)NULL;
 
     DBWResetBox(celldef);
@@ -2006,8 +2008,10 @@ DBCellDefFree(cellDef)
 	cellDef->cd_planes[pNum] = (Plane *) NULL;
     }
 
+    free_magic1_t mm1 = freeMagic1_init();
     for (lab = cellDef->cd_labels; lab; lab = lab->lab_next)
-	freeMagic((char *) lab);
+	freeMagic1(&mm1, (char *) lab);
+    freeMagic1_end(&mm1);
     SigEnableInterrupts();
     HashKill(&cellDef->cd_idHash);
 

--- a/database/DBcellsrch.c
+++ b/database/DBcellsrch.c
@@ -1514,13 +1514,14 @@ DBScaleEverything(scalen, scaled)
     }
 
     /* Free the linked CellDef list */
-
+    free_magic1_t mm1 = freeMagic1_init();
     lcd = lhead;
     while (lcd != NULL)
     {
-	freeMagic((char *)lcd);
+	freeMagic1(&mm1, (char *)lcd);
 	lcd = lcd->cd_next;
     }
+    freeMagic1_end(&mm1);
 
     /* Scale all elements */
     DBWScaleElements(scalen, scaled);
@@ -1767,12 +1768,14 @@ DBSrCellUses(cellDef, func, arg)
     }
 
     /* Free this linked cellUse structure */
+    free_magic1_t mm1 = freeMagic1_init();
     lu = luhead;
     while (lu != NULL)
     {
-	freeMagic((char *)lu);
+	freeMagic1(&mm1, (char *)lu);
 	lu = lu->cu_next;
     }
+    freeMagic1_end(&mm1);
     return retval;
 }
 
@@ -2000,12 +2003,14 @@ dbScaleCell(cellDef, scalen, scaled)
     BPFree(cellPlaneOrig);
 
     /* Free this linked cellUse structure */
+    free_magic1_t mm1 = freeMagic1_init();
     lu = luhead;
     while (lu != NULL)
     {
-	freeMagic((char *)lu);
+	freeMagic1(&mm1, (char *)lu);
 	lu = lu->cu_next;
     }
+    freeMagic1_end(&mm1);
 
     /* Scale all of the paint tiles in this cell by creating a new plane */
     /* and copying all tiles into the new plane at scaled dimensions.	 */
@@ -2208,12 +2213,14 @@ DBMoveCell(cellDef, origx, origy)
     BPFree(cellPlaneOrig);
 
     /* Free this linked cellUse structure */
+    free_magic1_t mm1 = freeMagic1_init();
     lu = luhead;
     while (lu != NULL)
     {
-	freeMagic((char *)lu);
+	freeMagic1(&mm1, (char *)lu);
 	lu = lu->cu_next;
     }
+    freeMagic1_end(&mm1);
 
     /* Move all of the paint tiles in this cell by creating a new plane */
     /* and copying all tiles into the new plane at the new position.	 */

--- a/database/DBcellsubr.c
+++ b/database/DBcellsubr.c
@@ -218,8 +218,10 @@ DBCellClearDef(cellDef)
     cellDef->cd_bbox.r_xtop = cellDef->cd_bbox.r_ytop = 1;
     cellDef->cd_extended.r_xbot = cellDef->cd_extended.r_ybot = 0;
     cellDef->cd_extended.r_xtop = cellDef->cd_extended.r_ytop = 1;
+    free_magic1_t mm1 = freeMagic1_init();
     for (lab = cellDef->cd_labels; lab; lab = lab->lab_next)
-	freeMagic((char *) lab);
+	freeMagic1(&mm1, (char *) lab);
+    freeMagic1_end(&mm1);
     cellDef->cd_labels = (Label *) NULL;
     cellDef->cd_lastLabel = (Label *) NULL;
 

--- a/database/DBio.c
+++ b/database/DBio.c
@@ -280,8 +280,10 @@ DBSearchForTech(techname, techroot, pathroot, level)
 		if (!strcmp(tdent->d_name, techname))
 		{
 		    closedir(tdir);
+		    free_magic1_t mm1 = freeMagic1_init();
 		    for (ld = dlist; ld; ld = ld->ld_next)
-			freeMagic(ld);
+			freeMagic1(&mm1, ld);
+		    freeMagic1_end(&mm1);
 		    return pathroot;
 		}
 	    }
@@ -294,8 +296,10 @@ DBSearchForTech(techname, techroot, pathroot, level)
 		if (found)
 		{
 		    closedir(tdir);
+		    free_magic1_t mm1 = freeMagic1_init();
 		    for (ld = dlist; ld; ld = ld->ld_next)
-			freeMagic(ld);
+			freeMagic1(&mm1, ld);
+		    freeMagic1_end(&mm1);
 		    return found;
 		}
 	    }
@@ -303,8 +307,12 @@ DBSearchForTech(techname, techroot, pathroot, level)
 	closedir(tdir);
     }
 
-    for (ld = dlist; ld; ld = ld->ld_next)
-	freeMagic(ld);
+    {
+	free_magic1_t mm1 = freeMagic1_init();
+	for (ld = dlist; ld; ld = ld->ld_next)
+	    freeMagic1(&mm1, ld);
+	freeMagic1_end(&mm1);
+    }
 
     return NULL;
 }

--- a/database/DBlabel.c
+++ b/database/DBlabel.c
@@ -280,6 +280,7 @@ DBEraseGlobLabel(cellDef, area, mask, areaReturn, globmatch)
     bool erasedAny = FALSE;
     TileType newType;
 
+    free_magic1_t mm1 = freeMagic1_init();
     labPrev = NULL;
     lab = cellDef->cd_labels;
     while (lab != NULL)
@@ -313,7 +314,7 @@ DBEraseGlobLabel(cellDef, area, mask, areaReturn, globmatch)
 	if ((lab->lab_font >= 0) && areaReturn)
 	    GeoInclude(&lab->lab_bbox, areaReturn);
 
-	freeMagic((char *) lab);
+	freeMagic1(&mm1, (char *) lab);
 	lab = lab->lab_next;
 	erasedAny = TRUE;
 	continue;
@@ -321,6 +322,7 @@ DBEraseGlobLabel(cellDef, area, mask, areaReturn, globmatch)
 	nextLab: labPrev = lab;
 	lab = lab->lab_next;
     }
+    freeMagic1_end(&mm1);
 
     if (erasedAny)
 	cellDef->cd_flags |= CDMODIFIED|CDGETNEWSTAMP;
@@ -442,6 +444,7 @@ DBEraseLabelsByContent(def, rect, type, text)
 {
     Label *lab, *labPrev;
 
+    free_magic1_t mm1 = freeMagic1_init();
     for (labPrev = NULL, lab = def->cd_labels;
 	    lab != NULL;
 	    labPrev = lab, lab = lab->lab_next)
@@ -457,7 +460,7 @@ DBEraseLabelsByContent(def, rect, type, text)
 	else labPrev->lab_next = lab->lab_next;
 	if (def->cd_lastLabel == lab)
 	    def->cd_lastLabel = labPrev;
-	freeMagic((char *) lab);
+	freeMagic1(&mm1, (char *) lab);
 
 	/* Don't iterate through loop, since this will skip a label:
 	 * just go back to top.  This is tricky!
@@ -467,6 +470,7 @@ DBEraseLabelsByContent(def, rect, type, text)
 	if (lab == NULL) break;
 	else goto nextCheck;
     }
+    freeMagic1_end(&mm1);
 }
 
 /*
@@ -495,6 +499,7 @@ DBRemoveLabel(def, refLab)
 {
     Label *lab, *labPrev;
 
+    free_magic1_t mm1 = freeMagic1_init();
     for (labPrev = NULL, lab = def->cd_labels;
 	    lab != NULL;
 	    labPrev = lab, lab = lab->lab_next)
@@ -508,7 +513,7 @@ DBRemoveLabel(def, refLab)
 	else labPrev->lab_next = lab->lab_next;
 	if (def->cd_lastLabel == lab)
 	    def->cd_lastLabel = labPrev;
-	freeMagic((char *) lab);
+	freeMagic1(&mm1, (char *) lab);
 
 	/* Don't iterate through loop, since this will skip a label:
 	 * just go back to top.  This is tricky!
@@ -518,6 +523,7 @@ DBRemoveLabel(def, refLab)
 	if (lab == NULL) break;
 	else goto nextCheck;
     }
+    freeMagic1_end(&mm1);
 }
 
 /*
@@ -760,8 +766,10 @@ DBAdjustLabelsNew(def, area)
 		    def->cd_lastLabel = labPrev;
 		DBUndoEraseLabel(def, lab);
 		DBWLabelChanged(def, lab, DBW_ALLWINDOWS);
-		freeMagic((char *) lab);
+		free_magic1_t mm1 = freeMagic1_init();
+		freeMagic1(&mm1, (char *) lab);
 		lab = lab->lab_next;
+		freeMagic1_end(&mm1);
 		modified = TRUE;
 		continue;
 	    }
@@ -1744,8 +1752,10 @@ DBLoadFont(fontfile, scale)
 		}
 
 		/* Remove the pointlist */
+		free_magic1_t mm1 = freeMagic1_init();
 		for (newPath = pathStart; newPath != NULL; newPath = newPath->fp_next)
-		    freeMagic(newPath);
+		    freeMagic1(&mm1, newPath);
+		freeMagic1_end(&mm1);
 		pathStart = NULL;
 	    }
 	    else

--- a/database/DBpaint.c
+++ b/database/DBpaint.c
@@ -1796,12 +1796,14 @@ nextrect:
 	    lr = lr->r_next;
 	}
 
+	free_magic1_t mm1 = freeMagic1_init();
 	lr = lhead;
 	while (lr != NULL)
 	{
-	    freeMagic((char *) lr);
+	    freeMagic1(&mm1, (char *) lr);
 	    lr = lr->r_next;
 	}
+	freeMagic1_end(&mm1);
     }
     else
 	result = DBPaintPlane0(plane, area, resultTbl, undo, (method == PAINT_MARK) ?

--- a/database/DBtechtype.c
+++ b/database/DBtechtype.c
@@ -126,12 +126,14 @@ DBTechInitPlane(void)
     {
 	NameList *tbl;
 
+	free_magic1_t mm1 = freeMagic1_init();
 	for (tbl = dbPlaneNameLists.sn_next; tbl != &dbPlaneNameLists;
 			tbl = tbl->sn_next)
 	{
 	    freeMagic(tbl->sn_name);
-	    freeMagic(tbl);
+	    freeMagic1(&mm1, tbl);
 	}
+	freeMagic1_end(&mm1);
     }
 
     /* Tables of short names */
@@ -205,12 +207,14 @@ DBTechInitType()
     {
 	NameList *tbl;
 
+	free_magic1_t mm1 = freeMagic1_init();
 	for (tbl = dbTypeNameLists.sn_next; tbl != &dbTypeNameLists;
 		tbl = tbl->sn_next)
 	{
 	    freeMagic(tbl->sn_name);
-	    freeMagic(tbl);
+	    freeMagic1(&mm1, tbl);
 	}
+	freeMagic1_end(&mm1);
     }
 
     /* Tables of short names */

--- a/database/DBtimestmp.c
+++ b/database/DBtimestmp.c
@@ -137,8 +137,10 @@ DBFixMismatch()
 
 	cellDef = mismatch->mm_cellDef;
 	oldArea = mismatch->mm_oldArea;
-	freeMagic((char *) mismatch);
+	free_magic1_t mm1 = freeMagic1_init();
+	freeMagic1(&mm1, (char *) mismatch);
 	mismatch = mismatch->mm_next;
+	freeMagic1_end(&mm1);
 	if (cellDef->cd_flags & CDPROCESSED) continue;
 
 	(void) DBCellRead(cellDef, TRUE, TRUE, NULL);
@@ -182,13 +184,15 @@ DBFixMismatch()
     }
     SigEnableInterrupts();
     TxPrintf("Timestamp mismatches found in these cells: ");
+    free_magic1_t mm1 = freeMagic1_init();
     while (cl != NULL)
     {
 	TxPrintf("%s", cl->cl_cell->cd_name);
 	if (cl->cl_next != NULL) TxPrintf(", ");
-	freeMagic(cl);
+	freeMagic1(&mm1, cl);
 	cl = cl->cl_next;
     }
+    freeMagic1_end(&mm1);
     TxPrintf(".\n");
     TxFlush();
     if (redisplay) WindAreaChanged((MagWindow *) NULL, (Rect *) NULL);

--- a/dbwind/DBWelement.c
+++ b/dbwind/DBWelement.c
@@ -588,10 +588,12 @@ DBWElementDelete(MagWindow *w, char *name)
     if (elem->flags & DBW_ELEMENT_PERSISTENT)
 	elem->rootDef->cd_flags |= CDMODIFIED;
 
+    free_magic1_t mm1 = freeMagic1_init();
     for (stylePtr = elem->stylelist; stylePtr != NULL; stylePtr = stylePtr->next)
     {
-	freeMagic(stylePtr);
+	freeMagic1(&mm1, stylePtr);
     }
+    freeMagic1_end(&mm1);
     if (elem->type == ELEMENT_TEXT)
 	freeMagic(elem->text);
 
@@ -1156,8 +1158,10 @@ DBWElementStyle(MagWindow *w, char *ename, int style, bool add)
 			(elem->stylelist->style == style))
 	    {
 		dbwElementUndraw(w, elem);
-		freeMagic(elem->stylelist);
+		free_magic1_t mm1 = freeMagic1_init();
+		freeMagic1(&mm1, elem->stylelist);
 		elem->stylelist = elem->stylelist->next;
+		freeMagic1_end(&mm1);
 		if (elem->stylelist == NULL)
 		    TxPrintf("Warning:  Element %s has no styles!\n", ename);
 	    }
@@ -1169,8 +1173,10 @@ DBWElementStyle(MagWindow *w, char *ename, int style, bool add)
 	    else if (sptr->next != NULL)
 	    {
 		dbwElementUndraw(w, elem);
-		freeMagic(sptr->next);
+		free_magic1_t mm1 = freeMagic1_init();
+		freeMagic1(&mm1, sptr->next);
 		sptr->next = sptr->next->next;
+		freeMagic1_end(&mm1);
 	    }
 	}
 	/* mark element's cell as having been modified */
@@ -1279,8 +1285,10 @@ DBWElementClearDef(cellDef)
 	if (!elem) continue;
 	if (elem->rootDef != cellDef) continue;
 
+	free_magic1_t mm1 = freeMagic1_init();
 	for (stylePtr = elem->stylelist; stylePtr != NULL; stylePtr = stylePtr->next)
-	    freeMagic(stylePtr);
+	    freeMagic1(&mm1, stylePtr);
+	freeMagic1_end(&mm1);
 
 	if (elem->type == ELEMENT_TEXT)
 	    freeMagic(elem->text);

--- a/drc/DRCcontin.c
+++ b/drc/DRCcontin.c
@@ -547,8 +547,10 @@ DRCContinuous()
 
 	if (DRCPendingRoot != (DRCPendingCookie *)NULL) {
 	    DBReComputeBbox(DRCPendingRoot->dpc_def);
-	    freeMagic((char *) DRCPendingRoot);
+	    free_magic1_t mm1 = freeMagic1_init();
+	    freeMagic1(&mm1, (char *) DRCPendingRoot);
 	    DRCPendingRoot = DRCPendingRoot->dpc_next;
+	    freeMagic1_end(&mm1);
 	}
 
 	/* Give the timestamp manager a chance to update any mismatches. */

--- a/drc/DRCtech.c
+++ b/drc/DRCtech.c
@@ -522,11 +522,13 @@ DRCTechInit()
 
     drcTechFreeStyle();
 
+    free_magic1_t mm1 = freeMagic1_init();
     for (style = DRCStyleList; style != NULL; style = style->ds_next)
     {
 	freeMagic(style->ds_name);
-	freeMagic(style);
+	freeMagic1(&mm1, style);
     }
+    freeMagic1_end(&mm1);
     DRCStyleList = NULL;
 }
 
@@ -4044,6 +4046,7 @@ drcTechFinalStyle(style)
     {
 	for (j = 0; j < DBNumTypes; j++)
 	{
+	    free_magic1_t mm1 = freeMagic1_init();
 	    for (dp = style->DRCRulesTbl[i][j]; dp != NULL; dp = dp->drcc_next)
 	    {
 		/* Don't optimize on trigger rules; optimize on the	*/
@@ -4126,7 +4129,8 @@ drcTechFinalStyle(style)
 		if (dptrig != NULL)
 		{
 		    dptrig = dp->drcc_next;
-		    freeMagic((char *)dp->drcc_next);
+		    free_magic1_t mm1_ = freeMagic1_init();
+		    freeMagic1(&mm1_, (char *)dp->drcc_next);
 		    *dp2back = dp->drcc_next->drcc_next;
 
 		    /* Replace this entry so on the next cycle	*/
@@ -4134,13 +4138,15 @@ drcTechFinalStyle(style)
 		    /* even though dp is free'd (below), due to	*/
 		    /* the one-delayed free mechanism.		*/
 		    dp->drcc_next = *dp2back;
+		    freeMagic1_end(&mm1_);
 		}
 		else
 		    *dp2back = dp->drcc_next;
 
-		freeMagic((char *) dp);
+		freeMagic1(&mm1, (char *) dp);
 		drcRulesOptimized += 1;
 	    }
+	    freeMagic1_end(&mm1);
 	}
     }
 }

--- a/ext2sim/ext2sim.c
+++ b/ext2sim/ext2sim.c
@@ -683,8 +683,10 @@ runexttosim:
 	EFVisitDevs(simmergeVisit, PTR2CD(NULL));
 	TxPrintf("Devices merged: %d\n", esDevsMerged);
 	esFMIndex = 0;
+	free_magic1_t mm1 = freeMagic1_init();
 	for (p = devMergeList; p != NULL; p = p->next)
-	    freeMagic((char *)p);
+	    freeMagic1(&mm1, (char *)p);
+	freeMagic1_end(&mm1);
 	devMergeList = NULL;
     }
 

--- a/ext2spice/ext2hier.c
+++ b/ext2spice/ext2hier.c
@@ -2201,11 +2201,13 @@ esMakePorts(
     }
 
     /* Free table data */
+    free_magic1_t mm1 = freeMagic1_init();
     while (flagtop != NULL)
     {
-	freeMagic((char *)flagtop);
+	freeMagic1(&mm1, (char *)flagtop);
 	flagtop = flagtop->fdr_next;
     }
+    freeMagic1_end(&mm1);
     HashKill(&flagHashTable);
     return 0;
 }
@@ -2337,8 +2339,10 @@ esHierVisit(
 	    EFHierVisitDevs(hcf, spcdevHierMergeVisit, (ClientData)NULL);
 	    TxPrintf("Devs merged: %d\n", esSpiceDevsMerged);
 	    esFMIndex = 0;
+	    free_magic1_t mm1 = freeMagic1_init();
 	    for (p = devMergeList; p != NULL; p = p->next)
-		freeMagic((char *)p);
+		freeMagic1(&mm1, (char *)p);
+	    freeMagic1_end(&mm1);
 	    devMergeList = NULL;
 	}
 	else if (esDistrJunct)

--- a/ext2spice/ext2spice.c
+++ b/ext2spice/ext2spice.c
@@ -1104,8 +1104,10 @@ runexttospice:
 
 	    fprintf(esSpiceF, " ");
 	    freeMagic(glist->gll_name);
-	    freeMagic(glist);
+	    free_magic1_t mm1 = freeMagic1_init();
+	    freeMagic1(&mm1, glist);
 	    glist = glist->gll_next;
+	    freeMagic1_end(&mm1);
 	}
 	fprintf(esSpiceF, "\n\n");
     }
@@ -1159,8 +1161,10 @@ runexttospice:
 	    EFVisitDevs(devMergeVisit, (ClientData) NULL);
 	    TxPrintf("Devs merged: %d\n", esSpiceDevsMerged);
 	    esFMIndex = 0;
+	    free_magic1_t mm1 = freeMagic1_init();
 	    for (p = devMergeList; p != NULL; p = p->next)
-		freeMagic((char *) p);
+		freeMagic1(&mm1, (char *) p);
+	    freeMagic1_end(&mm1);
 	    devMergeList = NULL;
 	}
 	else if (esDistrJunct)
@@ -1905,8 +1909,10 @@ topVisit(
 	sname = lnn->lnn_nodeName;
 	if (esDoBlackBox == FALSE || !(def->def_flags & DEF_ABSTRACT))
 	    sname->efnn_port = ++portmax;
-	freeMagic(lnn);
+	free_magic1_t mm1 = freeMagic1_init();
+	freeMagic1(&mm1, lnn);
 	lnn = lnn->lnn_next;
+	freeMagic1_end(&mm1);
     }
 
     /* Port numbers need not start at zero or be contiguous.  They will be  */

--- a/extflat/EFbuild.c
+++ b/extflat/EFbuild.c
@@ -2240,23 +2240,33 @@ efFreeNodeList(head, func)
     EFAttr *ap;
     LinkedRect *lr;
 
+    free_magic1_t mm1 = freeMagic1_init();
     for (node = (EFNode *) head->efnode_next;
 	    node != head;
 	    node = (EFNode *) node->efnode_next)
     {
-	for (ap = node->efnode_attrs; ap; ap = ap->efa_next)
-	    freeMagic((char *) ap);
+	{
+	    free_magic1_t mm1_ = freeMagic1_init();
+	    for (ap = node->efnode_attrs; ap; ap = ap->efa_next)
+		freeMagic1(&mm1_, (char *) ap);
+	    freeMagic1_end(&mm1_);
+	}
 	if (node->efnode_client != (ClientData)NULL)
 	{
 	    if (func != NULL)
 		(*func)(node->efnode_client);
 	    freeMagic((char *)node->efnode_client);
 	}
-	for (lr = node->efnode_disjoint; lr; lr = lr->r_next)
-	    freeMagic((char *)lr);
+	{
+	    free_magic1_t mm1_ = freeMagic1_init();
+	    for (lr = node->efnode_disjoint; lr; lr = lr->r_next)
+		freeMagic1(&mm1_, (char *)lr);
+	    freeMagic1_end(&mm1_);
+	}
 
-	freeMagic((char *) node);
+	freeMagic1(&mm1, (char *) node);
     }
+    freeMagic1_end(&mm1);
 }
 
 /*

--- a/extflat/EFbuild.c
+++ b/extflat/EFbuild.c
@@ -1487,6 +1487,34 @@ efBuildUse(def, subDefName, subUseId, ta, tb, tc, td, te, tf)
 /*
  * ----------------------------------------------------------------------------
  *
+ * efConnectionFreeLinkedList --
+ *
+ * Release memory for linked-list of Connection* based on internal list
+ *  at Connection->conn_next.  'conn' argument must be non-NULL.
+ *
+ * Results:
+ *	Deallocates linked-list of Connection* starting at 'conn'
+ *
+ * Side effects:
+ *	Deallocates one or more connection record(s).
+ *
+ * ----------------------------------------------------------------------------
+ */
+
+void
+efConnectionFreeLinkedList(Connection *conn)
+{
+    while (conn)
+    {
+	Connection *next = conn->conn_next;
+	efFreeConn(conn);
+	conn = next;
+    }
+}
+
+/*
+ * ----------------------------------------------------------------------------
+ *
  * efBuildConnect --
  *
  * Process a "connect" line from a .ext file.

--- a/extflat/EFdef.c
+++ b/extflat/EFdef.c
@@ -126,11 +126,13 @@ EFDone(func)
 	for (conn = def->def_resistors; conn; conn = conn->conn_next)
 	    efFreeConn(conn);
 
+	free_magic1_t mm1 = freeMagic1_init();
 	for (kill = def->def_kills; kill; kill = kill->kill_next)
 	{
 	    freeMagic(kill->kill_name);
-	    freeMagic((char *) kill);
+	    freeMagic1(&mm1, (char *) kill);
 	}
+	freeMagic1_end(&mm1);
 	freeMagic((char *) def);
     }
 
@@ -157,8 +159,10 @@ EFDone(func)
 	while (plist != NULL)
 	{
 	    freeMagic(plist->parm_name);
-	    freeMagic(plist);
+	    free_magic1_t mm1 = freeMagic1_init();
+	    freeMagic1(&mm1, plist);
 	    plist = plist->parm_next;
+	    freeMagic1_end(&mm1);
 	}
     }
     HashKill(&efDevParamTable);

--- a/extflat/EFdef.c
+++ b/extflat/EFdef.c
@@ -119,12 +119,9 @@ EFDone(func)
 	HashKill(&def->def_dists);
 	HashKill(&def->def_uses);
 	HashKill(&def->def_devs);
-	for (conn = def->def_conns; conn; conn = conn->conn_next)
-	    efFreeConn(conn);
-	for (conn = def->def_caps; conn; conn = conn->conn_next)
-	    efFreeConn(conn);
-	for (conn = def->def_resistors; conn; conn = conn->conn_next)
-	    efFreeConn(conn);
+	efConnectionFreeLinkedList(def->def_conns);
+	efConnectionFreeLinkedList(def->def_caps);
+	efConnectionFreeLinkedList(def->def_resistors);
 
 	free_magic1_t mm1 = freeMagic1_init();
 	for (kill = def->def_kills; kill; kill = kill->kill_next)

--- a/extflat/EFint.h
+++ b/extflat/EFint.h
@@ -306,6 +306,7 @@ extern void CapHashSetValue();
 
 extern DevParam *efGetDeviceParams();
 extern void efBuildNode();
+extern void efConnectionFreeLinkedList(Connection *conn);
 extern void efBuildConnect();
 extern void efBuildResistor();
 extern void efBuildCap();

--- a/extflat/EFname.c
+++ b/extflat/EFname.c
@@ -465,18 +465,20 @@ EFHNFree(hierName, prefix, type)
 {
     HierName *hn;
 
+    free_magic1_t mm1 = freeMagic1_init();
     for (hn = hierName; hn; hn = hn->hn_parent)
     {
 	if (hn == prefix)
 	    break;
 
-	freeMagic((char *) hn);
+	freeMagic1(&mm1, (char *) hn);
 	if (efHNStats)
 	{
 	    int len = strlen(hn->hn_name);
 	    efHNRecord(-HIERNAMESIZE(len), type);
 	}
     }
+    freeMagic1_end(&mm1);
 }
 
 /*

--- a/extract/ExtBasic.c
+++ b/extract/ExtBasic.c
@@ -2361,8 +2361,10 @@ extOutputDevices(def, transList, outFile)
 				    break;
 				}
 			    }
+			    free_magic1_t mm1 = freeMagic1_init();
 			    for (lt = extSpecialDevice; lt; lt = lt->t_next)
-				freeMagic((char *)lt);
+				freeMagic1(&mm1, (char *)lt);
+			    freeMagic1_end(&mm1);
 			}
 		    }
 		    else
@@ -2679,8 +2681,12 @@ extOutputDevices(def, transList, outFile)
 		    /* Free the lists */
 
 		    for (i = 0; i < extTransRec.tr_nterm; i++)
+		    {
+			free_magic1_t mm1 = freeMagic1_init();
 			for (lb = extSpecialBounds[i]; lb != NULL; lb = lb->b_next)
-			    freeMagic((char *)lb);
+			    freeMagic1(&mm1, (char *)lb);
+			freeMagic1_end(&mm1);
+		    }
 		    freeMagic((char *)extSpecialBounds);
 
 		    /* Put the region list back the way we found it: */
@@ -2868,8 +2874,12 @@ extOutputDevices(def, transList, outFile)
 		    /* Free the lists */
 
 		    for (i = 0; i < n; i++)
+		    {
+			free_magic1_t mm1 = freeMagic1_init();
 			for (lb = extSpecialBounds[i]; lb != NULL; lb = lb->b_next)
-			    freeMagic((char *)lb);
+			    freeMagic1(&mm1, (char *)lb);
+			freeMagic1_end(&mm1);
+		    }
 		    freeMagic((char *)extSpecialBounds);
 
 		    /* Put the region list back the way we found it: */
@@ -3016,8 +3026,12 @@ extOutputDevices(def, transList, outFile)
 			/* Free the lists */
 
 			for (i = 0; i < n; i++)
+			{
+			    free_magic1_t mm1 = freeMagic1_init();
 			    for (lb = extSpecialBounds[i]; lb != NULL; lb = lb->b_next)
-				freeMagic((char *)lb);
+				freeMagic1(&mm1, (char *)lb);
+			    freeMagic1_end(&mm1);
+			}
 			freeMagic((char *)extSpecialBounds);
 
 			/* Put the region list back the way we found it: */
@@ -3850,12 +3864,14 @@ extTransPerimFunc(bp)
 					extTermAPFunc, (ClientData)&eapd);
 
 		    shared = 1;
+		    free_magic1_t mm1 = freeMagic1_init();
 		    while (eapd.eapd_shared)
 		    {
 			shared++;
-			freeMagic(eapd.eapd_shared);
+			freeMagic1(&mm1, eapd.eapd_shared);
 			eapd.eapd_shared = eapd.eapd_shared->nl_next;
 		    }
+		    freeMagic1_end(&mm1);
 
 		    extTransRec.tr_termarea[thisterm] = eapd.eapd_area;
 		    extTransRec.tr_termperim[thisterm] = eapd.eapd_perim;

--- a/extract/ExtHard.c
+++ b/extract/ExtHard.c
@@ -495,6 +495,7 @@ extHardFreeAll(def, tReg)
     arg.fra_each = (int (*)()) NULL;
     arg.fra_region = (ExtRegion *) extUnInit;
 
+    free_magic1_t mm1 = freeMagic1_init();
     for (reg = tReg; reg; reg = reg->treg_next)
     {
 	/* Reset all ti_client fields to extUnInit */
@@ -506,11 +507,16 @@ extHardFreeAll(def, tReg)
 	}
 
 	/* Free all LabelLists and then the region */
-	for (ll = reg->treg_labels; ll; ll = ll->ll_next)
 	{
-	    if (ll->ll_label->lab_flags & LABEL_GENERATE) freeMagic(ll->ll_label);
-	    freeMagic((char *) ll);
+	    free_magic1_t mm1_ = freeMagic1_init();
+	    for (ll = reg->treg_labels; ll; ll = ll->ll_next)
+	    {
+		if (ll->ll_label->lab_flags & LABEL_GENERATE) freeMagic(ll->ll_label);
+		freeMagic1(&mm1_, (char *) ll);
+	    }
+	    freeMagic1_end(&mm1_);
 	}
-	freeMagic((char *) reg);
+	freeMagic1(&mm1, (char *) reg);
     }
+    freeMagic1_end(&mm1);
 }

--- a/extract/ExtLength.c
+++ b/extract/ExtLength.c
@@ -293,22 +293,30 @@ extLength(rootUse, f)
 	 * each of the receivers.  Free each driver label
 	 * as it is processed.
 	 */
-	for (dLab = dList; dLab; dLab = dLab->lab_next)
 	{
-	    for (rLab = rList; rLab; rLab = rLab->lab_next)
+	    free_magic1_t mm1 = freeMagic1_init();
+	    for (dLab = dList; dLab; dLab = dLab->lab_next)
 	    {
-		extPathPairDistance(dLab, rLab, &min, &max);
-		fprintf(f, "distance %s %s %d %d\n",
+		for (rLab = rList; rLab; rLab = rLab->lab_next)
+		{
+		    extPathPairDistance(dLab, rLab, &min, &max);
+		    fprintf(f, "distance %s %s %d %d\n",
 			dLab->lab_text, rLab->lab_text, min, max);
-	    }
+		}
 
-	    /* Free the driver label */
-	    freeMagic((char *) dLab);
+		/* Free the driver label */
+		freeMagic1(&mm1, (char *) dLab);
+	    }
+	    freeMagic1_end(&mm1);
 	}
 
 	/* Free all the receiver labels built up during this iteration */
-	for (rLab = rList; rLab; rLab = rLab->lab_next)
-	    freeMagic((char *) rLab);
+	{
+	    free_magic1_t mm1 = freeMagic1_init();
+	    for (rLab = rList; rLab; rLab = rLab->lab_next)
+		freeMagic1(&mm1, (char *) rLab);
+	    freeMagic1_end(&mm1);
+	}
 
 	/* For sanity since we've freed the driver label list */
 	HashSetValue(he, (ClientData) NULL);

--- a/extract/ExtMain.c
+++ b/extract/ExtMain.c
@@ -426,8 +426,10 @@ extDefPush(defList)
     while (defList != NULL)
     {
     	StackPush((ClientData)defList->ld_def, extDefStack);
-	freeMagic(defList);
+	free_magic1_t mm1 = freeMagic1_init();
+	freeMagic1(&mm1, defList);
 	defList = defList->ld_next;
+	freeMagic1_end(&mm1);
     }
 }
 
@@ -569,8 +571,12 @@ extParents(use, doExtract)
     extDefListFunc(use, &defList);
 
     /* use->cu_def is on the top of the list, so remove it */ 
-    freeMagic(defList);
-    defList = defList->ld_next;
+    {
+	free_magic1_t mm1 = freeMagic1_init();
+	freeMagic1(&mm1, defList);
+	defList = defList->ld_next;
+	freeMagic1_end(&mm1);
+    }
 
     while (defList != NULL)
     {
@@ -585,8 +591,10 @@ extParents(use, doExtract)
 	    sl = newsl;
 	}
 
-	freeMagic(defList);
+	free_magic1_t mm1 = freeMagic1_init();
+	freeMagic1(&mm1, defList);
 	defList = defList->ld_next;
+	freeMagic1_end(&mm1);
     }
 
     /* Mark all defs as being unvisited */
@@ -601,10 +609,14 @@ extParents(use, doExtract)
     StackFree(extDefStack);
 
     /* Replace any modified substrate planes in use->cu_def's children */
-    for (; sl; sl = sl->sl_next)
     {
-	ExtRevertSubstrate(sl->sl_def, sl->sl_plane);
-	freeMagic(sl);
+	free_magic1_t mm1 = freeMagic1_init();
+	for (; sl; sl = sl->sl_next)
+	{
+	    ExtRevertSubstrate(sl->sl_def, sl->sl_plane);
+	    freeMagic1(&mm1, sl);
+	}
+	freeMagic1_end(&mm1);
     }
 }
 
@@ -765,8 +777,12 @@ ExtractOneCell(def, outName, doLength)
     extDefListFunc(&dummyUse, &defList);
 
     /* def is on top of the list, so remove it */
-    freeMagic(defList);
-    defList = defList->ld_next;
+    {
+        free_magic1_t mm1 = freeMagic1_init();
+        freeMagic1(&mm1, defList);
+        defList = defList->ld_next;
+        freeMagic1_end(&mm1);
+    }
 
     /* Prepare substrates of all children of def */
     while (defList != NULL)
@@ -781,8 +797,10 @@ ExtractOneCell(def, outName, doLength)
             newsl->sl_next = sl;
             sl = newsl;
         }
-        freeMagic(defList);
+        free_magic1_t mm1 = freeMagic1_init();
+        freeMagic1(&mm1, defList);
         defList = defList->ld_next;
+        freeMagic1_end(&mm1);
     }
 
     savePlane = ExtCell(def, outName, doLength);
@@ -790,11 +808,13 @@ ExtractOneCell(def, outName, doLength)
     /* Restore all modified substrate planes */
 
     if (savePlane != NULL) ExtRevertSubstrate(def, savePlane);
+    free_magic1_t mm1 = freeMagic1_init();
     for (; sl; sl = sl->sl_next)
     {
         ExtRevertSubstrate(sl->sl_def, sl->sl_plane);
-        freeMagic(sl);
+        freeMagic1(&mm1, sl);
     }
+    freeMagic1_end(&mm1);
 }
 
 /* ------------------------------------------------------------------------- */
@@ -999,12 +1019,14 @@ extExtractStack(stack, doExtract, rootDef)
     }
 
     /* Replace any modified substrate planes */
+    free_magic1_t mm1 = freeMagic1_init();
     for (; sl; sl = sl->sl_next)
     {
 	ExtRevertSubstrate(sl->sl_def, sl->sl_plane);
 	sl->sl_def->cd_flags &= ~CDNOEXTRACT; 
-	freeMagic(sl);
+	freeMagic1(&mm1, sl);
     }
+    freeMagic1_end(&mm1);
 
     if (!doExtract)
     {

--- a/extract/ExtRegion.c
+++ b/extract/ExtRegion.c
@@ -507,8 +507,10 @@ ExtFreeRegions(regList)
 {
     ExtRegion *reg;
 
+    free_magic1_t mm1 = freeMagic1_init();
     for (reg = regList; reg; reg = reg->reg_next)
-	freeMagic((char *) reg);
+	freeMagic1(&mm1, (char *) reg);
+    freeMagic1_end(&mm1);
 }
 
 void
@@ -518,12 +520,16 @@ ExtFreeLabRegions(regList)
     LabRegion *lreg;
     LabelList *ll;
 
+    free_magic1_t mm1 = freeMagic1_init();
     for (lreg = regList; lreg; lreg = lreg->lreg_next)
     {
+	free_magic1_t mm1_ = freeMagic1_init();
 	for (ll = lreg->lreg_labels; ll; ll = ll->ll_next)
-	    freeMagic((char *) ll);
-	freeMagic((char *) lreg);
+	    freeMagic1(&mm1_, (char *) ll);
+	freeMagic1_end(&mm1_);
+	freeMagic1(&mm1, (char *) lreg);
     }
+    freeMagic1_end(&mm1);
 }
 
 void
@@ -533,13 +539,17 @@ ExtFreeHierLabRegions(regList)
     ExtRegion *reg;
     LabelList *ll;
 
+    free_magic1_t mm1 = freeMagic1_init();
     for (reg = regList; reg; reg = reg->reg_next)
     {
+	free_magic1_t mm1_ = freeMagic1_init();
 	for (ll = ((LabRegion *)reg)->lreg_labels; ll; ll = ll->ll_next)
 	{
 	    freeMagic((char *) ll->ll_label);
-	    freeMagic((char *) ll);
+	    freeMagic1(&mm1_, (char *) ll);
 	}
-	freeMagic((char *) reg);
+	freeMagic1_end(&mm1_);
+	freeMagic1(&mm1, (char *) reg);
     }
+    freeMagic1_end(&mm1);
 }

--- a/extract/ExtTech.c
+++ b/extract/ExtTech.c
@@ -884,6 +884,7 @@ extTechStyleInit(style)
 	if (style->exts_device[r] != NULL)
 	{
 	    ExtDevice *devptr;
+	    free_magic1_t mm1 = freeMagic1_init();
 	    for (devptr = style->exts_device[r]; devptr; devptr = devptr->exts_next)
 	    {
 
@@ -906,15 +907,18 @@ extTechStyleInit(style)
 		    {
 			if (devptr->exts_deviceParams->pl_name != NULL)
 			    freeMagic(devptr->exts_deviceParams->pl_name);
-			freeMagic(devptr->exts_deviceParams);
+			free_magic1_t mm1_ = freeMagic1_init();
+			freeMagic1(&mm1_, devptr->exts_deviceParams);
 			devptr->exts_deviceParams = devptr->exts_deviceParams->pl_next;
+			freeMagic1_end(&mm1_);
 		    }
 		}
 		if (devptr->exts_deviceResist.ht_table != (HashEntry **) NULL)
 		    HashKill(&devptr->exts_deviceResist);
 
-		freeMagic(devptr);
+		freeMagic1(&mm1, devptr);
 	    }
+	    freeMagic1_end(&mm1);
 	    style->exts_device[r] = (ExtDevice *)NULL;
 	}
     }
@@ -1124,11 +1128,13 @@ ExtTechInit()
 
     /* Forget all the extract style names */
 
+    free_magic1_t mm1 = freeMagic1_init();
     for (style = ExtAllStyles; style != NULL; style = style->exts_next)
     {
 	freeMagic(style->exts_name);
-	freeMagic(style);
+	freeMagic1(&mm1, style);
     }
+    freeMagic1_end(&mm1);
     ExtAllStyles = NULL;
 
     if (allExtractTypes == NULL)
@@ -2625,8 +2631,10 @@ ExtTechLine(sectionName, argc, argv)
 			{
 			    if (subcktParams->pl_name != NULL)
 				freeMagic(subcktParams->pl_name);
-			    freeMagic(subcktParams);
+			    free_magic1_t mm1 = freeMagic1_init();
+			    freeMagic1(&mm1, subcktParams);
 			    subcktParams = subcktParams->pl_next;
+			    freeMagic1_end(&mm1);
 			}
 			goto usage;
 		    }

--- a/extract/ExtYank.c
+++ b/extract/ExtYank.c
@@ -120,8 +120,10 @@ extHierFreeLabels(def)
 {
     Label *lab;
 
+    free_magic1_t mm1 = freeMagic1_init();
     for (lab = def->cd_labels; lab; lab = lab->lab_next)
-	freeMagic((char *) lab);
+	freeMagic1(&mm1, (char *) lab);
+    freeMagic1_end(&mm1);
     def->cd_labels = (Label *) NULL;
 }
 

--- a/gcr/gcrChannel.c
+++ b/gcr/gcrChannel.c
@@ -176,8 +176,10 @@ GCRFreeChannel(ch)
     freeMagic((char *) ch->gcr_bPins);
     freeMagic((char *) ch->gcr_lPins);
     freeMagic((char *) ch->gcr_rPins);
+    free_magic1_t mm1 = freeMagic1_init();
     for (net = ch->gcr_nets; net; net = net->gcr_next)
-	freeMagic((char *) net);
+	freeMagic1(&mm1, (char *) net);
+    freeMagic1_end(&mm1);
     freeMagic((char *) ch->gcr_lCol);
 
     freeMagic((char *) ch->gcr_dRowsByCol);

--- a/gcr/gcrRoute.c
+++ b/gcr/gcrRoute.c
@@ -127,8 +127,10 @@ bottom:
      * the channel and cause the net structure to become invalid
      * anyway.
      */
+    free_magic1_t mm1 = freeMagic1_init();
     for (net = ch->gcr_nets; net; net = net->gcr_next)
-	freeMagic((char *) net);
+	freeMagic1(&mm1, (char *) net);
+    freeMagic1_end(&mm1);
     ch->gcr_nets = NULL;
 
     return (gcrRouterErrors);

--- a/graphics/W3Dmain.c
+++ b/graphics/W3Dmain.c
@@ -309,6 +309,7 @@ w3dFillOps(trans, tile, cliprect, ztop, zbot)
     }
     else
     {
+	free_magic1_t mm1 = freeMagic1_init();
 	for (segptr = tilesegs; segptr != NULL; segptr = segptr->r_next)
 	{
 	    GeoTransRect(trans, &segptr->r_r, &r2);
@@ -322,8 +323,9 @@ w3dFillOps(trans, tile, cliprect, ztop, zbot)
 	    }
 	    else
 		w3dFillEdge(&r, &r2, ztop, zbot);
-	    freeMagic(segptr);
+	    freeMagic1(&mm1, segptr);
 	}
+	freeMagic1_end(&mm1);
 
 	/* For non-manhattan tiles, GrBoxOutline only returns	*/
 	/* the manhattan edges.  This leaves the (possibly	*/

--- a/graphics/grClip.c
+++ b/graphics/grClip.c
@@ -912,6 +912,7 @@ GrBox(MagWindow *mw, Transform *trans, Tile *tile)
 	}
 	else
 	{
+	    free_magic1_t mm1 = freeMagic1_init();
 	    /* non-rectangular box; requires drawing segments */
 	    for (segptr = tilesegs; segptr != NULL; segptr = segptr->r_next)
 	    {
@@ -924,8 +925,9 @@ GrBox(MagWindow *mw, Transform *trans, Tile *tile)
 		    (*grDrawLinePtr)(r.r_xbot, r.r_ybot, r.r_xtop, r.r_ytop);
 
 		/* Free memory, if it was allocated for outline segments */
-		freeMagic(segptr);
+		freeMagic1(&mm1, segptr);
 	    }
+	    freeMagic1_end(&mm1);
 
 	    /* For non-manhattan tiles, the manhattan parts of the	*/
 	    /* boundary have already been drawn.  The diagonal boundary */

--- a/graphics/grDStyle.c
+++ b/graphics/grDStyle.c
@@ -632,8 +632,10 @@ recovery:
 		    GrStyleTable[i] = sstyle->style;
 		    /* Add short style name reverse lookup table entry */
 		    GrStyleNames[(int)(sstyle->shortname)] = i;
-		    freeMagic(sstyle);
+		    free_magic1_t mm1 = freeMagic1_init();
+		    freeMagic1(&mm1, sstyle);
 		    sstyle = sstyle->next;
+		    freeMagic1_end(&mm1);
 		}
 	    }
 	    dstylehead = NULL;

--- a/graphics/grTkCommon.c
+++ b/graphics/grTkCommon.c
@@ -209,9 +209,17 @@ grTkDefineCursor(glyphs)
 	    return;
 	}
 
+#ifdef SUPPORT_DIRECT_MALLOC
+        glyphcache = (CursorCache *)malloc(sizeof(CursorCache));
+#else
         glyphcache = (CursorCache *)mallocMagic(sizeof(CursorCache));
+#endif
 	g->gr_cache = (ClientData)glyphcache;
-	g->gr_free = freeMagic;
+#ifdef SUPPORT_DIRECT_MALLOC
+	g->gr_free = free;
+#else
+	g->gr_free = freeMagicLegacy;
+#endif
 
 	/* Find the foreground and background colors of the glyph */
 

--- a/grouter/grouteChan.c
+++ b/grouter/grouteChan.c
@@ -763,11 +763,13 @@ glChanBlockDens(ch)
 	}
 
 	/* Second pass to propagate blockages to nearby areas */
+	free_magic1_t mm1 = freeMagic1_init();
 	for (pa = glChanPaintList, glChanPaintList = NULL; pa; pa = pa->pa_next)
 	{
 	    glChanFlood(&pa->pa_area, pa->pa_type);
-	    freeMagic((char *) pa);
+	    freeMagic1(&mm1, (char *) pa);
 	}
+	freeMagic1_end(&mm1);
     } while (glChanPaintList != NULL);
 }
 

--- a/grouter/grouteDens.c
+++ b/grouter/grouteDens.c
@@ -194,7 +194,7 @@ glDMAlloc(dm, top, cap)
     dm->dm_max = 0;
     dm->dm_size = top + 1;
     dm->dm_cap = cap;
-    dm->dm_value = (short *) callocMagic((unsigned) (sizeof (short) * dm->dm_size));
+    dm->dm_value = (short *) callocMagic(dm->dm_size, (unsigned) (sizeof (short)));
 }
 
 /*

--- a/grouter/grouteMain.c
+++ b/grouter/grouteMain.c
@@ -238,8 +238,10 @@ glClientFree(chanList, netList)
     for (net = netList->nnl_nets; net; net = net->nnet_next)
     {
 	nclient = (NetClient *) net->nnet_cdata;
+	free_magic1_t mm1 = freeMagic1_init();
 	for (cz = nclient->nc_pens; cz; cz = cz->cz_next)
-	    freeMagic((char *) cz);
+	    freeMagic1(&mm1, (char *) cz);
+	freeMagic1_end(&mm1);
 	net->nnet_cdata = (ClientData) NULL;
     }
 }

--- a/grouter/grouteMain.c
+++ b/grouter/grouteMain.c
@@ -192,7 +192,7 @@ glClientInit(chanList, netList)
     }
 
     for (net = netList->nnl_nets; net; net = net->nnet_next)
-	net->nnet_cdata = (ClientData) callocMagic((unsigned) (sizeof (NetClient)));
+	net->nnet_cdata = (ClientData) callocMagic(1, (unsigned) (sizeof (NetClient)));
 }
 
 /*

--- a/grouter/groutePath.c
+++ b/grouter/groutePath.c
@@ -188,8 +188,10 @@ glPathFreePerm(list)
 {
     GlPoint *p;
 
+    free_magic1_t mm1 = freeMagic1_init();
     for (p = list; p; p = p->gl_path)
-	freeMagic((char *) p);
+	freeMagic1(&mm1, (char *) p);
+    freeMagic1_end(&mm1);
     return 0;
 }
 

--- a/grouter/groutePen.c
+++ b/grouter/groutePen.c
@@ -103,8 +103,10 @@ glPenClearPerChan(net)
 	    czNet = czNet->cz_next)
     {
 	gc = (GlobChan *) czNet->cz_chan->gcr_client;
+	free_magic1_t mm1 = freeMagic1_init();
 	for (czChan = gc->gc_penList; czChan; czChan = czChan->cz_next)
-	    freeMagic((char *) czChan);
+	    freeMagic1(&mm1, (char *) czChan);
+	freeMagic1_end(&mm1);
 	gc->gc_penList = (CZone *) NULL;
     }
     return 0;
@@ -457,8 +459,10 @@ glPenAssignCosts(cz, netList)
     }
 
     /* Cleanup */
+    free_magic1_t mm1 = freeMagic1_init();
     for (ns = crossNets; ns; ns = ns->ns_next)
-	freeMagic((char *) ns);
+	freeMagic1(&mm1, (char *) ns);
+    freeMagic1_end(&mm1);
     freeMagic((char *) crossArray);
 }
 

--- a/grouter/grouteTest.c
+++ b/grouter/grouteTest.c
@@ -505,8 +505,10 @@ glHistoDump()
     fprintf(fp, "TOTAL: %d\n", total);
 
     /* Free memory */
+    free_magic1_t mm1 = freeMagic1_init();
     for (gh = glNetHistoList; gh; gh = gh->glh_next)
-	freeMagic((char *) gh);
+	freeMagic1(&mm1, (char *) gh);
+    freeMagic1_end(&mm1);
     glNetHistoList = NULL;
 
     /* Done */

--- a/lef/defRead.c
+++ b/lef/defRead.c
@@ -699,6 +699,7 @@ endCoord:
 
     /* Process each segment and paint into the layout */
 
+    free_magic1_t mm1 = freeMagic1_init();
     while (routeTop != NULL)
     {
 	/* paint */
@@ -752,9 +753,10 @@ endCoord:
 	}
 
 	/* advance to next point and free record (1-delayed) */
-	freeMagic((char *)routeTop);
+	freeMagic1(&mm1, (char *)routeTop);
 	routeTop = routeTop->r_next;
     }
+    freeMagic1_end(&mm1);
     return token;	/* Pass back the last token found */
 }
 
@@ -1633,6 +1635,7 @@ DefReadPins(
 				else
 				    flags |= LABEL_STICKY;
 
+				free_magic1_t mm1 = freeMagic1_init();
 				while (rectList != NULL)
 				{
 				    GeoTransRect(&t, &rectList->r_r, &topRect);
@@ -1658,9 +1661,10 @@ DefReadPins(
 						GEO_CENTER, pinname,
 				    		rectList->r_type,
 				    		pinDir | pinUse | flags, pinNum);
-				    freeMagic(rectList);
+				    freeMagic1(&mm1, rectList);
 				    rectList = rectList->r_next;
 				}
+				freeMagic1_end(&mm1);
 				pending = FALSE;
 				pinNum++;
 			    }
@@ -1681,6 +1685,7 @@ DefReadPins(
 				else
 				    flags |= LABEL_STICKY;
 
+				free_magic1_t mm1 = freeMagic1_init();
 				while (rectList != NULL)
 				{
 				    GeoTransRect(&t, &rectList->r_r, &topRect);
@@ -1715,9 +1720,10 @@ DefReadPins(
 						GEO_CENTER, pinname,
 				    		rectList->r_type,
 				    		pinDir | pinUse | flags, pinNum);
-				    freeMagic(rectList);
+				    freeMagic1(&mm1, rectList);
 				    rectList = rectList->r_next;
 				}
+				freeMagic1_end(&mm1);
 				pending = FALSE;
 				pinNum++;
 			    }

--- a/lef/defWrite.c
+++ b/lef/defWrite.c
@@ -2559,6 +2559,7 @@ defWriteBlockages(
     	{
 	    if (defobsdata.blockData[i] == NULL) continue;
 	    fprintf(f, "   - LAYER %s", defobsdata.baseNames[i]);
+	    free_magic1_t mm1 = freeMagic1_init();
 	    for (lr = defobsdata.blockData[i]; lr; lr = lr->r_next)
 	    {
 	    	fprintf(f, "\n      RECT ( %.10g %.10g ) ( %.10g %.10g )",
@@ -2566,8 +2567,9 @@ defWriteBlockages(
 				(float)(lr->r_r.r_ybot * oscale),
 				(float)(lr->r_r.r_xtop * oscale),
 				(float)(lr->r_r.r_ytop * oscale));
-	    	freeMagic(lr);
+		freeMagic1(&mm1, lr);
 	    }
+	    freeMagic1_end(&mm1);
             fprintf(f, " ;\n");
     	}
     	fprintf(f, "END BLOCKAGES\n\n");

--- a/lef/lefCmd.c
+++ b/lef/lefCmd.c
@@ -532,8 +532,10 @@ CmdLef(
 		    if (!strcasecmp(inet, "none"))
 		    {
 			/* Remove all net names from the list */
+			free_magic1_t mm1 = freeMagic1_init();
 			for (lnn = lefIgnoreNets; lnn; lnn = lnn->lnn_next)
-			    freeMagic(lnn);
+			    freeMagic1(&mm1, lnn);
+			freeMagic1_end(&mm1);
 			lefIgnoreNets = NULL;
 		    }
 		    else

--- a/lef/lefRead.c
+++ b/lef/lefRead.c
@@ -701,8 +701,10 @@ LefRedefined(
 	/* Only one name associated with the record, so	*/
 	/* just clear all the allocated information.	*/
 
+	free_magic1_t mm1 = freeMagic1_init();
 	for (viaLR = lefl->info.via.lr; viaLR != NULL; viaLR = viaLR->r_next)
-	    freeMagic(viaLR);
+	    freeMagic1(&mm1, viaLR);
+	freeMagic1_end(&mm1);
 	newlefl = lefl;
     }
     else
@@ -1077,14 +1079,16 @@ LefReadPolygon(
 
     plist = (Point *)mallocMagic(lpoints * sizeof(Point));
     lpoints = 0;
+    free_magic1_t mm1 = freeMagic1_init();
     while (lr != NULL)
     {
 	plist[*ppoints - lpoints - 1].p_x = lr->r_r.r_xbot;
 	plist[*ppoints - lpoints - 1].p_y = lr->r_r.r_ybot;
-	freeMagic(lr);
+	freeMagic1(&mm1, lr);
 	lpoints++;
 	lr = lr->r_next;
     }
+    freeMagic1_end(&mm1);
     return plist;
 }
 
@@ -1450,6 +1454,7 @@ LefReadPort(
 
     rectList = LefReadGeometry(lefMacro, f, oscale, gdsOffset, TRUE, is_imported);
 
+    free_magic1_t mm1 = freeMagic1_init();
     while (rectList != NULL)
     {
 	if ((pinNum >= 0) || (lanno != NULL))
@@ -1529,9 +1534,10 @@ LefReadPort(
 	    if (lanno != NULL) lanno = NULL;
 	}
 
-	freeMagic((char *)rectList);
+	freeMagic1(&mm1, (char *)rectList);
 	rectList = rectList->r_next;
     }
+    freeMagic1_end(&mm1);
 }
 
 /*

--- a/lef/lefWrite.c
+++ b/lef/lefWrite.c
@@ -1861,6 +1861,7 @@ lefWriteMacro(
 		DBPaint(lc.lefYank, &layerBound, ttype);
 	    }
 
+	free_magic1_t mm1 = freeMagic1_init();
 	for (thislll = lll; thislll; thislll = thislll->lll_next)
 	{
 	    int mspace;
@@ -1879,8 +1880,9 @@ lefWriteMacro(
 	    thislll->lll_area.r_ytop += mspace;
 
 	    DBErase(lc.lefYank, &thislll->lll_area, lab->lab_type);
-	    freeMagic(thislll);
+	    freeMagic1(&mm1, thislll);
 	}
+	freeMagic1_end(&mm1);
 
 	if (setback >= 0)
 	{

--- a/mzrouter/mzEstimate.c
+++ b/mzrouter/mzEstimate.c
@@ -497,10 +497,12 @@ mzReclaimTCFunc(tile, notUsed)
 	Estimate *e;
 
 	/* free estimates attached to tilecosts struc */
+	free_magic1_t mm1 = freeMagic1_init();
 	for(e=tc->tc_estimates; e!=NULL; e=e->e_next)
 	{
-	    freeMagic((char *) e);
+	    freeMagic1(&mm1, (char *) e);
 	}
+	freeMagic1_end(&mm1);
 
 	/* free tilecosts struc */
 	freeMagic((char *) (tile->ti_client));

--- a/mzrouter/mzTech.c
+++ b/mzrouter/mzTech.c
@@ -123,16 +123,24 @@ MZFreeParameters(params)
     RouteLayer *rL;
     RouteContact *rC;
 
-    for (rL = params->mp_rLayers; rL; rL = rL->rl_next)
     {
-	ListDealloc(rL->rl_contactL);
-	TiFreePlane(rL->rl_routeType.rt_hBlock);
-	TiFreePlane(rL->rl_routeType.rt_vBlock);
-	freeMagic(rL);
+	free_magic1_t mm1 = freeMagic1_init();
+	for (rL = params->mp_rLayers; rL; rL = rL->rl_next)
+	{
+	    ListDealloc(rL->rl_contactL);
+	    TiFreePlane(rL->rl_routeType.rt_hBlock);
+	    TiFreePlane(rL->rl_routeType.rt_vBlock);
+	    freeMagic1(&mm1, rL);
+	}
+	freeMagic1_end(&mm1);
     }
 
-    for (rC = params->mp_rContacts; rC; rC = rC->rc_next)
-	freeMagic(rC);
+    {
+	free_magic1_t mm1 = freeMagic1_init();
+	for (rC = params->mp_rContacts; rC; rC = rC->rc_next)
+	    freeMagic1(&mm1, rC);
+	freeMagic1_end(&mm1);
+    }
 }
 
 
@@ -159,12 +167,14 @@ MZTechInit()
     /* Clear out any old information */
     if (mzStyles != NULL)
     {
+	free_magic1_t mm1 = freeMagic1_init();
 	for (style = mzStyles; style != NULL; style = style->ms_next)
 	{
 	    MZFreeParameters(&(style->ms_parms));
 	    freeMagic(style->ms_name);
-	    freeMagic(style);
+	    freeMagic1(&mm1, style);
 	}
+	freeMagic1_end(&mm1);
     }
 
     /* Initially no route types defined */

--- a/mzrouter/mzTech.c
+++ b/mzrouter/mzTech.c
@@ -609,7 +609,7 @@ mzTechLayer(argc, argv)
     }
 
     /* Allocate  new route layer */
-    new = (RouteLayer *) callocMagic((unsigned) (sizeof (RouteLayer)));
+    new = (RouteLayer *) callocMagic(1, (unsigned) (sizeof (RouteLayer)));
 
     /* Initialize RouteType section */
     mzInitRouteType(&(new->rl_routeType),tileType);
@@ -1143,7 +1143,7 @@ mzTechContact(argc, argv)
     if(tileType < 0) return;
 
     /* allocate new route contact */
-    new = (RouteContact *) callocMagic((unsigned) (sizeof (RouteContact)));
+    new = (RouteContact *) callocMagic(1, (unsigned) (sizeof (RouteContact)));
 
     /* initialize RouteType section:
      * sets route type, initializes spacing array, etc.

--- a/netmenu/NMcmdAK.c
+++ b/netmenu/NMcmdAK.c
@@ -157,7 +157,8 @@ NMCmdCleanup(w, cmd)
      * is in progress.
      */
 
-    for (p = nmCleanupList; p != NULL; p = p->nmcl_next)
+     free_magic1_t mm1 = freeMagic1_init();
+     for (p = nmCleanupList; p != NULL; p = p->nmcl_next)
     {
 	char answer[30];
 	int indx, defaultValue;
@@ -184,11 +185,15 @@ NMCmdCleanup(w, cmd)
         switch (indx)
 	{
 	    case 0:
+	    {
+		free_magic1_t mm1_ = freeMagic1_init();
 		while (p != NULL)
 		{
-		    freeMagic((char *) p);
+		    freeMagic1(&mm1_, (char *) p);
 		    p = p->nmcl_next;
 		}
+		freeMagic1_end(&mm1_);
+	    }
 		return;
 	    case 1:
 		NMDeleteNet(p->nmcl_name);
@@ -197,8 +202,9 @@ NMCmdCleanup(w, cmd)
 		NMDeleteTerm(p->nmcl_name);
 		break;
 	}
-	freeMagic((char *) p);
+	freeMagic1(&mm1, (char *) p);
     }
+    freeMagic1_end(&mm1);
 
     if (nmCleanupList == NULL)
 	TxPrintf("No problems found.\n");

--- a/netmenu/NMnetlist.c
+++ b/netmenu/NMnetlist.c
@@ -350,14 +350,16 @@ NMDeleteNet(net)
      */
 
     next = ne->ne_next;
+    free_magic1_t mm1 = freeMagic1_init();
     while (TRUE)
     {
 	NMUndo(next->ne_name, net, NMUE_REMOVE);
 	HashSetValue(HashFind(&nmCurrentNetlist->nl_table, next->ne_name), 0);
-	freeMagic((char *) next);
+	freeMagic1(&mm1, (char *) next);
 	if (next == ne) break;
 	next = next->ne_next;
     }
+    freeMagic1_end(&mm1);
 }
 
 /*

--- a/netmenu/NMwiring.c
+++ b/netmenu/NMwiring.c
@@ -180,6 +180,7 @@ NMRipup()
      */
 
     TTMaskZero(&maskBits);
+    free_magic1_t mm1 = freeMagic1_init();
     while (list != NULL)
     {
 	DBErase(EditCellUse->cu_def, &list->nmwa_area, list->nmwa_type);
@@ -189,9 +190,10 @@ NMRipup()
 	DRCCheckThis(EditCellUse->cu_def, TT_CHECKPAINT, &list->nmwa_area);
 	DBWAreaChanged(EditCellUse->cu_def, &list->nmwa_area, DBW_ALLWINDOWS,
 	     &DBAllButSpaceBits);
-	freeMagic((char *) list);
+	freeMagic1(&mm1, (char *) list);
 	list = list->nmwa_next;
     }
+    freeMagic1_end(&mm1);
     DBReComputeBbox(EditCellUse->cu_def);
     return 0;
 }
@@ -240,6 +242,7 @@ nmRipLocFunc(rect, name, label, area)
 	&TiPlaneRect, nmwRipTileFunc, (ClientData) &list);
     TTMaskZero(&maskBits);
     TTMaskClearType(&maskBits, label->lab_type);
+    free_magic1_t mm1 = freeMagic1_init();
     while (list != NULL)
     {
 	DBErase(EditCellUse->cu_def, &list->nmwa_area, list->nmwa_type);
@@ -247,9 +250,10 @@ nmRipLocFunc(rect, name, label, area)
 	(void) DBEraseLabel(EditCellUse->cu_def, &list->nmwa_area, &maskBits, NULL);
 	TTMaskClearType(&maskBits, list->nmwa_type);
 	(void) GeoInclude(&list->nmwa_area, area);
-	freeMagic((char *) list);
+	freeMagic1(&mm1, (char *) list);
 	list = list->nmwa_next;
     }
+    freeMagic1_end(&mm1);
     return 0;
 }
 

--- a/plot/plotPS.c
+++ b/plot/plotPS.c
@@ -181,23 +181,35 @@ PlotPSTechInit()
 
     /* Clear out any old information */
 
-    for (style = plotPSStyles; style != NULL; style = style->grs_next)
     {
-	freeMagic((char *) style);
+	free_magic1_t mm1 = freeMagic1_init();
+	for (style = plotPSStyles; style != NULL; style = style->grs_next)
+	{
+	    freeMagic1(&mm1, (char *) style);
+	}
+	freeMagic1_end(&mm1);
+	plotPSStyles = NULL;
     }
-    plotPSStyles = NULL;
 
-    for (pattern = plotPSPatterns; pattern != NULL; pattern = pattern->pat_next)
     {
-	freeMagic((char *) pattern);
+	free_magic1_t mm1 = freeMagic1_init();
+	for (pattern = plotPSPatterns; pattern != NULL; pattern = pattern->pat_next)
+	{
+	    freeMagic1(&mm1, (char *) pattern);
+	}
+	freeMagic1_end(&mm1);
+	plotPSPatterns = NULL;
     }
-    plotPSPatterns = NULL;
 
-    for (color = plotPSColors; color != NULL; color = color->col_next)
     {
-	freeMagic((char *) color);
+	free_magic1_t mm1 = freeMagic1_init();
+	for (color = plotPSColors; color != NULL; color = color->col_next)
+	{
+	    freeMagic1(&mm1, (char *) color);
+	}
+	freeMagic1_end(&mm1);
+	plotPSColors = NULL;
     }
-    plotPSColors = NULL;
 
     if (!PlotPSIdFont)
 	StrDup(&PlotPSIdFont, defaultFont);

--- a/plot/plotVers.c
+++ b/plot/plotVers.c
@@ -216,10 +216,12 @@ PlotVersTechInit()
 {
     VersatecStyle *style;
 
+    free_magic1_t mm1 = freeMagic1_init();
     for (style = plotVersStyles; style != NULL; style = style->vs_next)
     {
-	freeMagic((char *) style);
+	freeMagic1(&mm1, (char *) style);
     }
+    freeMagic1_end(&mm1);
     plotVersStyles = NULL;
 
     if (PlotVersPrinter == NULL)
@@ -267,10 +269,12 @@ PlotColorVersTechInit()
 {
     VersatecStyle *style;
 
+    free_magic1_t mm1 = freeMagic1_init();
     for (style = plotColorVersStyles; style != NULL; style = style->vs_next)
     {
-	freeMagic((char *) style);
+	freeMagic1(&mm1, (char *) style);
     }
+    freeMagic1_end(&mm1);
     plotColorVersStyles = NULL;
 
     if (PlotVersPrinter == NULL)

--- a/plow/PlowMain.c
+++ b/plow/PlowMain.c
@@ -239,11 +239,13 @@ PlowClearBound()
     pb = plowBoundaryList;
     plowCheckBoundary = FALSE;
     plowBoundaryList = (PlowBoundary *) NULL;
+    free_magic1_t mm1 = freeMagic1_init();
     for ( ; pb; pb = pb->pb_next)
     {
 	DBWHLRedraw(pb->pb_rootDef, &pb->pb_rootArea, TRUE);
-	freeMagic((char *) pb);
+	freeMagic1(&mm1, (char *) pb);
     }
+    freeMagic1_end(&mm1);
 }
 
 /*

--- a/plow/PlowTech.c
+++ b/plow/PlowTech.c
@@ -127,11 +127,19 @@ PlowDRCInit()
     {
 	for (j = 0; j < DBNumTypes; j++)
 	{
-	    for (pr = plowWidthRulesTbl[i][j]; pr; pr = pr->pr_next)
-		freeMagic((char *)pr);
+	    {
+		free_magic1_t mm1 = freeMagic1_init();
+		for (pr = plowWidthRulesTbl[i][j]; pr; pr = pr->pr_next)
+		    freeMagic1(&mm1, (char *)pr);
+		freeMagic1_end(&mm1);
+	    }
 
-	    for (pr = plowSpacingRulesTbl[i][j]; pr; pr = pr->pr_next)
-		freeMagic((char *)pr);
+	    {
+		free_magic1_t mm1 = freeMagic1_init();
+		for (pr = plowSpacingRulesTbl[i][j]; pr; pr = pr->pr_next)
+		    freeMagic1(&mm1, (char *)pr);
+		freeMagic1_end(&mm1);
+	    }
 
 	    plowWidthRulesTbl[i][j] = NULL;
 	    plowSpacingRulesTbl[i][j] = NULL;
@@ -697,6 +705,7 @@ plowTechOptimizeRule(ruleList)
      */
     pCand = ruleList;
     pCandLast = (PlowRule *) NULL;
+    free_magic1_t mm1 = freeMagic1_init();
     while (pCand)
     {
 	for (pr = ruleList; pr; pr = pr->pr_next)
@@ -718,7 +727,7 @@ plowTechOptimizeRule(ruleList)
 		     * Delete pCand, and resume outer loop with the
 		     * new values of pCand and pCandLast set below.
 		     */
-		    freeMagic((char *) pCand);
+		    freeMagic1(&mm1, (char *) pCand);
 		    if (pCandLast)
 			pCandLast->pr_next = pCand->pr_next;
 		    else
@@ -734,6 +743,7 @@ plowTechOptimizeRule(ruleList)
 
 next:	;
     }
+    freeMagic1_end(&mm1);
 
     return (ruleList);
 }

--- a/resis/ResBasic.c
+++ b/resis/ResBasic.c
@@ -92,6 +92,7 @@ resAllPortNodes(tile, list)
     resPort 	*pl;
     tileJunk	*junk = (tileJunk *)TiGetClientPTR(tile);
 
+    free_magic1_t mm1 = freeMagic1_init();
     for (pl = junk->portList; pl; pl = pl->rp_nextPort)
     {
 	x = pl->rp_loc.p_x;
@@ -103,8 +104,9 @@ resAllPortNodes(tile, list)
 	resptr->rn_name = pl->rp_nodename;
 	ResAddToQueue(resptr, list);
 	NEWBREAK(resptr, tile, x, y, NULL);
-	freeMagic(pl);
+	freeMagic1(&mm1, pl);
     }
+    freeMagic1_end(&mm1);
 }
 
 /*

--- a/resis/ResRex.c
+++ b/resis/ResRex.c
@@ -685,11 +685,13 @@ typedef enum {
     HashKill(&ResProcessedTable);
 
     /* Revert substrate planes */
+    free_magic1_t mm1 = freeMagic1_init();
     for (sl = resisdata.savePlanes; sl; sl = sl->sl_next)
     {
 	ExtRevertSubstrate(sl->sl_def, sl->sl_plane);
-	freeMagic(sl);
+	freeMagic1(&mm1, sl);
     }
+    freeMagic1_end(&mm1);
 
     /* turn back on undo stuff */
     UndoEnable();

--- a/router/rtrStem.c
+++ b/router/rtrStem.c
@@ -173,6 +173,7 @@ RtrStemProcessAll(use, netList, doWarn, func)
 	     * they all turned out to be unusable.
 	     */
 	    locPrev = locFirst = (NLTermLoc *) NULL;
+	    free_magic1_t mm1 = freeMagic1_init();
 	    for (loc = term->nterm_locs; loc; loc = loc->nloc_next)
 	    {
 		if (loc->nloc_chan == (GCRChannel *) NULL)
@@ -187,13 +188,14 @@ RtrStemProcessAll(use, netList, doWarn, func)
 
 		    /* Nuke it */
 		    if (locPrev) locPrev->nloc_next = loc->nloc_next;
-		    freeMagic((char *) loc);
+		    freeMagic1(&mm1, (char *) loc);
 		    continue;
 		}
 		locPrev = loc;
 		if (locFirst == (NLTermLoc *) NULL)
 		    locFirst = loc;
 	    }
+	    freeMagic1_end(&mm1);
 
 	    /* Nuke any leading elements */
 	    term->nterm_locs = locFirst;

--- a/router/rtrVia.c
+++ b/router/rtrVia.c
@@ -386,11 +386,13 @@ rtrViaCheck(area, def)
      */
 
     DBErase(def, area, RtrContactType);
+    free_magic1_t mm1 = freeMagic1_init();
     for ( pl = rtrPaintList; pl; pl = pl->pl_next)
     {
 	DBPaint(def, &pl->pl_area, type);
-	freeMagic( (char *)pl );
+	freeMagic1(&mm1, (char *)pl );
     }
+    freeMagic1_end(&mm1);
 
     rtrVias++;
     return;
@@ -523,21 +525,29 @@ RtrViaMinimize(def)
      * Replace poly with metal where appropriate.
      */
 
-    for ( ap = rtrAreaList; ap; ap = ap->ap_next)
     {
-	DBErase(def, &ap->ap_erase, ap->ap_oldtype);
-	DBPaint(def, &ap->ap_paint, ap->ap_newtype);
-	freeMagic( (char *)ap);
+	free_magic1_t mm1 = freeMagic1_init();
+	for ( ap = rtrAreaList; ap; ap = ap->ap_next)
+	{
+	    DBErase(def, &ap->ap_erase, ap->ap_oldtype);
+	    DBPaint(def, &ap->ap_paint, ap->ap_newtype);
+	    freeMagic1(&mm1, (char *)ap);
+	}
+	freeMagic1_end(&mm1);
     }
 
     /*
      * Eliminate unnecessary vias.
      */
 
-    for ( vp = rtrViaList; vp; vp = vp->vp_next)
     {
-	rtrViaCheck(&vp->vp_area, def);
-	freeMagic( (char *)vp);
+	free_magic1_t mm1 = freeMagic1_init();
+	for ( vp = rtrViaList; vp; vp = vp->vp_next)
+	{
+	    rtrViaCheck(&vp->vp_area, def);
+	    freeMagic1(&mm1, (char *)vp);
+	}
+	freeMagic1_end(&mm1);
     }
 
     /*
@@ -558,21 +568,29 @@ RtrViaMinimize(def)
      * Erase poly and replace with metal.
      */
 
-    for ( ap = rtrAreaList; ap; ap = ap->ap_next)
     {
-	DBErase(def, &ap->ap_erase, ap->ap_oldtype);
-	DBPaint(def, &ap->ap_paint, ap->ap_newtype);
-	freeMagic( (char *)ap);
+	free_magic1_t mm1 = freeMagic1_init();
+	for ( ap = rtrAreaList; ap; ap = ap->ap_next)
+	{
+	    DBErase(def, &ap->ap_erase, ap->ap_oldtype);
+	    DBPaint(def, &ap->ap_paint, ap->ap_newtype);
+	    freeMagic1(&mm1, (char *)ap);
+	}
+	freeMagic1_end(&mm1);
     }
 
     /*
      * Eliminate unnecessary vias.
      */
 
-    for ( vp = rtrViaList; vp; vp = vp->vp_next)
     {
-	rtrViaCheck(&vp->vp_area, def);
-	freeMagic( (char *)vp);
+	free_magic1_t mm1 = freeMagic1_init();
+	for ( vp = rtrViaList; vp; vp = vp->vp_next)
+	{
+	    rtrViaCheck(&vp->vp_area, def);
+	    freeMagic1(&mm1, (char *)vp);
+	}
+	freeMagic1_end(&mm1);
     }
 
     return rtrVias;

--- a/scripts/defs.mak.in
+++ b/scripts/defs.mak.in
@@ -93,12 +93,29 @@ CC                     = @CC@
 CPP                    = @CPP@
 CXX		       = @CXX@
 
+###
+### Feature flags (to enable uncomment these from ./defs.mak after your ./configure)
+###
+### SUPPORT_DIRECT_MALLOC: this removes the legacy malloc/free APIs that are
+###   not thread-safe and have a defer-free-by-1 quirk that maybe covering
+###   up unknown problems.   See utils/malloc.[ch] for more info.
+###
+###   Status: EXPERIMENTAL (this is expected to uncover issues we don't know about yet)
+#FEATURE_FLAGS += -DSUPPORT_DIRECT_MALLOC
+###
+### SUPPORT_REMOVE_MALLOC_LEGACY this completely removes the older non-threadsafe API
+###   from the output binaries.
+###   This option is dependent on SUPPORT_DIRECT_MALLOC
+###
+###   Status: NOT-STABILITY-AFFECTING (if your binary links you are good to continue)
+#FEATURE_FLAGS += -DSUPPORT_REMOVE_MALLOC_LEGACY
+
 CPPFLAGS               = -I${MAGICDIR} @CPPFLAGS@
 DFLAGS_MAGICVERSION    = -DMAGIC_VERSION=\"${MAGIC_VERSION}\" -DMAGIC_REVISION=\"${MAGIC_REVISION}\" -DMAGIC_COMMIT=\"${MAGIC_COMMIT}\" "-DMAGIC_BUILDDATE=\"${MAGIC_BUILDDATE}\""
 DFLAGS                 = @extra_defs@ @stub_defs@ @DEFS@ ${DFLAGS_MAGICVERSION} -DGCORE=\"@GCORE@\"
-DFLAGS		      += -DSHDLIB_EXT=\"@SHDLIB_EXT@\" @NDEBUG_defs@ @DEBUG_defs@
+DFLAGS		      += -DSHDLIB_EXT=\"@SHDLIB_EXT@\" @NDEBUG_defs@ @DEBUG_defs@ ${FEATURE_FLAGS}
 DFLAGS_NOSTUB	       = @extra_defs@             @DEFS@ ${DFLAGS_MAGICVERSION} -DGCORE=\"@GCORE@\"
-DFLAGS_NOSTUB	      += -DSHDLIB_EXT=\"@SHDLIB_EXT@\" @NDEBUG_defs@ @DEBUG_defs@
+DFLAGS_NOSTUB	      += -DSHDLIB_EXT=\"@SHDLIB_EXT@\" @NDEBUG_defs@ @DEBUG_defs@ ${FEATURE_FLAGS}
 CFLAGS                 = @CFLAGS@ @SHLIB_CFLAGS@ @INC_SPECS@
 
 READLINE_DEFS          = @rl_defs@

--- a/select/selEnum.c
+++ b/select/selEnum.c
@@ -259,8 +259,10 @@ selEnumPFunc1(tile, arg)
 
 	if ((*arg->sea_func)(&rootRect, arg->sea_rectList->r_type, arg->sea_cdarg) != 0)
 	    return 1;
-	freeMagic((char *)arg->sea_rectList);
+	free_magic1_t mm1 = freeMagic1_init();
+	freeMagic1(&mm1, (char *)arg->sea_rectList);
 	arg->sea_rectList = arg->sea_rectList->r_next;
+	freeMagic1_end(&mm1);
     }
     return 0;
 }

--- a/select/selOps.c
+++ b/select/selOps.c
@@ -1594,8 +1594,10 @@ SelectStretch(x, y)
 	TTMaskSetOnlyType(&tmask, tloc);
 
 	DBPaintValid(EditCellUse->cu_def, &selStretchList->sa_area, &tmask, type);
-	freeMagic((char *) selStretchList);
+	free_magic1_t mm1 = freeMagic1_init();
+	freeMagic1(&mm1, (char *) selStretchList);
 	selStretchList = selStretchList->sa_next;
+	freeMagic1_end(&mm1);
     }
 
     /* Paint the new translated selection back into the edit cell,

--- a/utils/ihash.c
+++ b/utils/ihash.c
@@ -73,7 +73,7 @@ extern IHashTable *IHashInit(
   IHashTable *table;
 
   table = (IHashTable *)mallocMagic(sizeof(IHashTable));
-  table->iht_table = (void **)callocMagic(sizeof(void *)*nBuckets);
+  table->iht_table = (void **)callocMagic(nBuckets, sizeof(void *));
   table->iht_nBucketsInit = nBuckets;
   table->iht_nBuckets = nBuckets;
   table->iht_nEntries = 0;
@@ -99,7 +99,7 @@ void IHashClear(IHashTable *table)
 {
   /* reinitial bucket array */
   freeMagic((char *) table->iht_table);
-  table->iht_table = (void **)callocMagic(sizeof(void *)*table->iht_nBucketsInit);
+  table->iht_table = (void **)callocMagic(table->iht_nBucketsInit, sizeof(void *));
 
   table->iht_nBuckets = table->iht_nBucketsInit;
   table->iht_nEntries = 0;
@@ -217,7 +217,7 @@ static void iHashResize(IHashTable *table)
   int bucket;
 
   /* alloc a new table */
-  table->iht_table = (void **)callocMagic(sizeof(void *)*newSize);
+  table->iht_table = (void **)callocMagic(newSize, sizeof(void *));
   table->iht_nBuckets = newSize;
   table->iht_nEntries = 0;
 

--- a/utils/list.c
+++ b/utils/list.c
@@ -98,8 +98,10 @@ void
 ListDealloc(list)
     List *list;		/* List to free */
 {
+    free_magic1_t mm1 = freeMagic1_init();
     for(;list!=NULL; list=LIST_TAIL(list))
-	freeMagic((char *) list);
+	freeMagic1(&mm1, (char *) list);
+    freeMagic1_end(&mm1);
 
     return;
 }
@@ -124,11 +126,13 @@ void
 ListDeallocC(list)
     List *list;		/* List to free */
 {
+    free_magic1_t mm1 = freeMagic1_init();
     for(;list!=NULL; list=LIST_TAIL(list))
     {
-        freeMagic((char *) LIST_FIRST(list));
-	freeMagic((char *) list);
+        freeMagic1(&mm1, (char *) LIST_FIRST(list)); /* can probably use normal free() */
+	freeMagic1(&mm1, (char *) list);
     }
+    freeMagic1_end(&mm1);
 
     return;
 }

--- a/utils/magic.h
+++ b/utils/magic.h
@@ -133,9 +133,11 @@ extern char *SysLibPath;	/* Path for finding system
  * Just for the sake of robustness, though, we define malloc and free
  * here to error strings.
  */
+#ifndef SUPPORT_DIRECT_MALLOC
 #define	malloc	You_should_use_the_Magic_procedure_mallocMagic_instead
 #define	free	You_should_use_the_Magic_procedure_freeMagic_instead
 #define calloc	You_should_use_the_Magic_procedure_callocMagic_instead
+#endif
 
 /* ---------- Flag for global variables (for readability) ------------- */
 

--- a/utils/malloc.c
+++ b/utils/malloc.c
@@ -176,16 +176,20 @@ callocMagicLegacy(nbytes)
 #endif /* SUPPORT_REMOVE_MALLOC_LEGACY */
 
 
+#ifdef __GNUC_STDC_INLINE__
+/* Use of 'extern inline' force an emit of inline code at a symbol */
+extern inline free_magic1_t freeMagic1_init(void);
+extern inline void freeMagic1(free_magic1_t* m1, void* ptr);
+extern inline void freeMagic1_end(free_magic1_t* m1);
+#else /* __GNUC_STDC_INLINE__ */
 /*
  *  NOTICE: non-inline form of emitted functions, keep in sync with malloc.h
  */
-#pragma weak freeMagic1_init = freeMagic1_init_func
-free_magic1_t freeMagic1_init_func() {
+free_magic1_t freeMagic1_init(void) {
     return NULL;
 }
 
-#pragma weak freeMagic1 = freeMagic1_func
-void freeMagic1_func(free_magic1_t* m1, void* ptr) {
+void freeMagic1(free_magic1_t* m1, void* ptr) {
     //if(*m1) /* this if() is here to help inliner remove the call to free() when it can */
     /* this is not the inline form here so if() is commented out */
     {
@@ -199,8 +203,7 @@ void freeMagic1_func(free_magic1_t* m1, void* ptr) {
     *m1 = ptr;
 }
 
-#pragma weak freeMagic1_end = freeMagic1_end_func
-void freeMagic1_end_func(free_magic1_t* m1) {
+void freeMagic1_end(free_magic1_t* m1) {
     //if(*m1) /* this if() is here to help inliner remove the call to free() when it can */
     /* this is not the inline form here so if() is commented out */
     {
@@ -212,3 +215,4 @@ void freeMagic1_end_func(free_magic1_t* m1) {
 #endif
     }
 }
+#endif /* __GNUC_STDC_INLINE__ */

--- a/utils/malloc.h
+++ b/utils/malloc.h
@@ -22,8 +22,95 @@
 #ifndef _MAGIC__UTILS__MALLOC_H
 #define _MAGIC__UTILS__MALLOC_H
 
-extern void *mallocMagic(size_t);
-extern void *callocMagic(size_t);
-extern void freeMagic(void *);
+#include <stdlib.h>
+
+
+/* build time configuration check */
+#if (!defined(SUPPORT_DIRECT_MALLOC) && defined(SUPPORT_REMOVE_MALLOC_LEGACY))
+ #error "ERROR: Unspported build configuration SUPPORT_REMOVE_MALLOC_LEGACY is defined but SUPPORT_DIRECT_MALLOC is undefined"
+#endif
+
+
+#ifdef SUPPORT_DIRECT_MALLOC
+
+#define mallocMagic malloc
+#define callocMagic calloc
+#define freeMagic free
+
+#else
+
+extern void *mallocMagicLegacy(size_t);
+#define mallocMagic(size) mallocMagicLegacy(size)
+
+/* renamed like this, so there is no performance loss if the byte count
+ *  can be computed at compile time.
+ */
+extern void *callocMagicLegacy(size_t);
+#define callocMagic(nmemb, size) callocMagicLegacy((nmemb) * (size))
+
+extern void freeMagicLegacy(void *);
+#define freeMagic(ptr) freeMagicLegacy(ptr)
+
+#endif /* SUPPORT_DIRECT_MALLOC */
+
+
+typedef void* free_magic1_t;
+
+/* TODO this should be moved to autoconf/build/toolchain detection, this does exist
+ * in autoconf and in another changeset, so I come back and fixup/remove this later.
+ */
+#if (defined(__STDC__) && defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L))
+ /* C99 or later */
+ #ifndef __inline__
+   /* you'd have thought on linux this was enabled already, TODO check bplane module inlines */
+   #define __inline__ inline
+ #endif
+#endif
+
+#if (!defined(_MAGIC__UTILS__MALLOC_H__NOINLINE) && defined(__inline__))
+
+/* TODO this (__extern_inline__) should be moved to autoconf/build/toolchain detection */
+#define __extern_inline__ inline
+
+/*
+ *  NOTICE: inline form, keep in sync with malloc.c copied
+ */
+__extern_inline__ free_magic1_t freeMagic1_init() {
+    return NULL;
+}
+__extern_inline__ void freeMagic1(free_magic1_t* m1, void* ptr) {
+    if(*m1) /* this if() is here to help inliner remove the call to free() when it can */
+    {
+#if (defined(SUPPORT_DIRECT_MALLOC) || defined(SUPPORT_REMOVE_MALLOC_LEGACY))
+	free(*m1); /* no need for NULL check with free() */
+#else
+	freeMagicLegacy(*m1);
+#endif
+    }
+    *m1 = ptr;
+}
+__extern_inline__ void freeMagic1_end(free_magic1_t* m1) {
+    if(*m1) /* this if() is here to help inliner remove the call to free() when it can */
+    {
+#if (defined(SUPPORT_DIRECT_MALLOC) || defined(SUPPORT_REMOVE_MALLOC_LEGACY))
+	free(*m1); /* no need for NULL check with free() */
+#else
+	freeMagicLegacy(*m1);
+#endif
+    }
+}
+
+#else
+
+#define freeMagic1_init() freeMagic1_init_func()
+#define freeMagic1(m1, ptr) freeMagic1_func((m1), (ptr))
+#define freeMagic1_end(m1) freeMagic1_end_func((m1))
+
+#endif /* !_MAGIC__UTILS__MALLOC_H__NOINLINE && __inline__ */
+
+/* we'll emit a function call interface just in case a platform won't inline and we can redirect */
+extern free_magic1_t freeMagic1_init_func(void);
+extern void freeMagic1_func(free_magic1_t* m1, void* ptr);
+extern void freeMagic1_end_func(free_magic1_t* m1);
 
 #endif /* _MAGIC__UTILS__MALLOC_H */

--- a/utils/netlist.c
+++ b/utils/netlist.c
@@ -268,16 +268,18 @@ NLFree(netList)
     NLTerm *term;
     NLNet *net;
 
+    free_magic1_t mm1 = freeMagic1_init();
     for (net = netList->nnl_nets; net; net = net->nnet_next)
     {
 	for (term = net->nnet_terms; term; term = term->nterm_next)
 	{
 	    for (loc = term->nterm_locs; loc; loc = loc->nloc_next)
-		freeMagic((char *) loc);
-	    freeMagic((char *) term);
+		freeMagic1(&mm1, (char *) loc);
+	    freeMagic1(&mm1, (char *) term);
 	}
-	freeMagic((char *) net);
+	freeMagic1(&mm1, (char *) net);
     }
+    freeMagic1_end(&mm1);
 
     HashKill(&netList->nnl_names);
 }

--- a/utils/pathvisit.c
+++ b/utils/pathvisit.c
@@ -83,12 +83,14 @@ PaVisitFree(pv)
 {
     PaVisitClient *pvc;
 
+    free_magic1_t mm1 = freeMagic1_init();
     for (pvc = pv->pv_first; pvc; pvc = pvc->pvc_next)
     {
 	if (pvc->pvc_keyword)
 	    freeMagic(pvc->pvc_keyword);
-	freeMagic((char *) pvc);
+	freeMagic1(&mm1, (char *) pvc);
     }
+    freeMagic1_end(&mm1);
 
     freeMagic((char *) pv);
 }

--- a/utils/tech.c
+++ b/utils/tech.c
@@ -760,8 +760,10 @@ skipsection:
     {
 	fclose(fstack->file);
 	freeMagic(fstack->filename);
-	freeMagic(fstack);
+	free_magic1_t mm1 = freeMagic1_init();
+	freeMagic1(&mm1, fstack);
 	fstack = fstack->next;
+	freeMagic1_end(&mm1);
     }
     if (fstack) fclose(fstack->file);
 

--- a/utils/undo.c
+++ b/utils/undo.c
@@ -244,11 +244,13 @@ UndoInit(logFileName, mode)
      * Deallocate any events stored in main memory
      */
 
-    while (undoLogHead != (internalUndoEvent *) NULL)
+     free_magic1_t mm1 = freeMagic1_init();
+     while (undoLogHead != (internalUndoEvent *) NULL)
     {
-	freeMagic((char *) undoLogHead);
+	freeMagic1(&mm1, (char *) undoLogHead);
 	undoLogHead = undoLogHead->iue_forw;
     }
+    freeMagic1_end(&mm1);
 
     return (TRUE);
 }
@@ -370,12 +372,14 @@ UndoFlush()
     if (undoLogHead == (internalUndoEvent *) NULL)
 	return;
 
+    free_magic1_t mm1 = freeMagic1_init();
     while (undoLogTail != undoLogHead)
     {
-	freeMagic((char *) undoLogTail);
+	freeMagic1(&mm1, (char *) undoLogTail);
 	undoLogTail = undoLogTail->iue_back;
 	ASSERT(undoLogTail != (internalUndoEvent *) NULL, "UndoFlush");
     }
+    freeMagic1_end(&mm1);
     freeMagic((char *) undoLogHead);
 
     undoLogHead = undoLogTail = undoLogCur = (internalUndoEvent *) NULL;
@@ -813,18 +817,22 @@ undoFreeHead()
 
     while (undoNumCommands > LOWCOMMANDS)
     {
+	free_magic1_t mm1 = freeMagic1_init();
 	do
 	{
 	    ASSERT(undoLogHead != undoLogCur, "undoFreeHead");
-	    freeMagic((char *) undoLogHead);
+	    freeMagic1(&mm1, (char *) undoLogHead);
 	    undoLogHead = undoLogHead->iue_forw;
 	    ASSERT(undoLogHead != (internalUndoEvent *) NULL, "undoFreeHead");
 	}
 	while (undoLogHead->iue_type != UT_DELIM);
+	freeMagic1_end(&mm1);
 	undoNumCommands--;
     }
-    freeMagic((char *) undoLogHead);
+    free_magic1_t mm1 = freeMagic1_init();
+    freeMagic1(&mm1, (char *) undoLogHead);
     undoLogHead = undoLogHead->iue_forw;
+    freeMagic1_end(&mm1);
     undoLogHead->iue_back = (internalUndoEvent *) NULL;
 }
 
@@ -864,11 +872,13 @@ undoMemTruncate()
 	 * Delete ALL events from memory
 	 */
 	up = undoLogHead;
+	free_magic1_t mm1 = freeMagic1_init();
 	while (up != (internalUndoEvent *) NULL)
 	{
-	    freeMagic((char *) up);
+	    freeMagic1(&mm1, (char *) up);
 	    up = up->iue_forw;
 	}
+	freeMagic1_end(&mm1);
 	undoLogTail = undoLogHead = (internalUndoEvent *) NULL;
 	undoNumCommands = 0;
     }
@@ -879,13 +889,15 @@ undoMemTruncate()
 	 * Delete only some of the events in main memory.
 	 */
 	up = undoLogCur->iue_forw;
+	free_magic1_t mm1 = freeMagic1_init();
 	while (up != (internalUndoEvent *) NULL)
 	{
 	    if (up->iue_type == UT_DELIM)
 		undoNumCommands--;
-	    freeMagic((char *) up);
+	    freeMagic1(&mm1, (char *) up);
 	    up = up->iue_forw;
 	}
+	freeMagic1_end(&mm1);
 	undoLogCur->iue_forw = (internalUndoEvent *) NULL;
 	undoLogTail = undoLogCur;
     }

--- a/wiring/wireTech.c
+++ b/wiring/wireTech.c
@@ -61,11 +61,13 @@ WireTechInit(void)
     Contact *contact;
     int i;
 
+    free_magic1_t mm1 = freeMagic1_init();
     while (WireContacts != NULL)
     {
-	freeMagic((char *) WireContacts);
+	freeMagic1(&mm1, (char *) WireContacts);
 	WireContacts = WireContacts->con_next;
     }
+    freeMagic1_end(&mm1);
     WireUnits = 1;
 }
 


### PR DESCRIPTION
The idiom created is like so to allow potential instrumentation/debugging possibilities around specific sites if it is found specific memory bugs need chasing, maybe due to the scoping choice of this patch (the location of the init() and end() sites) is found to be incorrect.
It also marks with a unique grep'able term 'freeMagic1' to facilitate later cleanup/removal of the idiom, or inspection for optimization at a later date.
The '1' in the naming related to the deferred-by-one more than it being version 1.
There is some overlapping usage so the variable naming ended up as `mm1` and `mm1_` where a 2nd variable was needed.

While this patch seeks to not modify magic default configuration (you must opt-in via manual editing of defs.mak after ./configure) it is designed to allow community testing, bug hunting and reporting to take place.

PLEASE DO NOT ENABLE THESE FEATURE FLAGS FOR PRODUCTION USE, only evaluation and bug hunting.

TODO: The tcl `version` command (and the startup banner) needs indicate which feature flags are enable for the specific binary being run.

--

Methodology summary:
Changes applied in commit order (except for last commit).
Use CodeQL to find use-after-free sites.
Introduce freeMagic1 idiom at each callsite, with an assessment of scope (placement of init/end).
Create the last commit in the sequence based on the changes.

---

Comment taken from the lead commit:

    This supports three build modes:
    
    No additional -D options, default legacy mode
    
    -DSUPPORT_DIRECT_MALLOC, magic will use direct calls to libc malloc/free
     and will leave in place the symbols now renamed as mallocMagicLegacy()
     freeMagicLegacy() and callocMagicLegacy().
    
    -DSUPPORT_DIRECT_MALLOC -DSUPPORT_REMOVE_MALLOC_LEGACY as above but will
     remove the three legacy functions from the binary to provide assurance
     they can not be used.
    
    The system malloc is thread-safe the legacy magic malloc has a global
    deferred free pointer and the mmap() allocate has a free-list that is
    not thread-safe making use of free not thread-safe.
    This could of course be improved with the use of
    atomic_compare_and_exchange operations but for what gain ?
    
    Then there is the additional function call overhead (of the indirection)
    and a few tests/branches inserted into a commonly used code paths around
    memory allocation, it hides the call site of the malloc/free usage from
    the compiler which maybe have special optimization cases.
    
    The existing malloc/free makes static code analysis around memory
    allocation more problematic, also use of runtime analysers will operate
    better with a fail-fast to bad memory usage.
