### PR TITLE
rtrTravers.c: missing const

### DIFF
--- a/router/rtrTravers.c
+++ b/router/rtrTravers.c
@@ -245,7 +245,7 @@ rtrSrTraverseFunc(tile, ts)
     Tile *t2;
     Rect tileArea;
     int i;
-    TileTypeBitMask *connectMask;
+    const TileTypeBitMask *connectMask;
     TileType ttype;
     unsigned int planes;
     struct conSrArg *csa = ts->ts_csa;


### PR DESCRIPTION
This is to remove the constness warning.