### PR TITLE
CodeQL guided high risk (potential) file handle leaks DBio.c

### DIFF
--- a/database/DBio.c
+++ b/database/DBio.c
@@ -3875,7 +3875,6 @@ DBCellWrite(cellDef, fileName)
     const char *cp1;
     char *cp2, *dotptr;
     char expandbuf[NAME_SIZE];
-    FILE *realf, *tmpf;
     int tmpres;
     struct stat statb;
     bool result, exists;
@@ -3989,6 +3988,7 @@ DBCellWrite(cellDef, fileName)
 	tmpname = StrDup((char **)NULL, expandname);
     }
 
+    FILE *realf = NULL, *tmpf;
     /*
      * See if we can create a temporary file in this directory.
      * If so, write to the temp file and then rename it after
@@ -4119,6 +4119,7 @@ DBCellWrite(cellDef, fileName)
 #endif
 	    realf = fopen(expandname, "r");
 
+	bool do_close = FALSE;
 	if (realf == NULL)
 	{
 	    cellDef->cd_flags |= CDMODIFIED;
@@ -4135,15 +4136,26 @@ DBCellWrite(cellDef, fileName)
 	    }
 
 #ifdef FILE_LOCKS
+	    /* when file locking is in use the FD needs to stay open to hold the lock
+	     *  as with fcntl() locking any call to close() on any FD even dup() and
+	     *  those from separate open() calls, will cause all locks to be dropped
+	     *  by all FDs as they are process wide locks and associated with file
+	     *  system st_dev(kernel-device)/st_ino(inode) and not with FD handles.
+	     */
 	    cellDef->cd_fd = -1;
 	    if (FileLocking && (is_locked == FALSE))
 		cellDef->cd_fd = fd;
 	    else if (FileLocking && (is_locked == TRUE))
 		cellDef->cd_fd = -2;
 	    else
+		do_close = TRUE;
+#else
+	    do_close = TRUE;
 #endif
-		fclose(realf);
 	}
+	if(do_close)
+	    fclose(realf);
+	/* invalidate even if we don't close to ensure cleanup below does not close */
 	realf = NULL;
     }
 
@@ -4151,6 +4163,8 @@ cleanup:
     SigEnableInterrupts();
     freeMagic(realname);
     freeMagic(tmpname);
+    if(realf)
+	fclose(realf);
     return result;
 }
 


### PR DESCRIPTION
Should the `cd_fd` field by managed by a new `flock_close(int fd)` function, where the application can hand the open FD back to flock.c to manage when the real close should occur ?  Which in turn, will receive the other active FD when it is also close.  Then when both are close (active_user_count_of_this_fd==0) then flock.c will manage closing all FDs ?

Maybe if the sequence of events can be written in a comment, highlight the potential data-race-data-corruption concern (the need for a file lock) in the order of events.  I can better understand if it meets requirements.

In the this one method there are multiple `fp = fopen(expandname)` then `fclose(fp)` that occur, without being locking-aware.  The call to fclose(fp) will destroy any existing locks that may have been obtained before, on that file.  The file looks to be appended/write/rewind/truncate etc... and then closed(), if there were to happen more than once the 2nd use of this function the same file, would invalidate the 1st use's locks that were laid down.  (due to the `close(fp)` syscall getting called from fclose use above)

---

DBio.c: CodeQL File{MayNot,Never}BeClosed.ql file-handle resource leaks

Guided by CodeQL static code analyser.

FileMayNotBeClosed.ql
FileMayNeverBeClosed.ql

Technically the FILE_LOCKS feature leaks the file handle, but maybe this isn't in a perfectly controlled way (with assurance that at some correct point in the program future, all the fd's are eventually closed)