### PR TITLE
RLIMIT_NOFILE >= 4096 when on TCL9 support

### DIFF
--- a/scripts/configure
+++ b/scripts/configure
@@ -4893,6 +4893,30 @@ fi
 done
 
 
+for ac_func in getrlimit
+do :
+  ac_fn_c_check_func "$LINENO" "getrlimit" "ac_cv_func_getrlimit"
+if test "x$ac_cv_func_getrlimit" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_GETRLIMIT 1
+_ACEOF
+
+fi
+done
+
+
+for ac_func in setrlimit
+do :
+  ac_fn_c_check_func "$LINENO" "setrlimit" "ac_cv_func_setrlimit"
+if test "x$ac_cv_func_setrlimit" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_SETRLIMIT 1
+_ACEOF
+
+fi
+done
+
+
 ac_fn_c_check_func "$LINENO" "vfork" "ac_cv_func_vfork"
 if test "x$ac_cv_func_vfork" = xyes; then :
 
@@ -4957,6 +4981,19 @@ do :
 if test "x$ac_cv_header_paths_h" = xyes; then :
   cat >>confdefs.h <<_ACEOF
 #define HAVE_PATHS_H 1
+_ACEOF
+
+fi
+
+done
+
+
+for ac_header in sys/resource.h
+do :
+  ac_fn_c_check_header_mongrel "$LINENO" "sys/resource.h" "ac_cv_header_sys_resource_h" "$ac_includes_default"
+if test "x$ac_cv_header_sys_resource_h" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_SYS_RESOURCE_H 1
 _ACEOF
 
 fi

--- a/scripts/configure.in
+++ b/scripts/configure.in
@@ -132,6 +132,12 @@ AC_HEADER_STDC
 dnl Need either setenv or putenv
 AC_CHECK_FUNCS(setenv putenv)
 
+dnl Check for getrlimit
+AC_CHECK_FUNCS(getrlimit)
+
+dnl Check for setrlimit
+AC_CHECK_FUNCS(setrlimit)
+
 dnl Check for vfork
 AC_CHECK_FUNC(vfork)
 
@@ -149,6 +155,9 @@ AC_CHECK_HEADERS(param.h)
 
 dnl Check for <paths.h>
 AC_CHECK_HEADERS(paths.h)
+
+dnl Check for <sys/resource.h>
+AC_CHECK_HEADERS(sys/resource.h)
 
 dnl Check for <sys/time.h>
 AC_CHECK_HEADERS(sys/time.h)

--- a/sim/SimRsim.c
+++ b/sim/SimRsim.c
@@ -650,6 +650,13 @@ SimFillBuffer(buffHead, pLastChar, charCount)
     FD_ZERO(&exceptfds);
 #endif  /* SYSV */
 
+    ASSERT(pipeIn >= 0 && pipeIn < FD_SETSIZE, "pipeIn>=0&&pipeIn<FD_SETSIZE");
+    if (pipeIn < 0 || pipeIn >= FD_SETSIZE)
+    {
+        TxError("WARNING: SimFillBuffer(fd=%d) called with fd out of range 0..%d\n", pipeIn, FD_SETSIZE-1);
+        return -1; /* allowing things to continue is UB */
+    }
+
     nfd = pipeIn + 1;
 
 try_again:

--- a/textio/textio.h
+++ b/textio/textio.h
@@ -110,6 +110,4 @@ extern void TxInit(void);
 extern void TxInitReadline(void);
 #endif
 
-#define   TX_MAX_OPEN_FILES       20
-
 #endif /* _TEXTIO_H */

--- a/textio/txCommands.c
+++ b/textio/txCommands.c
@@ -489,6 +489,12 @@ TxAdd1InputDevice(
     ClientData cdata)
 {
     fd_set fs;
+    ASSERT(fd >= 0 && fd < FD_SETSIZE, "fd>=0&&fd<FD_SETSIZE");
+    if (fd < 0 || fd >= FD_SETSIZE)
+    {
+	TxError("WARNING: TxAdd1InputDevice(fd=%d) called with fd out of range 0..%d\n", fd, FD_SETSIZE-1);
+	return; /* allowing things to continue is UB */
+    }
     FD_ZERO(&fs);
     FD_SET(fd, &fs);
     TxAddInputDevice(&fs, inputProc, cdata);
@@ -524,8 +530,14 @@ void
 TxDelete1InputDevice(
     int fd)
 {
-    int i, j;
+    ASSERT(fd >= 0 && fd < FD_SETSIZE, "fd>=0&&fd<FD_SETSIZE");
+    if (fd < 0 || fd >= FD_SETSIZE)
+    {
+	TxError("WARNING: TxDelete1InputDevice(fd=%d) called with fd out of range 0..%d\n", fd, FD_SETSIZE-1);
+	return; /* allowing things to continue is UB */
+    }
 
+    int i, j;
     for (i = 0; i <= txLastInputEntry; i++)
     {
 	FD_CLR(fd, &(txInputDevice[i].tx_fdmask));


### PR DESCRIPTION
Including defensive counter measures for areas of magic that don't support FDs >= 1024.

Any suggestions on getting to see TxGetInputEvent() in action ?  Does not appear to be in use ?

Comments around this item https://github.com/RTimothyEdwards/magic/pull/374#issuecomment-2668749478
