### PR TITLE
Refactor: use functionality based checking instead of OS-level checking

### DIFF
--- a/utils/magsgtty.h
+++ b/utils/magsgtty.h
@@ -21,44 +21,18 @@
 #ifndef	_MAGIC__UTILS__MAGSGTTY_H
 #define _MAGIC__UTILS__MAGSGTTY_H
 
-/* maybe this can be #ifndef HAVE_TERMIO_H */
-#if !defined(SYSV) && !defined(CYGWIN)
-
-# ifdef	ALPHA
-# undef MAX
-# undef MIN
+#if defined(HAVE_TERMIOS_H) /* POSIX */
+# include <termios.h>
+#elif defined(HAVE_TERMIO_H) /* SYSV */
+# include <termio.h>
+# include <sys/ioctl.h>
+#else /* Fallback for older BSD/V7 systems */
+# if defined(HAVE_SGTTY_H)
+#  include <sgtty.h>
+# elif defined(HAVE_SYS_IOCTL_COMPAT_H)
+#  include <sys/ioctl_compat.h>
 # endif
-
-/* unclear what platform requires this OpenBSD/FreeBSD ? */
-# ifndef COMPAT_43TTY
-# define COMPAT_43TTY
-# endif
-
-#ifdef HAVE_SYS_IOCTL_H
-#include <sys/ioctl.h>
+# include <sys/ioctl.h>
 #endif
-
-#if defined(HAVE_TERMIOS_H)
-#include <termios.h>
-#elif defined(HAVE_SYS_IOCTL_COMPAT_H)
-/* unclear which platform(s) require <sys/ioctl_compat.h> and the structure
- *  of this file is such that it will try to include it by default, better
- *  to invert the #if and only select this on the known platforms that need
- *  it so that <termios.h> goes by default, which exists on MacOSX, Linux, etc..
- * many possible solutions to make this work by default:
- *   HAVE_SYS_IOCTL_COMPAT_H ?  HAVE_TERMIOS_H ?  !defined(linux) at top (MaxOSX is BSD type)
- */
-#include <sys/ioctl_compat.h> /* replaced sgtty.h */
-#elif defined(HAVE_SGTTY_H)
-#include <sgtty.h> /* legacy - struct sgttyb{} defn */
-#endif
-
-#else
-
-#if defined(HAVE_TERMIO_H)
-#include <termio.h>
-#endif
-
-#endif /* !SYSV && !CYGWIN */
 
 #endif	/* _MAGIC__UTILS__MAGSGTTY_H */


### PR DESCRIPTION
What?
---

This refactors some of the code to use functionality based checking rather than OS-level checking for header includes

Motivation
---
For bleeding edge systems that are using GLIBC v2.42, `termio.h` has been removed, and `termios.h` is the replacement.
Due to recent refactors + removal of these headers one is not able to compile this when using GLIBC v2.24.

Note
---
Only tested the compilation on my machine (Arch Linux x86_64),
hopefully this doesn't break for other systems (BSD etc.)!

Closes: #434