### PR TITLE
ExtTech.c: fix uninitialized exts_linearResist value leaks into extresist

### DIFF
--- a/extract/ExtTech.c
+++ b/extract/ExtTech.c
@@ -2807,6 +2807,7 @@ ExtTechLine(sectionName, argc, argv)
 		    }
 		    devptr->exts_deviceResist.ht_table = (HashEntry **) NULL;
 		    HashInit(&devptr->exts_deviceResist, 8, HT_STRINGKEYS);
+		    devptr->exts_linearResist = 0;
 
 		    devptr->exts_next = ExtCurStyle->exts_device[t];
 		    ExtCurStyle->exts_device[t] = devptr;


### PR DESCRIPTION

This value appears to be initialised at only one spot in the codebase (under very narrow conditions) but extresist will read it and make branching decisions based on the uninitialised state.

This 'X' state propagation appears to eventually get processed in ResWriteExtFile() near where final output formatting is occurring.

It is unclear (at this time) if it perturbs output values in a problematic way, or if due to algorithmic reasons the data is discarded before output anyway.  I have at least one trace run (with multiple triggers) of printf formatters handling uninitialised data in ResWriteExtFile().