### PR TITLE
appimage: allow git tags with annotation to match expected SHA for ChangeLog

### DIFF
--- a/.github/workflows/appimage10.yml
+++ b/.github/workflows/appimage10.yml
@@ -75,19 +75,16 @@ jobs:
           set +e
           git fetch --tags --prune --no-recurse-submodules --depth=149 origin +$GITHUB_SHA # fetch-tags: true # is broken
           echo git_fetch_exitstatus=$?
-          git_show_ref=$(git show-ref --hash $GITHUB_REF)
+          git_show_ref=$(git show-ref --hash $GITHUB_REF) # get tagcommit hash
           git_show_ref_exitstatus=$?
-          set -e
           echo git_show_ref_exitstatus=$git_show_ref_exitstatus
-          if [ $git_show_ref_exitstatus -ne 0 ] # should never occur
-          then
-            git update-ref $GITHUB_REF $GITHUB_SHA # put it back
-            echo git_update_ref=$?
-            git_show_ref=$(git show-ref --hash $GITHUB_REF) # retry
-            echo git_show_ref_exitstatus=$?
-          fi
           echo git_show_ref=$git_show_ref
-          test "$git_show_ref" = "$GITHUB_SHA" # check we got the ref back (or fail CI)
+          git_rev_list=$(git rev-list -n1 $GITHUB_REF) # get commit hash
+          git_rev_list_exitstatus=$?
+          echo git_rev_list_exitstatus=$git_rev_list_exitstatus
+          echo git_rev_list=$git_rev_list
+          set -e
+          test "$git_show_ref" = "$GITHUB_SHA" || test "$git_rev_list" = "$GITHUB_SHA" # check we got the ref back (or fail CI)
           git_describe=$(git describe --tags $GITHUB_SHA | sed -e 's#\-\([0-9]\+\-g\)#\+\1#') # /-\d+-g/
           echo git_describe=$git_describe
 

--- a/.github/workflows/appimage7.yml
+++ b/.github/workflows/appimage7.yml
@@ -75,19 +75,16 @@ jobs:
           set +e
           git fetch --tags --prune --no-recurse-submodules --depth=149 origin +$GITHUB_SHA # fetch-tags: true # is broken
           echo git_fetch_exitstatus=$?
-          git_show_ref=$(git show-ref --hash $GITHUB_REF)
+          git_show_ref=$(git show-ref --hash $GITHUB_REF) # get tagcommit hash
           git_show_ref_exitstatus=$?
-          set -e
           echo git_show_ref_exitstatus=$git_show_ref_exitstatus
-          if [ $git_show_ref_exitstatus -ne 0 ] # should never occur
-          then
-            git update-ref $GITHUB_REF $GITHUB_SHA # put it back
-            echo git_update_ref=$?
-            git_show_ref=$(git show-ref --hash $GITHUB_REF) # retry
-            echo git_show_ref_exitstatus=$?
-          fi
           echo git_show_ref=$git_show_ref
-          test "$git_show_ref" = "$GITHUB_SHA" # check we got the ref back (or fail CI)
+          git_rev_list=$(git rev-list -n1 $GITHUB_REF) # get commit hash
+          git_rev_list_exitstatus=$?
+          echo git_rev_list_exitstatus=$git_rev_list_exitstatus
+          echo git_rev_list=$git_rev_list
+          set -e
+          test "$git_show_ref" = "$GITHUB_SHA" || test "$git_rev_list" = "$GITHUB_SHA" # check we got the ref back (or fail CI)
           git_describe=$(git describe --tags $GITHUB_SHA | sed -e 's#\-\([0-9]\+\-g\)#\+\1#') # /-\d+-g/
           echo git_describe=$git_describe
 

--- a/.github/workflows/appimage8.yml
+++ b/.github/workflows/appimage8.yml
@@ -75,19 +75,16 @@ jobs:
           set +e
           git fetch --tags --prune --no-recurse-submodules --depth=149 origin +$GITHUB_SHA # fetch-tags: true # is broken
           echo git_fetch_exitstatus=$?
-          git_show_ref=$(git show-ref --hash $GITHUB_REF)
+          git_show_ref=$(git show-ref --hash $GITHUB_REF) # get tagcommit hash
           git_show_ref_exitstatus=$?
-          set -e
           echo git_show_ref_exitstatus=$git_show_ref_exitstatus
-          if [ $git_show_ref_exitstatus -ne 0 ] # should never occur
-          then
-            git update-ref $GITHUB_REF $GITHUB_SHA # put it back
-            echo git_update_ref=$?
-            git_show_ref=$(git show-ref --hash $GITHUB_REF) # retry
-            echo git_show_ref_exitstatus=$?
-          fi
           echo git_show_ref=$git_show_ref
-          test "$git_show_ref" = "$GITHUB_SHA" # check we got the ref back (or fail CI)
+          git_rev_list=$(git rev-list -n1 $GITHUB_REF) # get commit hash
+          git_rev_list_exitstatus=$?
+          echo git_rev_list_exitstatus=$git_rev_list_exitstatus
+          echo git_rev_list=$git_rev_list
+          set -e
+          test "$git_show_ref" = "$GITHUB_SHA" || test "$git_rev_list" = "$GITHUB_SHA" # check we got the ref back (or fail CI)
           git_describe=$(git describe --tags $GITHUB_SHA | sed -e 's#\-\([0-9]\+\-g\)#\+\1#') # /-\d+-g/
           echo git_describe=$git_describe
 

--- a/.github/workflows/appimage9.yml
+++ b/.github/workflows/appimage9.yml
@@ -75,19 +75,16 @@ jobs:
           set +e
           git fetch --tags --prune --no-recurse-submodules --depth=149 origin +$GITHUB_SHA # fetch-tags: true # is broken
           echo git_fetch_exitstatus=$?
-          git_show_ref=$(git show-ref --hash $GITHUB_REF)
+          git_show_ref=$(git show-ref --hash $GITHUB_REF) # get tagcommit hash
           git_show_ref_exitstatus=$?
-          set -e
           echo git_show_ref_exitstatus=$git_show_ref_exitstatus
-          if [ $git_show_ref_exitstatus -ne 0 ] # should never occur
-          then
-            git update-ref $GITHUB_REF $GITHUB_SHA # put it back
-            echo git_update_ref=$?
-            git_show_ref=$(git show-ref --hash $GITHUB_REF) # retry
-            echo git_show_ref_exitstatus=$?
-          fi
           echo git_show_ref=$git_show_ref
-          test "$git_show_ref" = "$GITHUB_SHA" # check we got the ref back (or fail CI)
+          git_rev_list=$(git rev-list -n1 $GITHUB_REF) # get commit hash
+          git_rev_list_exitstatus=$?
+          echo git_rev_list_exitstatus=$git_rev_list_exitstatus
+          echo git_rev_list=$git_rev_list
+          set -e
+          test "$git_show_ref" = "$GITHUB_SHA" || test "$git_rev_list" = "$GITHUB_SHA" # check we got the ref back (or fail CI)
           git_describe=$(git describe --tags $GITHUB_SHA | sed -e 's#\-\([0-9]\+\-g\)#\+\1#') # /-\d+-g/
           echo git_describe=$git_describe
 


### PR DESCRIPTION
The situation is due to the difference for tags with message / annotation:

$ git tag -l -n1 8.3.534
8.3.534         "Tagging version 8.3.534"

$ git show-ref -s -d refs/tags/8.3.534
4426cc859e4f22ab96df941f123babd0d8076928
1ec8b6ee1a30c09debe5ad8a3208d810fdb1219f refs/tags/8.3.534^{}

$ git rev-list -n1 refs/tags/8.3.534
1ec8b6ee1a30c09debe5ad8a3208d810fdb1219f

Use of rev-lsit will always get the commit ID we expect to see for the workflow, so we allow either of the SHA above to match at the point of failure.
