### PR TITLE
plotPNM.c: Fix crash due to uninited rtl_args.outfile

### DIFF
--- a/plot/plotPNM.c
+++ b/plot/plotPNM.c
@@ -587,6 +587,7 @@ PlotPNM(fileName, scx, layers, xMask, width)
 
 #ifdef VERSATEC
     struct plotRTLdata rtl_args;
+    rtl_args.outfile = NULL;
     char command[200], tempFile[200];
 #endif
 


### PR DESCRIPTION
I introduced this issue in recent commit e88dcba1c