### PR TITLE
CodeQL guided medium risk (potential) file handle leaks path.c/flock.c

### DIFF
--- a/utils/flock.c
+++ b/utils/flock.c
@@ -127,10 +127,8 @@ gzFile flock_zopen(filename, mode, is_locked, fdp)
 	else if (mode[0] == 'w')
 	    oflag = (mode[1] == '+') ? O_APPEND : O_WRONLY;
 
-	fd = open(fname, oflag);
-	if (fdp != NULL) *fdp = fd;
-	freeMagic(fname);
-	return gzdopen(fd, mode);
+	f = path_gzdopen_internal(fname, oflag, mode, fdp);
+	goto done;
     }
 
     /* Diagnostic */
@@ -140,8 +138,7 @@ gzFile flock_zopen(filename, mode, is_locked, fdp)
     if (fd < 0)
     {
 	if (is_locked) *is_locked = TRUE;
-	fd = open(fname, O_RDONLY);
-	f = gzdopen(fd, "r");
+	f = path_gzdopen_internal(fname, O_RDONLY, "r", fdp);
 	goto done;
     }
 
@@ -155,7 +152,8 @@ gzFile flock_zopen(filename, mode, is_locked, fdp)
     {
 	perror(fname);
 	f = gzdopen(fd, mode);
-	goto done;
+	if (f)
+	    goto done_store_fdp;
     }
     close(fd);
     fd = -1;
@@ -171,7 +169,9 @@ gzFile flock_zopen(filename, mode, is_locked, fdp)
 	fd = open(fname, O_RDWR);
 	if (fcntl(fd, F_SETLK, &fl))
 	{
- 	    perror(fname);
+	    perror(fname);
+	    /* appears to be a best-effort rather than signal error, */
+	    /* and continues to gzdopen() to provide caller handle   */
 	}
 	else
 	{
@@ -179,6 +179,11 @@ gzFile flock_zopen(filename, mode, is_locked, fdp)
 	    /* TxPrintf("Obtained lock on file <%s> (fd=%d)\n", fname, fd); */
 	}
 	f = gzdopen(fd, mode);
+	if (f == NULL)
+	{
+	    close(fd);
+	    fd = -1;
+	}
     }
     else
     {
@@ -190,12 +195,13 @@ gzFile flock_zopen(filename, mode, is_locked, fdp)
 	    TxPrintf("File <%s> is already locked by pid %d.  Opening read-only.\n",
 				fname, (int)fl.l_pid);
 	if (is_locked) *is_locked = TRUE;
-        fd = open(fname, O_RDONLY);
-	f = gzdopen(fd, "r");
+	f = path_gzdopen_internal(fname, O_RDONLY, "r", fdp);
+	goto done;
     }
 
+done_store_fdp:
+    if (fdp) *fdp = fd;
 done:
-    if (fdp != NULL) *fdp = fd;
     freeMagic(fname);
     return f;
 }
@@ -235,7 +241,8 @@ FILE *flock_open(filename, mode, is_locked, fdp)
     if (is_locked == NULL)
     {
 	f = fopen(filename, mode);
-	if ((fdp != NULL) && (f != NULL)) *fdp = fileno(f);
+	if (f)
+	    if (fdp) *fdp = fileno(f);
 	return f;
     }
 
@@ -297,7 +304,8 @@ FILE *flock_open(filename, mode, is_locked, fdp)
     }
 
 done:
-    if ((fdp != NULL) && (f != NULL)) *fdp = fileno(f);
+    if (f)
+	if (fdp) *fdp = fileno(f);
     return f;
 }
 

--- a/utils/path.c
+++ b/utils/path.c
@@ -61,6 +61,35 @@ bool FileLocking = TRUE;
 #define MAXSIZE MAXPATHLEN
 
 #ifdef HAVE_ZLIB
+/* this was found repeated a number of times, only sometimes checking NULL
+ * return from gzdopen() which is unlikely/difficult to ever see from libz,
+ * but then static code analyser raises multiple concerns over multiple paths
+ * leaking an fd. So at least this resolve these things and quietens the
+ * output somewhat.
+ */
+static gzFile
+gzdopen_internal(const char *path, int oflags, const char *modestr, int *fdp)
+{
+    ASSERT(fdp, "fdp");
+
+    int fd = open(path, oflags);
+    if(fd < 0)
+	return NULL;
+
+    /* when gzdopen() successful ownership of fd is transferred */
+    gzFile gzhandle = gzdopen(fd, modestr);
+    if(gzhandle == NULL)
+	goto close;
+
+    if(fdp) /* but sometimes the caller still wants to know the fd */
+	*fdp = fd;
+    return gzhandle;
+
+close:
+    close(fd);
+    return NULL;
+}
+
 /*
  *-------------------------------------------------------------------
  *
@@ -501,12 +530,8 @@ PaLockZOpen(file, mode, ext, path, library, pRealName, is_locked, fdp)
 #ifdef FILE_LOCKS
 	if (FileLocking)
 	    return flock_zopen(realName, mode, is_locked, fdp);
-	else
 #endif
-	    fd = open(realName, oflag);
-
-	if (fdp != NULL) *fdp = fd;
-	return gzdopen(fd, mode);
+	return gzdopen_internal(realName, oflag, mode, fdp);
     }
 
     /* If we were already given a full rooted file name,
@@ -525,12 +550,8 @@ PaLockZOpen(file, mode, ext, path, library, pRealName, is_locked, fdp)
 #ifdef FILE_LOCKS
 	if (FileLocking)
 	    return flock_zopen(realName, mode, is_locked, fdp);
-	else
 #endif
-	    fd = open(realName, oflag);
-
-	if (fdp != NULL) *fdp = fd;
-	return gzdopen(fd, mode);
+	return gzdopen_internal(realName, oflag, mode, fdp);
     }
 
     /* Now try going through the path, one entry at a time. */
@@ -543,13 +564,9 @@ PaLockZOpen(file, mode, ext, path, library, pRealName, is_locked, fdp)
 	if (FileLocking)
 	    f = flock_zopen(realName, mode, is_locked, &fd);
 	else
-	{
-	    fd = open(realName, oflag);
-	    f = gzdopen(fd, mode);
-	}
+	    f = gzdopen_internal(realName, oflag, mode, &fd);
 #else
-	fd = open(realName, oflag);
-	f = gzdopen(fd, mode);
+	f = gzdopen_internal(realName, oflag, mode, &fd);
 #endif
 
 	if (f != NULL)
@@ -574,13 +591,9 @@ PaLockZOpen(file, mode, ext, path, library, pRealName, is_locked, fdp)
 	if (FileLocking)
 	    f = flock_zopen(realName, mode, is_locked, &fd);
 	else
-	{
-	    fd = open(realName, oflag);
-	    f = gzdopen(fd, mode);
-	}
+	    f = gzdopen_internal(realName, oflag, mode, &fd);
 #else
-	fd = open(realName, oflag);
-	f = gzdopen(fd, mode);
+	f = gzdopen_internal(realName, oflag, mode, &fd);
 #endif
 
 	if (f != NULL)

--- a/utils/path.c
+++ b/utils/path.c
@@ -66,9 +66,10 @@ bool FileLocking = TRUE;
  * but then static code analyser raises multiple concerns over multiple paths
  * leaking an fd. So at least this resolve these things and quietens the
  * output somewhat.
+ * Made non-static as flock() can use it but still considered module internal API.
  */
-static gzFile
-gzdopen_internal(const char *path, int oflags, const char *modestr, int *fdp)
+gzFile
+path_gzdopen_internal(const char *path, int oflags, const char *modestr, int *fdp)
 {
     ASSERT(fdp, "fdp");
 
@@ -531,7 +532,7 @@ PaLockZOpen(file, mode, ext, path, library, pRealName, is_locked, fdp)
 	if (FileLocking)
 	    return flock_zopen(realName, mode, is_locked, fdp);
 #endif
-	return gzdopen_internal(realName, oflag, mode, fdp);
+	return path_gzdopen_internal(realName, oflag, mode, fdp);
     }
 
     /* If we were already given a full rooted file name,
@@ -551,7 +552,7 @@ PaLockZOpen(file, mode, ext, path, library, pRealName, is_locked, fdp)
 	if (FileLocking)
 	    return flock_zopen(realName, mode, is_locked, fdp);
 #endif
-	return gzdopen_internal(realName, oflag, mode, fdp);
+	return path_gzdopen_internal(realName, oflag, mode, fdp);
     }
 
     /* Now try going through the path, one entry at a time. */
@@ -564,9 +565,9 @@ PaLockZOpen(file, mode, ext, path, library, pRealName, is_locked, fdp)
 	if (FileLocking)
 	    f = flock_zopen(realName, mode, is_locked, &fd);
 	else
-	    f = gzdopen_internal(realName, oflag, mode, &fd);
+	    f = path_gzdopen_internal(realName, oflag, mode, &fd);
 #else
-	f = gzdopen_internal(realName, oflag, mode, &fd);
+	f = path_gzdopen_internal(realName, oflag, mode, &fd);
 #endif
 
 	if (f != NULL)
@@ -591,9 +592,9 @@ PaLockZOpen(file, mode, ext, path, library, pRealName, is_locked, fdp)
 	if (FileLocking)
 	    f = flock_zopen(realName, mode, is_locked, &fd);
 	else
-	    f = gzdopen_internal(realName, oflag, mode, &fd);
+	    f = path_gzdopen_internal(realName, oflag, mode, &fd);
 #else
-	f = gzdopen_internal(realName, oflag, mode, &fd);
+	f = path_gzdopen_internal(realName, oflag, mode, &fd);
 #endif
 
 	if (f != NULL)

--- a/utils/utils.h
+++ b/utils/utils.h
@@ -82,6 +82,7 @@ extern gzFile PaZOpen(const char *file, const char *mode, const char *ext, const
 extern gzFile PaLockZOpen(const char *file, const char *mode, const char *ext, const char *path, const char *library,
                           char **pRealName, bool *is_locked, int *fdp);
 extern char *PaCheckCompressed(const char *filename);
+extern gzFile path_gzdopen_internal(const char *path, int oflags, const char *modestr, int *fdp);
 #endif
 
 extern int SetNoisyBool(bool *parm, const char *valueS, FILE *file);


### PR DESCRIPTION
This is mainly a refactor of a commonly repeated pattern into a new function that fully handle error paths.

Medium risk due to the high foot-fall and different use cases/filesystem scenarios.

I have a few questions with the flock.c file, best annotated into the source in a moment.