### PR TITLE
RFC re alternative approach to #370

### DIFF
--- a/cif/CIFrdpt.c
+++ b/cif/CIFrdpt.c
@@ -687,7 +687,8 @@ CIFParseWire(void)
 
     width /= cifReadScale2;
     savescale = cifReadScale1;
-    if (!CIFParsePath(&pathheadp, 2))
+    pathheadp = CIFParsePath(2);
+    if (pathheadp == NULL)
     {
 	CIFReadError("wire, but improper path; ignored.\n");
 	CIFSkipToSemi();
@@ -797,7 +798,8 @@ CIFParsePoly(void)
 	CIFSkipToSemi();
 	return FALSE;
     }
-    if (!CIFParsePath(&pathheadp, 1))
+    pathheadp = CIFParsePath(1);
+    if (pathheadp == NULL)
     {
 	CIFReadError("polygon, but improper path; ignored.\n");
 	CIFSkipToSemi();

--- a/cif/CIFread.h
+++ b/cif/CIFread.h
@@ -166,7 +166,7 @@ extern bool CIFParseUser(void);
 extern bool CIFParseCall(void);
 extern bool CIFParseTransform(Transform *transformp);
 extern bool CIFParseInteger(int *valuep);
-extern bool CIFParsePath(CIFPath **pathheadpp, int iscale);
+extern CIFPath *CIFParsePath(int iscale);
 extern bool CIFParsePoint(Point *pointp, int iscale);
 extern bool CIFParseSInteger(int *valuep);
 extern void CIFSkipToSemi(void);


### PR DESCRIPTION
This PR is a Request For Comments on these alternative commits related to #370 

In PR #370 I invalidate with `*pathheadpp = NULL` but this is of course extra work the CPU has to do.

So here is a V1 and V2 alternative, that achieves multiple things:

* make both functions easier for the next person to understand/reason about (understand this maybe somewhat opinionated)
* reduces the amount of work the CPU needs to do overall (true of V2 not of V1), mainly from the management on both sides of the function call for having 2 piece of data, return value and CIFPath*
* -O3 compiler headline in respective commit comment (of the function implementation in situation inside magic)
* quashes (false positive) static code analysis report concerning this (this is an issue, in that its easier to do something in the code than manage the extensive lists of points picked up)

just making a case to understand what kind of factors justify

At the moment consider the patch untested, looking to see if there is understanding that in win-win-win (readability-performance-concern_management) scenarios.
If there is a positive feedback I shall get to testing and report back in issue (could be days/weeks)
Thanks