### PR TITLE
DBcellsrch.c: #ifdef ROUTE_MODULE around hook to update MZAttachHintPlanes()

### DIFF
--- a/bplane/bpDump.c
+++ b/bplane/bpDump.c
@@ -78,6 +78,7 @@ void bpDumpRect(Rect *r)
     fprintf(stderr,"%d",
 	    r->r_ytop);
   }
+#ifdef CIF_MODULE
   else
   {
     float oscale;
@@ -93,6 +94,7 @@ void bpDumpRect(Rect *r)
     fprintf(stderr,"%f",
 	    oscale * (float)r->r_ytop);
   }
+#endif
 }
 
 /*
@@ -170,6 +172,7 @@ static void bpBinArrayDump(BinArray *ba, int indent)
     fprintf(stderr,"{dx %d} {dy %d} ",
 	    dx,dy);
   }
+#ifdef CIF_MODULE
   else
   {
     float oscale;
@@ -182,6 +185,7 @@ static void bpBinArrayDump(BinArray *ba, int indent)
     fprintf(stderr,"{dy %f} ",
 	    (float)dy * oscale);
   }
+#endif
     fprintf(stderr,"{dimX %d} {dimY %d} {  bbox ",
 	  dimX,
 	  dimY);

--- a/cif/CIFrdutils.c
+++ b/cif/CIFrdutils.c
@@ -276,8 +276,10 @@ CIFScaleCoord(
 		    PlowAfterTech();
 		    ExtTechScale(1, denom);
 		    WireTechScale(1, denom);
+#ifdef ROUTE_MODULE
 		    MZAfterTech();
 		    IRAfterTech();
+#endif
 #ifdef LEF_MODULE
 		    LefTechScale(1, denom);
 #endif

--- a/database/DBcellsrch.c
+++ b/database/DBcellsrch.c
@@ -1525,8 +1525,10 @@ DBScaleEverything(scalen, scaled)
     /* Scale all elements */
     DBWScaleElements(scalen, scaled);
 
+#ifdef ROUTE_MODULE
     /* Recovery of global plane pointers */
     MZAttachHintPlanes();
+#endif
 
     /* Modify root box */
     ToolScaleBox(scalen, scaled);

--- a/database/DBcellsrch.c
+++ b/database/DBcellsrch.c
@@ -1633,7 +1633,10 @@ dbTileScaleFunc(tile, scvals)
     if (IsSplit(tile))
 	type = (SplitSide(tile)) ? SplitRightType(tile) : SplitLeftType(tile);
     DBNMPaintPlane(scvals->ptarget, exact, &targetRect,
-		((scvals->doCIF) ? CIFPaintTable :
+		(
+#ifdef CIF_MODULE
+		(scvals->doCIF) ? CIFPaintTable :
+#endif
 		DBStdPaintTbl(type, scvals->pnum)),
 		(PaintUndoInfo *)NULL);
     return 0;

--- a/dbwind/DBWcommands.c
+++ b/dbwind/DBWcommands.c
@@ -223,9 +223,11 @@ DBWInitCommands()
     WindAddCommand(DBWclientID,
 	"addpath [path]		append to current search path",
 	CmdAddPath, FALSE);
+#ifdef LEF_MODULE
     WindAddCommand(DBWclientID,
 	"antennacheck [path]	check for antenna violations",
 	CmdAntennaCheck, FALSE);
+#endif
     WindAddCommand(DBWclientID,
 	"array xsize ysize	OR\n"
 	"array xlo xhi ylo yhi\n"

--- a/textio/txCommands.c
+++ b/textio/txCommands.c
@@ -49,7 +49,9 @@ static char rcsid[] __attribute__ ((unused)) ="$Header: /usr/cvsroot/magic-8.0/t
 #include "utils/dqueue.h"
 #include "utils/malloc.h"
 #include "utils/utils.h"
+#ifdef SCHEME_INTERPRETER
 #include "lisp/lisp.h"
+#endif
 
 /* C99 compat */
 #include "windows/windows.h"

--- a/utils/main.c
+++ b/utils/main.c
@@ -73,7 +73,9 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 #ifdef ROUTE_MODULE
 #include "mzrouter/mzrouter.h"
 #endif
+#ifdef SCHEME_INTERPRETER
 #include "lisp/lisp.h"
+#endif
 #ifdef THREE_D
 #include "graphics/wind3d.h"
 #endif

--- a/utils/tech.c
+++ b/utils/tech.c
@@ -577,7 +577,9 @@ TechLoad(filename, initmask)
 #endif
 	ExtTechInit();
 	DRCTechInit();
+#ifdef ROUTE_MODULE
 	MZTechInit();
+#endif
 
             /* Changing number of planes requires handling on every     */
             /* celldef.  So we need to save the original number of      */


### PR DESCRIPTION
DBcellsrch.c: #ifdef ROUTE_MODULE around hook to update MZAttachHintPlanes()

When building without this module MZInit() does not get called and MZAttachHintPlanes() does not guard against that situation.

To allow unused code to be pruned from final binary, better to remove the cross module hook breaking the dependency.