### PR TITLE
Fixed unused-parameters/unused-variables warnings

### DIFF
--- a/bplane/bpBins.c
+++ b/bplane/bpBins.c
@@ -80,7 +80,6 @@ static BinArray *bpBinArrayNew(int dx,      /* x diameter of bins */
 
 {
   BinArray *new;
-  Rect abbox;
   int w, h, dimX, dimY, numBins;
   int size;
 
@@ -262,7 +261,6 @@ bpBinArraySizeIt(Rect *bbox,            /* bin array bbox */
 		 int *numBinsp,         /* return number of bins here */
 		 int *countp)           /* return number of elements here */
 {
-  BinArray *ba;
   int count;
   double numBins;  /* need double to avoid overflow on tentative calc. */
   int h = GEO_HEIGHT(bbox);
@@ -590,7 +588,6 @@ BinArray *bpBinArrayBuild(Rect bbox,
 
   /* sub-bin normal bins */
   {
-    int dimX = ba->ba_dimX;
 
     int i;
     for(i=0;i<numBins;i++)

--- a/bplane/bpMain.c
+++ b/bplane/bpMain.c
@@ -113,8 +113,6 @@ void BPFree(BPlane *bp)
  */
 void BPAdd(BPlane *bp, void *element)
 {
-  int size;
-  int binDim;
   Element * e = element;
   Rect *r = &e->e_rect;
 

--- a/bplane/bpStat.c
+++ b/bplane/bpStat.c
@@ -85,14 +85,7 @@ unsigned int bpStatBA(BinArray *ba,
 		      int *totUnbinned,     /* ret tot num of e's not binned */
 		      int *maxDepth)        /* ret max bin array depth */
 {
-  Rect *bbox = &ba->ba_bbox;
-  int dx = ba->ba_dx;
-  int dy = ba->ba_dy;
   int numBins = ba->ba_numBins;
-  int dimX = ba->ba_dimX;
-  int dimY = numBins/dimX;
-  int w = GEO_WIDTH(bbox);
-  int h = GEO_HEIGHT(bbox);
 
   /* initial statistics */
   unsigned int mem = 0;
@@ -103,7 +96,6 @@ unsigned int bpStatBA(BinArray *ba,
   int maxCount = 0;
   int maxEff = 0;
   int maxEffSub = 0;
-  int maxSubCount = 0;
   int unbinned = 0;
   int depth = 1;
   int maxDepthSub = 0;
@@ -228,7 +220,6 @@ unsigned int BPStat(BPlane *bp,
 		      int *maxDepth)        /* ret max bin array depth */
 {
   BinArray *ba = bp->bp_rootNode;
-  int numBins;
   unsigned int mem = 0;
   int tot = 0;
   int bins = 0;

--- a/bplane/bpUtils.c
+++ b/bplane/bpUtils.c
@@ -53,25 +53,3 @@ int bpRectDim(Rect *r, bool xDir)
 {
   return xDir ? r->r_xtop - r->r_xbot : r->r_ytop - r->r_ybot;
 }
-
-/*
- * ----------------------------------------------------------------------------
- * bpBinIndices --
- *
- * compute bin indices corresponding to area.
- *
- * ----------------------------------------------------------------------------
- */
-static __inline__ void
-bpBinIndices(Rect area,        /* area */
-	     Rect binArea,     /* lower left corner of bin system */
-	     int indexBits,
-	     int dim,
-	     bool  xDir,       /* TRUE for x bin, FALSE for y bin */
-	     int *min,         /* results go here */
-	     int *max)
-{
-  int ref, coord;
-  int index;
-
-}

--- a/calma/CalmaRdcl.c
+++ b/calma/CalmaRdcl.c
@@ -99,11 +99,10 @@ OFFTYPE
 calmaSetPosition(
     char *sname)
 {
-    OFFTYPE originalPos = 0, currentPos = 0;
+    OFFTYPE originalPos = 0;
     int nbytes, rtype;
     char *strname = NULL;
     int strRecSize = 0;
-    bool found = FALSE;
 
     originalPos = FTELL(calmaInputFile);
 
@@ -302,10 +301,8 @@ calmaFlattenPolygonFunc(
     CellUse *use,
     CellDef *parent)
 {
-    int i;
     CellUse dummy;
     SearchContext scx;
-    HashEntry *he;
 
     if (use->cu_def == NULL || use->cu_def->cd_name == NULL) return 0;
     if (strncmp(use->cu_def->cd_name, "polygon", 7)) return 0;
@@ -356,7 +353,6 @@ calmaParseStructure(
     HashEntry *he;
     int timestampval = 0;
     int suffix;
-    int mfactor;
     int locPolygonCount;
     OFFTYPE filepos;
     bool was_called = FALSE;
@@ -364,7 +360,6 @@ calmaParseStructure(
     bool predefined;
     bool do_flatten;
     CellDef *def;
-    Label *lab;
 
     locPolygonCount = CalmaPolygonCount;
 
@@ -753,6 +748,8 @@ calmaEnumFunc(
     Tile *tile,
     int *plane)
 {
+    ARG_UNUSED(tile);
+    ARG_UNUSED(plane);
     return 1;
 }
 
@@ -1167,7 +1164,6 @@ calmaElementSref(
 	    Plane **gdsplanes = (Plane **)def->cd_client;
 	    GDSCopyRec gdsCopyRec;
 	    int pNum;
-	    bool hasUses;
 
 	    // Mark cell as flattened (at least once)
 	    def->cd_flags |= CDFLATTENED;
@@ -1281,6 +1277,8 @@ gdsHasUses(
     CellUse *use,
     ClientData clientdata)
 {
+    ARG_UNUSED(use);
+    ARG_UNUSED(clientdata);
     return 1;
 }
 
@@ -1291,7 +1289,6 @@ gdsCopyPaintFunc(
     Tile *tile,
     GDSCopyRec *gdsCopyRec)
 {
-    int pNum;
     TileType dinfo;
     Rect sourceRect, targetRect;
     Transform *trans = gdsCopyRec->trans;

--- a/calma/CalmaRdio.c
+++ b/calma/CalmaRdio.c
@@ -77,6 +77,7 @@ calmaReadTransform(
     Transform *ptrans,	/* Fill in this transform */
     char *name)		/* Name of subcell (for errors) */
 {
+    ARG_UNUSED(name);
     int nbytes, rtype, flags, angle;
     double dangle;
     double dmag;

--- a/calma/CalmaRdpt.c
+++ b/calma/CalmaRdpt.c
@@ -300,7 +300,6 @@ calmaElementBoundary(void)
     if (rp != NULL)
     {
         Rect rpc;
-	int savescale;
 
 	/* Convert rp to magic database units to compare to label rects */
         rpc = rp->r_r;
@@ -507,11 +506,8 @@ calmaElementPath(void)
 {
     int nbytes = -1, rtype = 0, extend1, extend2;
     int layer, dt, width, pathtype, ciftype, savescale;
-    int xmin, ymin, xmax, ymax, temp;
-    CIFPath *pathheadp, *pathp, *previousp;
-    Rect segment;
+    CIFPath *pathheadp, *pathp;
     Plane *plane;
-    int first,last;
     CellUse *use;
     CellDef *savedef = NULL, *newdef = NULL;
 

--- a/calma/CalmaWrite.c
+++ b/calma/CalmaWrite.c
@@ -286,7 +286,7 @@ CalmaWrite(
     CellDef *rootDef,	/* Pointer to CellDef to be written */
     FILE *f)		/* Open output file */
 {
-    int oldCount = DBWFeedbackCount, problems, nerr;
+    int oldCount = DBWFeedbackCount, problems;
     bool good;
     CellDef *err_def;
     CellUse dummy;
@@ -686,8 +686,8 @@ calmaFullDump(
     char *filename)
 {
     int version, rval;
-    char *libname = NULL, *testlib, uniqlibname[4];
-    char *sptr, *viewopts;
+    char *libname = NULL, uniqlibname[4];
+    char *viewopts;
     bool isAbstract;
     HashTable calmaDefHash;
     HashSearch hs;
@@ -977,7 +977,6 @@ calmaProcessDef(
 	size_t defsize, numbytes;
 	off_t cellstart, cellend, structstart;
  	dlong cval;
-	int namelen;
 	FILETYPE fi;
 
 	/* Give some feedback to the user */
@@ -1901,10 +1900,9 @@ calmaWriteContacts(
 {
     TileType type;
     TileTypeBitMask tMask, *rMask;
-    CellDef *def, *cellDef;
+    CellDef *def;
     Rect area, cliprect;
     int halfwidth, halfsize;
-    CIFOp *op;
 
     /* Turn off generation of contact arrays for the duration of this	*/
     /* subroutine, so that the contact definitions themselves will get	*/
@@ -2344,9 +2342,8 @@ calmaProcessBoundary(
     calmaOutputStruct *cos)
 {
     FILE *f = cos->f;
-    LinkedBoundary *listtop, *lbref, *lbstop, *lbfree;
+    LinkedBoundary *listtop, *lbref, *lbstop;
     BoundaryTop *bounds;
-    int sval;
     int chkcount;	/* diagnostic */
 
     for (bounds = blist; bounds != NULL; bounds = bounds->bt_next)
@@ -2456,8 +2453,6 @@ calmaMergePaintFunc(
     Tile *tile,			/* Tile to be written out. */
     calmaOutputStruct *cos)	/* Information needed by algorithm */
 {
-    FILE *f = cos->f;
-    const Rect *clipArea = cos->area;
     Tile *t, *tp;
     TileType ttype;
     int i, llx, lly, urx, ury, intedges, num_points, split_type;
@@ -2781,7 +2776,7 @@ calmaWritePaintFunc(
 {
     FILE *f = cos->f;
     const Rect *clipArea = cos->area;
-    Rect r, r2;
+    Rect r;
 
     TiToRect(tile, &r);
     if (clipArea != NULL)
@@ -3057,9 +3052,8 @@ calmaPaintLabelFunc(
 {
     FILE *f = cos->f;
     const Rect *clipArea = cos->area;
-    Rect r, r2;
+    Rect r;
     Point p;
-    int len;
     CIFLayer *layer = CIFCurStyle->cs_layers[cos->type];
 
     if (IsSplit(tile)) return 0;    /* Ignore non-Manhattan geometry */

--- a/calma/CalmaWriteZ.c
+++ b/calma/CalmaWriteZ.c
@@ -666,16 +666,13 @@ calmaFullDumpZ(
     char *filename)
 {
     int version, rval;
-    char *libname = NULL, *testlib, uniqlibname[4];
-    char *sptr, *viewopts;
+    char *libname = NULL, uniqlibname[4];
+    char *viewopts;
     bool isAbstract;
     HashTable calmaDefHash;
     HashSearch hs;
     HashEntry *he, *he2;
 
-    static const int hdrSkip[] = { CALMA_FORMAT, CALMA_MASK, CALMA_ENDMASKS,
-		CALMA_REFLIBS, CALMA_FONTS, CALMA_ATTRTABLE,
-		CALMA_STYPTABLE, CALMA_GENERATIONS, -1 };
     static const int skipBeforeLib[] = { CALMA_LIBDIRSIZE, CALMA_SRFNAME,
 		CALMA_LIBSECUR, -1 };
 
@@ -932,7 +929,6 @@ calmaProcessDefZ(
 	size_t defsize, numbytes;
 	z_off_t cellstart, cellend, structstart;
  	dlong cval;
-	int namelen;
 	gzFile fi;
 
 	/* Use PaOpen() so the paths searched are the same as were	*/
@@ -1726,10 +1722,9 @@ calmaWriteContactsZ(
 {
     TileType type;
     TileTypeBitMask tMask, *rMask;
-    CellDef *def, *cellDef;
+    CellDef *def;
     Rect area, cliprect;
     int halfwidth, halfsize;
-    CIFOp *op;
 
     /* Turn off generation of contact arrays for the duration of this	*/
     /* subroutine, so that the contact definitions themselves will get	*/
@@ -1809,9 +1804,8 @@ calmaProcessBoundaryZ(
     calmaOutputStructZ *cos)
 {
     gzFile f = cos->f;
-    LinkedBoundary *listtop, *lbref, *lbstop, *lbfree;
+    LinkedBoundary *listtop, *lbref, *lbstop;
     BoundaryTop *bounds;
-    int sval;
     int chkcount;	/* diagnostic */
 
     for (bounds = blist; bounds != NULL; bounds = bounds->bt_next)
@@ -1891,8 +1885,6 @@ calmaMergePaintFuncZ(
     Tile *tile,			/* Tile to be written out. */
     calmaOutputStructZ *cos)	/* Information needed by algorithm */
 {
-    gzFile f = cos->f;
-    const Rect *clipArea = cos->area;
     Tile *t, *tp;
     TileType ttype;
     int i, llx, lly, urx, ury, intedges, num_points, split_type;
@@ -2216,7 +2208,7 @@ calmaWritePaintFuncZ(
 {
     gzFile f = cos->f;
     const Rect *clipArea = cos->area;
-    Rect r, r2;
+    Rect r;
 
     TiToRect(tile, &r);
     if (clipArea != NULL)
@@ -2492,9 +2484,8 @@ calmaPaintLabelFuncZ(
 {
     gzFile f = cos->f;
     const Rect *clipArea = cos->area;
-    Rect r, r2;
+    Rect r;
     Point p;
-    int len;
     CIFLayer *layer = CIFCurStyle->cs_layers[cos->type];
 
     if (IsSplit(tile)) return 0;    /* Ignore non-Manhattan geometry */

--- a/cif/CIFgen.c
+++ b/cif/CIFgen.c
@@ -139,6 +139,8 @@ cifInteractFunc(
     Tile *tile,
     ClientData clientdata)		/* Unused */
 {
+    ARG_UNUSED(tile);
+    ARG_UNUSED(clientdata);
     return 1;
 }
 
@@ -326,7 +328,7 @@ cifGrowMinFunc(
 {
     Rect area, parea;
     int locDist, width, height, h;
-    TileType type, tptype;
+    TileType tptype;
     Tile *tp, *tp2;
     bool changed;
 
@@ -500,10 +502,9 @@ cifGrowGridFunc(
     PaintResultType *table)		/* Table to be used for painting. */
 {
     Rect area;
-    int remainder;
 
     /* To be done---handle non-Manhattan geometry */
-    TileType oldType = TiGetType(tile);
+    TiGetType(tile);
 
     TiToRect(tile, &area);
 
@@ -613,7 +614,6 @@ cifGrowEuclideanFunc(
 	int growDistanceX, growDistanceY;
 	int height, width;
 	double frac, ratio;
-	int limit;
 
 	if (oldType & TT_SIDE)
 	    growDirs &= ~GROW_WEST;
@@ -1244,6 +1244,7 @@ cifProcessResetFunc(
     Tile *tile,
     ClientData clientData)	/* unused */
 {
+    ARG_UNUSED(clientData);
     TiSetClient(tile, CIF_UNPROCESSED);
     return 0;
 }
@@ -1344,7 +1345,7 @@ cifBloatAllFunc(
     Tile *t, *tp, *firstTile = NULL;
     TileType type, ttype;
     BloatData *bloats;
-    int i, locScale;
+    int locScale;
     PlaneMask pmask;
     CIFOp *op;
     CellDef *def;
@@ -1423,7 +1424,6 @@ cifBloatAllFunc(
     }
     if (pmask == 0)
     {
-	Rect foundArea;
 
 	if (bloats->bl_plane < 0)   /* Bloat types are CIF types */
 	{
@@ -1905,7 +1905,6 @@ cifBridgeFunc2(
     Rect area;
     Tile *tp1, *tp2, *tpx;
     int width = brs->bridge->br_width;
-    int wtest;
     int spacing = growDistance;
     BridgeCheckStruct brcs;
     int cifBridgeCheckFunc(Tile *tile, BridgeCheckStruct *brcs);	/* Forward reference */
@@ -2124,7 +2123,7 @@ cifCloseFunc(
     Tile *tile,
     Plane *plane)
 {
-    Rect area, newarea;
+    ARG_UNUSED(plane);
     int atotal;
     int cifGatherFunc(Tile *tile, int *atotal, int mode);
 
@@ -2162,9 +2161,8 @@ cifGatherFunc(
     int mode)
 {
     Tile *tp;
-    TileType type;
     dlong locarea;
-    Rect area, newarea;
+    Rect area;
     ClientData cdata = (mode == CLOSE_SEARCH) ? CIF_UNPROCESSED :
 	    CD2INT(CIF_PENDING);
 
@@ -2312,6 +2310,7 @@ cifSquaresInitFunc(tile, clientData)
     Tile *tile;
     ClientData clientData;
 {
+    ARG_UNUSED(clientData);
     if (TiGetClient(tile) == CIF_UNPROCESSED)
 	return 1;
     else
@@ -2464,6 +2463,7 @@ cifUnconnectFunc(
     Tile *tile,
     ClientData clientData)	/* unused */
 {
+    ARG_UNUSED(clientData);
     TileType t = TiGetTypeExact(tile);
     if (t == TT_SPACE) return 1;
     else if (t & TT_DIAGONAL) return 1;
@@ -2495,10 +2495,9 @@ cifRectBoundingBox(
     CellDef *cellDef,
     Plane *plane)
 {
+    ARG_UNUSED(cellDef);
     Tile *tile = NULL, *t, *tp;
     Rect bbox, area, *maxr;
-    int i, j, savecount;
-    TileType type;
     bool simple;
     static Stack *BoxStack = (Stack *)NULL;
 
@@ -2654,11 +2653,11 @@ cifSquaresFillArea(
     CellDef *cellDef,
     Plane *plane)
 {
+    ARG_UNUSED(cellDef);
     Tile *tile, *t, *tp;
     Rect bbox, area, square, cut, llcut;
-    int nAcross, nUp, left, pitch, size, diff, right;
+    int nAcross, nUp, pitch, size, diff;
     int i, j, k, savecount;
-    TileType type;
     SquaresData *squares = (SquaresData *)op->co_client;
     StripsData stripsData;
     linkedStrip *stripList;
@@ -2983,13 +2982,13 @@ cifSlotsFillArea(
     CellDef *cellDef,
     Plane *plane)
 {
+    ARG_UNUSED(cellDef);
     Tile *tile, *t, *tp;
     Rect bbox, area, square, cut, llcut;
-    int nAcross, nUp, left, spitch, lpitch, ssize, lsize, offset;
-    int diff, right;
+    int nAcross, nUp, spitch, lpitch, ssize, lsize, offset;
+    int diff;
     int xpitch, ypitch, xborder, yborder, xdiff, ydiff;
     int i, j, k, savecount;
-    TileType type;
     SlotsData *slots = (SlotsData *)op->co_client;
     StripsData stripsData;
     linkedStrip *stripList;
@@ -3544,7 +3543,7 @@ cifContactFunc(
     CIFSquaresInfo *csi) 	/* Describes how to generate squares. */
 {
     Rect area;
-    int i, nAcross, j, nUp, left, bottom, pitch, halfsize;
+    int nAcross, nUp, left, bottom, pitch, halfsize;
     bool result;
     SquaresData *squares = csi->csi_squares;
 
@@ -3625,7 +3624,7 @@ cifSlotFunc(
     Rect *cut,			/* initial (lower left) cut area 	*/
     bool vertical)		/* if TRUE, slot is aligned vertically	*/
 {
-    int i, j, xpitch, ypitch, delta, limit;
+    int xpitch, ypitch, delta, limit;
     int *axtop, *axbot, *aytop, *aybot;
     int *sxtop, *sxbot, *sytop, *sybot;
     int *rows, *columns;
@@ -3972,7 +3971,6 @@ cifSrTiles(
 {
     TileTypeBitMask maskBits;
     TileType t;
-    Tile *tp;
     int i;
     BloatData *bloats;
 
@@ -4056,7 +4054,6 @@ cifSrTiles2(
     TileTypeBitMask maskBits;
     Rect r;
     TileType t;
-    Tile *tp;
     int i;
 
     /* When reading data from a cell, it must first be scaled to
@@ -4212,7 +4209,6 @@ cifBridgeLimFunc0(
     Tile *tile,
     BridgeLimStruct *brlims)
 {
-    Plane *plane = brlims->plane;
     Rect area, parea;
     int minDistance = brlims->bridge->br_width;
     int width, height, ybot0, tp2lim;
@@ -4573,7 +4569,6 @@ cifBridgeLimFunc2(
     Tile *tp1, *tp2, *tpx;
     int width = brlims->bridge->br_width;
     int thirdOption;
-    int spacing = growDistance;
     BridgeLimCheckStruct brlimcs;
     brlimcs.sqdistance = (long) width * width;
 
@@ -4701,8 +4696,6 @@ cifInteractingRegions(
 {
     Tile *tile = NULL, *t, *tp;
     Rect area;
-    int i;
-    TileType type;
     bool interacts;
     static Stack *RegStack = (Stack *)NULL;
 
@@ -4888,7 +4881,6 @@ CIFGenLayer(
     Plane *temp;
     static Plane *nextPlane, *curPlane;
     Rect bbox;
-    CIFOp *tempOp;
     CIFSquaresInfo csi;
     SearchContext scx;
     TileType ttype;
@@ -4896,7 +4888,6 @@ CIFGenLayer(
     BloatStruct bls;
     BridgeStruct brs;
     BridgeLimStruct brlims;
-    BridgeData *bridge;
     BloatData *bloats;
     bool hstop = FALSE;
     char *propvalue;

--- a/cif/CIFhier.c
+++ b/cif/CIFhier.c
@@ -1011,6 +1011,8 @@ cifHierElementFunc(
 					 * CIF-generated.
 					 */
 {
+    ARG_UNUSED(x);
+    ARG_UNUSED(y);
     Rect defArea;
     Transform tinv;
     SearchContext scx;

--- a/cif/CIFmain.c
+++ b/cif/CIFmain.c
@@ -259,7 +259,7 @@ CIFSetStyle(
 				 * print out the valid styles.
 				 */
 {
-    CIFKeep *style, *match, *exactmatch;
+    CIFKeep *style, *match;
     bool ambiguous = FALSE;
     int length;
 

--- a/cif/CIFrdcl.c
+++ b/cif/CIFrdcl.c
@@ -260,8 +260,7 @@ cifFindCell(
     int cifNum)			/* The CIF number of the desired cell. */
 {
     HashEntry *h;
-    CellDef *def, *testdef;
-    int reused;
+    CellDef *def;
 
     h = HashFind(&CifCellTable, (char *)(spointertype)cifNum);
 
@@ -507,6 +506,8 @@ int cifCheckPaintFunc(
     Tile *tile,
     ClientData clientData)
 {
+    ARG_UNUSED(tile);
+    ARG_UNUSED(clientData);
     return 1;
 }
 
@@ -517,7 +518,6 @@ cifCopyPaintFunc(
     Tile *tile,
     CIFCopyRec *cifCopyRec)
 {
-    int pNum;
     TileType dinfo;
     Rect sourceRect, targetRect;
     Transform *trans = cifCopyRec->trans;
@@ -563,7 +563,6 @@ cifMaskHintFunc(
     Tile *tile,
     LinkedRect **lrecp)
 {
-    Rect r;
     LinkedRect *newlr;
 
     newlr = (LinkedRect *)mallocMagic(sizeof(LinkedRect));
@@ -638,7 +637,6 @@ CIFPaintCurrent(
 		int pNum;
 		Plane *newplane;
 		Plane **parray;
-		extern char *(cifReadLayers[MAXCIFRLAYERS]);
 
 		/* NOTE:  The condition cd_client == 0 when CDFLATGDS
 		 * indicates that the cell was already in memory when the
@@ -1620,7 +1618,6 @@ CIFReadCellCleanup(
     HashEntry *h;
     HashSearch hs;
     CellDef *def;
-    MagWindow *window;
     int flags;
 
     if (cifSubcellBeingRead)

--- a/cif/CIFrdpt.c
+++ b/cif/CIFrdpt.c
@@ -327,7 +327,7 @@ CIFPaintWirePath(
     CIFPath *pathp, *previousp, *nextp, *polypath;
     CIFPath *returnpath, *newpath, *savepath;
     LinkedRect	*rectp;
-    double theta, phi, alpha, delta, cwidth, adjwidth, testmitre, savetheta;
+    double theta, phi, alpha, delta, cwidth, testmitre, savetheta;
     double xmaxoff, ymaxoff, xminoff, yminoff;
     double xmin, ymin, xmax, ymax, xnext, ynext;
     bool firstpoint;
@@ -495,9 +495,7 @@ CIFPaintWirePath(
 	}
 	else
 	{
-	    Rect r;
 	    double a1, a2, r2, d1;
-	    Point newpt;
 
 	    /* Check if either of the two new segments travels opposite	*/
 	    /* to theta.  If so, then we need to find the intersection	*/
@@ -666,7 +664,7 @@ bool
 CIFParseWire(void)
 {
     int		width;
-    CIFPath	*pathheadp, *polypath;
+    CIFPath	*pathheadp;
     int		savescale;
 
     /* Take the 'W'. */

--- a/cif/CIFrdtech.c
+++ b/cif/CIFrdtech.c
@@ -466,6 +466,7 @@ CIFReadTechLine(
     int argc,			/* Number of fields on line. */
     char *argv[])		/* Values of fields. */
 {
+    ARG_UNUSED(sectionName);
     CIFOp *newOp = NULL;
     CIFReadKeep *newStyle, *p;
     HashEntry *he;

--- a/cif/CIFrdutils.c
+++ b/cif/CIFrdutils.c
@@ -210,7 +210,7 @@ CIFScaleCoord(
     int snap_type)			/* How to deal with fractional results */
 {
     int result, scale, remain, denom;
-    int mult, mfactor;
+    int mult;
 
     /* If internal grid subdivision is disallowed, always round to the	*/
     /* nearest grid unit.						*/
@@ -1056,8 +1056,6 @@ CIFMakeManhattanPath(
     PaintUndoInfo *ui)
 {
     CIFPath *new, *new2, *next, *path;
-    int xinit, xdiff, xincr, xlast, x;
-    int yinit, ydiff, yincr, ylast, y;
 
     bool clockwise;
     CIFPath *first, *last;
@@ -1239,7 +1237,7 @@ void
 CIFCleanPath(
     CIFPath *pathHead)
 {
-    CIFPath *next, *path, *prev, *last;
+    CIFPath *next, *path, *prev;
     int dir1, dir2;
 
     if (!pathHead) return;

--- a/cif/CIFsee.c
+++ b/cif/CIFsee.c
@@ -142,7 +142,6 @@ CIFPaintLayer(
     CellDef *paintDef)		/* CellDef to paint into (may be NULL)	*/
 {
     int oldCount, i;
-    char msg[100];
     SearchContext scx;
     PaintLayerData pld;
     TileTypeBitMask mask, depend;

--- a/cif/CIFtech.c
+++ b/cif/CIFtech.c
@@ -234,7 +234,7 @@ cifParseLayers(
 				*/
 {
     TileTypeBitMask curCifMask, curPaintMask;
-    char curLayer[40], *p, *cp;
+    char curLayer[40], *p;
     TileType paintType;
     int i;
     bool allResidues;
@@ -533,6 +533,7 @@ CIFTechLine(
     int argc,			/* Number of fields on line. */
     char *argv[])		/* Values of fields. */
 {
+    ARG_UNUSED(sectionName);
     TileTypeBitMask mask, tempMask, cifMask, bloatLayers;
     int i, j, l, distance;
     CIFLayer *newLayer;
@@ -2572,7 +2573,6 @@ CIFTechOutputScale(
 
 	    if (op->co_client)
 	    {
-		int nlayers;
 		switch (op->co_opcode)
 		{
 		    case CIFOP_SLOTS:

--- a/cif/CIFwrite.c
+++ b/cif/CIFwrite.c
@@ -308,7 +308,6 @@ cifOut(
     FILE *outf)
 {
     CellDef *def;
-    bool needHier;
 
     while (!StackEmpty(cifStack))
     {
@@ -728,7 +727,6 @@ CIFWriteFlat(
 {
     bool good;
     int oldCount = DBWFeedbackCount;
-    TileTypeBitMask cifMask;
     SearchContext scx;
 
     cifStack = StackNew(1);

--- a/cmwind/CMWcmmnds.c
+++ b/cmwind/CMWcmmnds.c
@@ -455,6 +455,7 @@ cmwSave(
     MagWindow *w,
     TxCommand *cmd)
 {
+    ARG_UNUSED(w);
     bool ok;
     if ((cmd->tx_argc != 1) && (cmd->tx_argc != 4))
     {
@@ -500,6 +501,7 @@ cmwLoad(
     MagWindow *w,
     TxCommand *cmd)
 {
+    ARG_UNUSED(w);
     if ((cmd->tx_argc != 1) && (cmd->tx_argc != 4))
     {
 	TxError("Usage: %s [techStyle displayStyle monitorType]\n",

--- a/cmwind/CMWmain.c
+++ b/cmwind/CMWmain.c
@@ -223,6 +223,7 @@ CMWreposition(
     Rect *newScreenArea,
     bool final)
 {
+    ARG_UNUSED(newScreenArea);
     if (final)
 	WindMove(window, &colorWindowRect);
 }

--- a/commands/CmdAB.c
+++ b/commands/CmdAB.c
@@ -74,6 +74,7 @@ CmdAddPath(
     MagWindow *w,
     TxCommand *cmd)
 {
+    ARG_UNUSED(w);
     if (cmd->tx_argc != 2) {
 	TxError("Usage: %s appended_search_path\n", cmd->tx_argv[0]);
 	return;
@@ -111,6 +112,7 @@ CmdArchive(
     MagWindow *w,
     TxCommand *cmd)
 {
+    ARG_UNUSED(w);
     int option = -1;
     char *filename = NULL;
     static const char * const cmdArchiveOpt[] = {"write", "writeall",
@@ -198,6 +200,7 @@ CmdArray(
     MagWindow *w,
     TxCommand *cmd)
 {
+    ARG_UNUSED(w);
     static const char * const cmdArrayOption[] = {
 	"count 		[[xlo] xhi [ylo] yhi]	array subcells",
 	"width 		[value]			set or return array x-spacing",
@@ -214,7 +217,6 @@ CmdArray(
     ArrayInfo a;
     Rect toolRect;
     LinkedArray *lahead = NULL, *la;
-    int xval, yval;
 
 #ifdef MAGIC_WRAPPER
     Tcl_Obj *tobj;
@@ -364,11 +366,6 @@ CmdArray(
 	    }
 	    if ((locargc != 3) || (!StrIsInt(cmd->tx_argv[argstart + 1])))
 		goto badusage;
-
-	    xval = atoi(cmd->tx_argv[argstart + 1]);
-	    yval = atoi(cmd->tx_argv[argstart + 2]);
-
-	    TxPrintf("Unimplemented function.\n");
 	    break;
 
 	case ARRAY_HEIGHT:
@@ -400,11 +397,6 @@ CmdArray(
 	    }
 	    if ((locargc != 3) || (!StrIsInt(cmd->tx_argv[argstart + 1])))
 		goto badusage;
-
-	    xval = atoi(cmd->tx_argv[argstart + 1]);
-	    yval = atoi(cmd->tx_argv[argstart + 2]);
-
-	    TxPrintf("Unimplemented function.\n");
 	    break;
 
 	case ARRAY_PITCH:
@@ -440,11 +432,6 @@ CmdArray(
 	    if ((locargc != 4) || (!StrIsInt(cmd->tx_argv[argstart + 1])) ||
 				(!StrIsInt(cmd->tx_argv[argstart + 2])))
 		goto badusage;
-
-	    xval = atoi(cmd->tx_argv[argstart + 1]);
-	    yval = atoi(cmd->tx_argv[argstart + 2]);
-
-	    TxPrintf("Unimplemented function.\n");
 	    break;
 
 	case ARRAY_POSITION:
@@ -481,11 +468,6 @@ CmdArray(
 	    if ((locargc != 4) || (!StrIsInt(cmd->tx_argv[argstart + 1])) ||
 				(!StrIsInt(cmd->tx_argv[argstart + 2])))
 		goto badusage;
-
-	    xval = atoi(cmd->tx_argv[argstart + 1]);
-	    yval = atoi(cmd->tx_argv[argstart + 2]);
-
-	    TxPrintf("Unimplemented function.\n");
 	    break;
 
 	case ARRAY_DEFAULT:
@@ -529,7 +511,6 @@ badusage:
 	    break;
     }
 
-freelist:
     la = lahead;
     while (la != NULL)
     {
@@ -550,6 +531,7 @@ selGetArrayFunc(
    Transform *trans,
    LinkedArray **arg)
 {
+    ARG_UNUSED(selUse);
     /* Check "use" for array information and pass this to arrayInfo */
 
     LinkedArray *la;

--- a/commands/CmdCD.c
+++ b/commands/CmdCD.c
@@ -1146,13 +1146,13 @@ CmdCellname(
 	"modified	true if modified, false if not",
 	NULL
     };
-    typedef enum { IDX_CHILDREN, IDX_PARENTS, IDX_EXISTS, IDX_SELF,
+    enum optionType { IDX_CHILDREN, IDX_PARENTS, IDX_EXISTS, IDX_SELF,
 		   IDX_INSTANCE, IDX_CHILDINST, IDX_CELLDEF, IDX_ALLCELLS,
 		   IDX_TOPCELLS, IDX_IN_WINDOW, IDX_CREATE, IDX_DELETE,
 		   IDX_DEREFERENCE, IDX_FILEPATH, IDX_FLAGS, IDX_TIMESTAMP,
 		   IDX_LOCK, IDX_UNLOCK, IDX_PROPERTY, IDX_ABUTMENT,
 		   IDX_ORIENTATION, IDX_RENAME, IDX_READWRITE,
-		   IDX_MODIFIED } optionType;
+		   IDX_MODIFIED };
 
     static const char * const cmdCellnameYesNo[] = {
 		"no", "false", "off", "0", "yes", "true", "on", "1", 0 };
@@ -1736,7 +1736,6 @@ CmdCif(
     bool doforall = FALSE;
     float curscale;
     int argc = cmd->tx_argc;
-    int argshift;
     char **argv = cmd->tx_argv;
 
     static const char * const cmdCifWarnOptions[] = { "default", "none", "align",
@@ -2276,6 +2275,7 @@ CmdClockwise(
     MagWindow *w,
     TxCommand *cmd)
 {
+    ARG_UNUSED(w);
     Transform trans, t2;
     int degrees, locargc;
     Rect rootBox,  bbox;
@@ -2574,7 +2574,6 @@ cmdContactEraseFunc(
     LinkedRect **lr)
 {
     LinkedRect *newlr;
-    Rect area;
 
     newlr = (LinkedRect *)mallocMagic(sizeof(LinkedRect));
 
@@ -3694,6 +3693,7 @@ CmdCrash(
     MagWindow *w,
     TxCommand *cmd)
 {
+    ARG_UNUSED(w);
     int option = -1;
     char *filename = NULL;
     static const char * const cmdCrashOpt[] = {"save", "recover", 0};
@@ -3797,6 +3797,7 @@ CmdDelete(
     MagWindow *w,
     TxCommand *cmd)
 {
+    ARG_UNUSED(w);
     if (cmd->tx_argc != 1) goto badusage;
     if (!ToolGetEditBox((Rect *)NULL)) return;
 
@@ -3928,6 +3929,7 @@ cmdDownEnumFunc(
 				 * area, in root coords.
 				 */
 {
+    ARG_UNUSED(selUse);
     Rect defArea, useArea;
 
     /* Save this use as the default next edit cell, regardless of whether
@@ -3999,9 +4001,8 @@ CmdDrc(
     static int	drc_nth = 1;
     int		  option, result, radius;
     Rect	  rootArea, area;
-    CellUse	* rootUse, *use;
+    CellUse	* rootUse;
     CellDef	* rootDef;
-    Transform	  trans;
     MagWindow	* window;
     const char 	* const *msg;
     bool	wizardHelp;
@@ -4565,7 +4566,6 @@ cmdDropPaintCell(
 {
     CellDef *cellDef = cxp->tc_scx->scx_use->cu_def;
     TileTypeBitMask *lMask = (TileTypeBitMask *)cxp->tc_filter->tf_arg;
-    int pNum;
     TileType type;
     Rect area;
 
@@ -4573,7 +4573,7 @@ cmdDropPaintCell(
         type = SplitRightType(tile);
     else
         type = SplitLeftType(tile);
-    pNum = DBPlane(type);
+    (void) type; // FIXME: this silences the set-but-unused warning, but type is apparently not used at all.
 
     TiToRect(tile, &area);
 
@@ -4641,6 +4641,7 @@ cmdDropPaintFunc(
     TileType type,              /* Type of this piece of paint. */
     TileTypeBitMask *mask)      /* Place to OR in type's bit. */
 {
+    ARG_UNUSED(rect);
     if (type & TT_DIAGONAL)
 	type = (type & TT_SIDE) ? (type & TT_RIGHTMASK) >> 14 :
 		(type & TT_LEFTMASK);
@@ -4992,18 +4993,18 @@ cmdDumpParseArgs(
 					"0", "90", "180", "270",
 					"v", "0v", "90v", "180v", "270v",
 					"h", "0h", "90h", "180h", "270h", 0 };
-	typedef enum {
+	enum optionType {
 		IDX_CHILD, IDX_PARENT,
 		IDX_ZERO, IDX_90, IDX_180, IDX_270,
 		IDX_VERT, IDX_ZERO_VERT, IDX_90_VERT, IDX_180_VERT, IDX_270_VERT,
 		IDX_HORZ, IDX_ZERO_HORZ, IDX_90_HORZ, IDX_180_HORZ, IDX_270_HORZ
-	} optionType;
+	};
 
 	static const char * const refPointNames[] = {
 			"ll", "lr", "ul", "ur", "label", 0 };
-	typedef enum {
+	enum refPointType {
 		IDX_LL, IDX_LR, IDX_UL, IDX_UR, IDX_LABEL
-	} refPointType;
+	};
 
 	Label *lab;
 	int n, p;
@@ -5374,6 +5375,8 @@ cmdDumpFunc(
     Label *label,		/* Pointer to label (not used). */
     Point *point)		/* Place to store label's lower-left. */
 {
+    ARG_UNUSED(name);
+    ARG_UNUSED(label);
     *point = rect->r_ll;
     return 1;
 }

--- a/commands/CmdE.c
+++ b/commands/CmdE.c
@@ -88,7 +88,6 @@ CmdEdit(
     CellDef *csave;
     int cmdEditRedisplayFunc(MagWindow *w, Rect *area);		/* Forward declaration. */
     int cmdEditEnumFunc(CellUse *selUse, CellUse *use, Transform *transform, Rect *area);		/* Forward declaration. */
-    bool noCurrentUse = FALSE;
 
     if ((w != NULL) && (cmd->tx_argc == 2))
     {
@@ -236,6 +235,7 @@ cmdEditEnumFunc(
 				 * area, in root coords.
 				 */
 {
+    ARG_UNUSED(selUse);
     Rect defArea, useArea;
     int xhi, xlo, yhi, ylo;
 
@@ -547,7 +547,6 @@ CmdElement(
 			    DBWElementPos(w, cmd->tx_argv[2], &crect);
 			else
 			{
-badrect:
 			    TxError("Usage: element configure <name> position "
 					"<x> <y> [<x2> <y2>]\n");
 			    return;
@@ -585,7 +584,6 @@ badrect:
 	    DBWElementInbox(&area);
 	    break;
 	case ELEMENT_HELP:
-badusage:
             for (msg = &(cmdElementOption[0]); *msg != NULL; msg++)
             {
                 TxPrintf("    %s\n", *msg);
@@ -763,6 +761,7 @@ cmdEraseCellsFunc(
     SearchContext *scx,		/* Indicates cell found. */
     ClientData cdarg)		/* Not used. */
 {
+    ARG_UNUSED(cdarg);
     /* All this procedure does is to remember cells that are
      * found, up to MAXCELLS of them.
      */
@@ -954,7 +953,6 @@ CmdExtract(
     CellDef	*selectedDef;
     bool dolist = FALSE;
     bool doforall = FALSE;
-    bool doLocal = FALSE;
     int argc = cmd->tx_argc;
     char **argv = cmd->tx_argv;
 

--- a/commands/CmdFI.c
+++ b/commands/CmdFI.c
@@ -759,6 +759,8 @@ cmdFindLabelFunc(
     Label *label,
     LabSearchRec *cdarg)
 {
+    ARG_UNUSED(name);
+    ARG_UNUSED(label);
     if (cdarg->lsr_occur == 0)
     {
     	cdarg->lsr_rect = *rect;
@@ -897,6 +899,8 @@ dbListLabels(
     TerminalPath *tpath,		/* Full pathname of terminal	*/
     ClientData cdarg)			/* (unused)			*/
 {
+    ARG_UNUSED(scx);
+    ARG_UNUSED(cdarg);
     char *n = tpath->tp_next;
     char c = *n;
     strcpy(n, label->lab_text);
@@ -1515,6 +1519,7 @@ CmdIdentify(
     MagWindow *w,
     TxCommand *cmd)
 {
+    ARG_UNUSED(w);
     extern int cmdIdFunc(CellUse *selUse, CellUse *use, Transform *transform, char *newId);		/* Forward reference. */
 
     if (cmd->tx_argc != 2)
@@ -1548,6 +1553,7 @@ cmdIdFunc(
     Transform *transform,	/* Not used. */
     char *newId)		/* New id for cell use. */
 {
+    ARG_UNUSED(transform);
     if (EditCellUse == NULL)
     {
 	TxError("Top-level cell is not editable---cannot change identifier"
@@ -1969,7 +1975,7 @@ CmdFlatten(
     TxCommand *cmd)
 {
      int		i, xMask, optargs;
-     bool		dolabels, dobox, toplabels, invert, doports, doinplace;
+     bool		dolabels, dobox, toplabels, invert, doinplace;
      char		*destname;
      CellDef		*newdef;
      CellUse		*newuse;
@@ -1981,7 +1987,6 @@ CmdFlatten(
     dolabels = TRUE;
     toplabels = FALSE;
     dobox = FALSE;
-    doports = TRUE;
     doinplace = FALSE;
     optargs = cmd->tx_argc - 1;
 
@@ -2020,7 +2025,7 @@ CmdFlatten(
 			if (!strncmp(cmd->tx_argv[i] + 3, "prop", 4))
 			    xMask = (invert) ? CU_DESCEND_ALL : CU_DESCEND_PROP_FLAT;
 			else
-			    doports = (invert) ? FALSE : TRUE;
+			 	{;} // doports = (invert) ? FALSE : TRUE;
 			break;
 		    case 's':
 			xMask = (invert) ? CU_DESCEND_NO_SUBCKT : CU_DESCEND_ALL;

--- a/commands/CmdLQ.c
+++ b/commands/CmdLQ.c
@@ -189,7 +189,6 @@ CmdLabel(
     TileType type = (TileType)(-1);
     int pos = -1, font = -1, size = 0, rotate = 0, offx = 0, offy = 0;
     bool sticky = FALSE;
-    int option;
     char *p;
 
     if (cmd->tx_argc < 2 || cmd->tx_argc > 9)
@@ -554,6 +553,8 @@ keepGoing(
     CellUse *use,
     ClientData clientdata)
 {
+    ARG_UNUSED(use);
+    ARG_UNUSED(clientdata);
     return 0;	/* keep the search going */
 }
 
@@ -598,6 +599,7 @@ CmdLocking(
     MagWindow *w,
     TxCommand *cmd)
 {
+    ARG_UNUSED(w);
     int option;
 
     static const char * const cmdLockingYesNo[] = { "disable", "no", "false", "off", "0",
@@ -1089,6 +1091,7 @@ CmdPath(
     MagWindow *w,
     TxCommand *cmd)
 {
+    ARG_UNUSED(w);
     char **pathptr;
     char *srcptr;
     int option;
@@ -1289,6 +1292,7 @@ cmdPortLabelFunc1(
     TerminalPath *tpath,
     ClientData cdata)
 {
+    ARG_UNUSED(tpath);
     Label **rlab = (Label **)cdata;
 
     if (GEO_SURROUND(&scx->scx_area, &label->lab_rect))
@@ -1311,6 +1315,7 @@ cmdPortLabelFunc2(
     TerminalPath *tpath,
     ClientData cdata)
 {
+    ARG_UNUSED(tpath);
     Label **rlab = (Label **)cdata;
 
     if (GEO_OVERLAP(&scx->scx_area, &label->lab_rect))
@@ -1526,7 +1531,6 @@ CmdPort(
     int argstart;
     int i, refidx, idx, pos, type, option, argc;
     unsigned int dirmask;
-    bool found;
     bool nonEdit = FALSE, doQuiet = FALSE;
     Label *lab, *sl;
     Rect editBox, tmpArea;
@@ -2425,6 +2429,7 @@ printPropertiesFunc(
     ClientData value,
     ClientData cdata) /* not used */
 {
+    ARG_UNUSED(cdata);
 #ifdef MAGIC_WRAPPER
     char *keyvalue;
 
@@ -2479,8 +2484,6 @@ CmdNetlist(
 {
     int option;
     const char * const *msg;
-    char *lastargv;
-    Point cursor;
     static const char * const cmdNetlistOption[] =
     {
 	"help           print this help information",
@@ -2561,6 +2564,8 @@ CmdOrient(
     MagWindow *w,
     TxCommand *cmd)
 {
+    ARG_UNUSED(w);
+    ARG_UNUSED(cmd);
     Transform trans, t2;
     int orientidx, locargc;
     char *orientstr;

--- a/commands/CmdRS.c
+++ b/commands/CmdRS.c
@@ -90,6 +90,7 @@ CmdRandom(
     MagWindow *w,
     TxCommand *cmd)
 {
+    ARG_UNUSED(w);
     int value;
 
     if (cmd->tx_argc == 1)
@@ -266,6 +267,7 @@ CmdScaleGrid(
     MagWindow *w,
     TxCommand *cmd)
 {
+    ARG_UNUSED(w);
     int scalen, scaled;
     char *argsep;
     Rect rootBox;
@@ -422,6 +424,7 @@ CmdSee(
     MagWindow *w,
     TxCommand *cmd)
 {
+    ARG_UNUSED(w);
     int flags;
     bool off;
     char *arg;
@@ -844,7 +847,7 @@ CmdSelect(
     CellUse *use;
     CellDef *rootBoxDef;
     Transform trans, rootTrans, tmp1;
-    Point p, rootPoint, atPoint;
+    Point p, atPoint;
     Rect r, selarea;
     ExtRectList *rlist;
     int option;
@@ -969,7 +972,6 @@ CmdSelect(
 	option = SEL_DEFAULT;
     else
     {
-	char *fileName;
 
 	option = Lookup(optionArgs[0], cmdSelectOption);
 	if ((option < 0) && (primargs != 2))
@@ -1707,6 +1709,7 @@ cmdLabelTextFunc(
     Transform *transform,
     char *text)
 {
+    ARG_UNUSED(transform);
     Label *newlab;
     CellDef *cellDef = cellUse->cu_def;
 #ifdef MAGIC_WRAPPER
@@ -1747,11 +1750,11 @@ cmdLabelRotateFunc(
     Transform *transform,
     int *value)
 {
+    ARG_UNUSED(transform);
     CellDef *cellDef = cellUse->cu_def;
 #ifdef MAGIC_WRAPPER
     Tcl_Obj *lobj;
 #endif
-    Rect selarea;
 
     if (value == NULL)
     {
@@ -1784,6 +1787,7 @@ cmdLabelSizeFunc(
     Transform *transform,
     int *value)
 {
+    ARG_UNUSED(transform);
     CellDef *cellDef = cellUse->cu_def;
 #ifdef MAGIC_WRAPPER
     Tcl_Obj *lobj;
@@ -1820,6 +1824,7 @@ cmdLabelJustFunc(
     Transform *transform,
     int *value)
 {
+    ARG_UNUSED(transform);
     CellDef *cellDef = cellUse->cu_def;
 #ifdef MAGIC_WRAPPER
     Tcl_Obj *lobj;
@@ -1856,6 +1861,7 @@ cmdLabelLayerFunc(
     Transform *transform,
     int *value)
 {
+    ARG_UNUSED(transform);
     CellDef *cellDef = cellUse->cu_def;
     TileType ttype;
 #ifdef MAGIC_WRAPPER
@@ -1894,6 +1900,7 @@ cmdLabelStickyFunc(
     Transform *transform,
     int *value)
 {
+    ARG_UNUSED(transform);
     CellDef *cellDef = cellUse->cu_def;
     int newvalue;
 #ifdef MAGIC_WRAPPER
@@ -1935,6 +1942,7 @@ cmdLabelOffsetFunc(
     Transform *transform,
     Point *point)
 {
+    ARG_UNUSED(transform);
     CellDef *cellDef = cellUse->cu_def;
 #ifdef MAGIC_WRAPPER
     Tcl_Obj *lobj, *pobj;
@@ -1976,6 +1984,7 @@ cmdLabelRectFunc(
     Transform *transform,
     Rect *rect)
 {
+    ARG_UNUSED(transform);
     CellDef *cellDef = cellUse->cu_def;
 #ifdef MAGIC_WRAPPER
     Tcl_Obj *lobj, *pobj;
@@ -2022,6 +2031,7 @@ cmdLabelFontFunc(
     Transform *transform,
     int *font)
 {
+    ARG_UNUSED(transform);
     CellDef *cellDef = cellUse->cu_def;
 #ifdef MAGIC_WRAPPER
     Tcl_Obj *lobj;
@@ -2590,6 +2600,7 @@ CmdSideways(
     MagWindow *w,
     TxCommand *cmd)
 {
+    ARG_UNUSED(w);
     Transform trans;
     Rect rootBox, bbox;
     CellDef *rootDef;
@@ -2652,6 +2663,7 @@ CmdShell(
     MagWindow *w,
     TxCommand *cmd)
 {
+    ARG_UNUSED(w);
     int i, cmdlength;
     char *command;
 
@@ -2869,10 +2881,10 @@ CmdSnap(
     MagWindow *w,
     TxCommand *cmd)
 {
+    ARG_UNUSED(w);
     static const char * const names[] = { "off", "internal", "lambda", "grid", "user", "on",
 		"list", 0 };
     int n = SNAP_LIST;
-    DBWclientRec *crec;
 
     if (cmd->tx_argc < 2) goto printit;
 

--- a/commands/CmdSubrs.c
+++ b/commands/CmdSubrs.c
@@ -1190,6 +1190,7 @@ cmdGetSelFunc(
     Transform *transform,	/* Transform from coords of realUse to root. */
     CellUse **pResult)		/* Store realUse here. */
 {
+    ARG_UNUSED(selUse);
     *pResult = realUse;
     if (cmdSelTrans != NULL)
 	*cmdSelTrans = *transform;

--- a/commands/CmdTZ.c
+++ b/commands/CmdTZ.c
@@ -63,6 +63,7 @@ int
 existFunc(
     Tile *tile)
 {
+    ARG_UNUSED(tile);
     return 1;
 }
 
@@ -85,7 +86,7 @@ checkForPaintFunc(
     ClientData arg)
 {
     int numPlanes = *((int *)arg);
-    int pNum, result;
+    int pNum;
 
     if (cellDef->cd_flags & CDINTERNAL) return 0;
 
@@ -167,6 +168,7 @@ CmdTech(
     MagWindow *w,		/* Window in which command was invoked. */
     TxCommand *cmd)		/* Info about command options. */
 {
+    ARG_UNUSED(w);
     int	option, action, i, locargc;
     const char * const *msg;
 #ifdef MAGIC_WRAPPER
@@ -657,6 +659,7 @@ CmdTool(
     MagWindow *w,		/* Window in which command was invoked. */
     TxCommand *cmd)		/* Info about command options. */
 {
+    ARG_UNUSED(w);
     if (cmd->tx_argc == 1)
     {
 	(void) DBWChangeButtonHandler((char *) NULL);
@@ -777,6 +780,7 @@ CmdUpsidedown(
     MagWindow *w,
     TxCommand *cmd)
 {
+    ARG_UNUSED(w);
     Transform trans;
     Rect rootBox, bbox;
     CellDef *rootDef;
@@ -842,6 +846,7 @@ cmdWhatPrintCell(
    Tile *tile,
    TreeContext *cxp)
 {
+    ARG_UNUSED(tile);
     struct linked_id **lid = (struct linked_id **)cxp->tc_filter->tf_arg;
     struct linked_id *curlid = *lid;
     char *CurrCellName;
@@ -1217,6 +1222,7 @@ cmdWhatPaintFunc(
     TileType type,		/* Type of this piece of paint. */
     TileTypeBitMask *mask)	/* Place to OR in type's bit. */
 {
+    ARG_UNUSED(rect);
     if (type & TT_DIAGONAL)
 	type = (type & TT_SIDE) ? (type & TT_RIGHTMASK) >> 14 :
 		(type & TT_LEFTMASK);
@@ -1238,6 +1244,8 @@ cmdWhatLabelPreFunc(
 				 * label found.
 				 */
 {
+    ARG_UNUSED(transform);
+    ARG_UNUSED(foundAny);
     LabelStore	*newPtr;
     CellDef *cellDef = cellUse->cu_def;	/* Cell definition containing label. */
 
@@ -1358,6 +1366,8 @@ cmdWhatCellFunc(
 				 * use found.
 				 */
 {
+    ARG_UNUSED(selUse);
+    ARG_UNUSED(transform);
     /* Forward reference */
     char *dbGetUseName(CellUse *celluse);
 
@@ -1382,6 +1392,8 @@ cmdWhatCellListFunc(
     Transform *transform,	/* Not used. */
     Tcl_Obj *newobj)		/* Tcl list object holding use names */
 {
+    ARG_UNUSED(selUse);
+    ARG_UNUSED(transform);
     Tcl_Obj *tuple;
     /* Forward reference */
     char *dbGetUseName(CellUse *celluse);
@@ -1942,6 +1954,7 @@ CmdWriteall(
     MagWindow *w,
     TxCommand *cmd)
 {
+    ARG_UNUSED(w);
     int cmdWriteallFunc(CellDef *def, TxCommand *cmd);
     int option = -1;
     static const char * const writeallOpts[] = { "force", "modified", 0 };
@@ -2007,7 +2020,7 @@ cmdWriteallFunc(
 			 * argc is a list of cells to write.
 			 */
 {
-    char *prompt, *argv;
+    char *prompt;
     int i, action, cidx = 0;
     static const char * const actionNames[] =
         { "write", "flush", "skip", "abort", "autowrite", 0 };

--- a/commands/CmdWizard.c
+++ b/commands/CmdWizard.c
@@ -83,6 +83,7 @@ CmdCoord(
     MagWindow *w,
     TxCommand *cmd)
 {
+    ARG_UNUSED(cmd);
     MagWindow *pointW = (MagWindow *) NULL;
     Rect editRect, rootRect;
     Transform tinv;
@@ -363,6 +364,7 @@ CmdShowtech(
     MagWindow *w,
     TxCommand *cmd)
 {
+    ARG_UNUSED(w);
     FILE *outf;
     bool verbose;
     char **av;
@@ -431,6 +433,7 @@ CmdTilestats(
     MagWindow *w,
     TxCommand *cmd)
 {
+    ARG_UNUSED(w);
     CellUse *selectedUse;
     FILE *outf = stdout;
     bool allDefs = FALSE;
@@ -569,6 +572,7 @@ cmdStatsCount(
     CellDef *def,
     struct countClient *cc)
 {
+    ARG_UNUSED(cc);
     int cmdStatsCountTile(Tile *tile, struct cellInfo *ci);
     int pNum;
     struct cellInfo *ci;
@@ -756,6 +760,7 @@ CmdPsearch(
     MagWindow *w,
     TxCommand *cmd)
 {
+    ARG_UNUSED(w);
     char *RunStats(int flags, struct tms *lastt, struct tms *deltat);
     static struct tms tlast, tdelta;
     Point p;
@@ -868,6 +873,7 @@ CmdTsearch(
     MagWindow *w,
     TxCommand *cmd)
 {
+    ARG_UNUSED(w);
     int cmdTsrFunc(Tile *tp);
     char *RunStats(int flags, struct tms *lastt, struct tms *deltat);
     char *rstatp;

--- a/database/DBbound.c
+++ b/database/DBbound.c
@@ -61,7 +61,6 @@ DBBoundCellPlane(def, extended, rect)
     TreeFilter filter;
     DBCellBoundStruct cbs;
     int dbCellBoundFunc();
-    Plane *plane;
 
     filter.tf_func = NULL;
     filter.tf_arg = (ClientData)&cbs;

--- a/database/DBcell.c
+++ b/database/DBcell.c
@@ -150,10 +150,6 @@ DBPlaceCell (use, def)
     CellUse   * use;	/* new celluse to add to subcell tile plane */
     CellDef   * def;    /* parent cell's definition */
 {
-    Rect             rect;    /* argument to DBSrCellPlaneArea(), placeCellFunc() */
-    BPlane          *bplane;  /* argument to DBSrCellPlaneArea(), placeCellFunc() */
-    struct searchArg arg;     /* argument to placeCellFunc() */
-
     ASSERT(use != (CellUse *) NULL, "DBPlaceCell");
     ASSERT(def, "DBPlaceCell");
 
@@ -184,9 +180,6 @@ DBPlaceCellNoModify (use, def)
     CellUse   * use;	/* new celluse to add to subcell tile plane */
     CellDef   * def;    /* parent cell's definition */
 {
-    Rect             rect;    /* argument to DBSrCellPlaneArea(), placeCellFunc() */
-    BPlane          *bplane;  /* argument to DBSrCellPlaneArea(), placeCellFunc() */
-    struct searchArg arg;     /* argument to placeCellFunc() */
 
     ASSERT(use != (CellUse *) NULL, "DBPlaceCell");
     ASSERT(def, "DBPlaceCell");

--- a/database/DBcellcopy.c
+++ b/database/DBcellcopy.c
@@ -388,7 +388,7 @@ dbCopyMaskHintsFunc(key, value, puds)
     CellDef *dest = puds->puds_dest;
     Transform *trans = puds->puds_trans;
     char *propstr = (char *)value;
-    char *parentprop, *newvalue, *vptr;
+    char *parentprop, *newvalue;
     Rect r, rnew;
     bool propfound;
 
@@ -615,7 +615,6 @@ DBFlattenInPlace(use, dest, xMask, dolabels, toplabels, doclear)
 
 	for (lab = dest->cu_def->cd_labels; lab; lab = lab->lab_next)
 	{
-	    Label *newlab;
 	    char *newtext;
 
 	    if (lab->lab_flags & LABEL_GENERATE)
@@ -917,7 +916,6 @@ DBCellGenerateSimpleSubstrate(scx, subType, notSubMask, targetDef)
     int plane;
     Rect rect;
     TileTypeBitMask allButSubMask;
-    TileTypeBitMask defaultSubTypeMask;
     int dbEraseSubFunc();
     int dbPaintSubFunc();
     int dbEraseNonSub();
@@ -1192,6 +1190,7 @@ dbCopyAllLabels(scx, lab, tpath, arg)
     TerminalPath *tpath;
     struct copyLabelArg *arg;
 {
+    ARG_UNUSED(tpath);
     Rect labTargetRect;
     Point labOffset;
     int targetPos, labRotate;

--- a/database/DBcellname.c
+++ b/database/DBcellname.c
@@ -455,7 +455,6 @@ dbCellPrintInfo(StartDef, who, dolist)
     CellDef *celldef;
     CellUse *celluse;
     char *cu_name;
-    bool topdone;
 
     switch (who) {
 	case SELF:
@@ -1254,6 +1253,7 @@ dbLockUseFunc(selUse, use, transform, data)
     Transform *transform;
     ClientData data;
 {
+    ARG_UNUSED(transform);
     bool dolock = *((bool *)data);
 
     if (EditCellUse && !DBIsChild(use, EditCellUse))
@@ -1450,6 +1450,7 @@ dbOrientUseFunc(selUse, use, transform, data)
     Transform *transform;
     ClientData data;
 {
+    ARG_UNUSED(transform);
     bool *dodef = (bool *)data;
     int orient;
 
@@ -1608,6 +1609,8 @@ dbAbutmentUseFunc(selUse, use, transform, data)
     Transform *transform;
     ClientData data;
 {
+    ARG_UNUSED(selUse);
+    ARG_UNUSED(transform);
     Rect bbox, refbox;
     Transform *trans;
     char *propvalue;

--- a/database/DBcellsrch.c
+++ b/database/DBcellsrch.c
@@ -1802,7 +1802,7 @@ int dbScaleProp(name, value, cps)
     CellPropStruct *cps;
 {
     int scalen, scaled;
-    char *newvalue, *vptr;
+    char *newvalue;
     Rect r;
 
     if ((strlen(name) > 5) && !strncmp(name + strlen(name) - 5, "_BBOX", 5))
@@ -1940,7 +1940,6 @@ dbScaleCell(cellDef, scalen, scaled)
     int dbCellScaleFunc(), dbCellUseEnumFunc();
     Label *lab;
     int pNum;
-    LinkedTile *lhead, *lt;
     LinkedCellUse *luhead, *lu;
     Plane *newplane;
     BPlane *cellPlane, *cellPlaneOrig;
@@ -2155,7 +2154,6 @@ DBMoveCell(cellDef, origx, origy)
     int dbCellTileEnumFunc(), dbCellUseEnumFunc();
     Label *lab;
     int pNum;
-    LinkedTile *lhead, *lt;
     LinkedCellUse *luhead, *lu;
     Plane *newplane;
     BPlane *cellPlane, *cellPlaneOrig;

--- a/database/DBconnect.c
+++ b/database/DBconnect.c
@@ -737,8 +737,9 @@ int
 dbcUnconnectFunc(tile, clientData)
     Tile *tile;				/* Current tile	*/
     ClientData clientData;		/* Unused.	*/
-
 {
+    ARG_UNUSED(tile);
+    ARG_UNUSED(clientData);
     return 1;
 }
 
@@ -946,7 +947,6 @@ dbcConnectFunc(tile, cx)
     TileTypeBitMask notConnectMask;
     Rect *srArea;
     SearchContext *scx = cx->tc_scx;
-    SearchContext scx2;
     TileType loctype = TiGetTypeExact(tile);
     TileType dinfo = 0;
     int retval, i, pNum = cx->tc_plane;

--- a/database/DBexpand.c
+++ b/database/DBexpand.c
@@ -183,7 +183,6 @@ dbExpandFunc(scx, arg)
     struct expandArg *arg;	/* Client data from caller */
 {
     CellUse *childUse = scx->scx_use;
-    int n = DBLambda[1];
 
     /*
      * Change the expansion status of this cell if necessary.  Call the

--- a/database/DBio.c
+++ b/database/DBio.c
@@ -225,11 +225,10 @@ DBSearchForTech(techname, techroot, pathroot, level)
     char *pathroot;
     int level;
 {
-    char *newpath, *found, *dptr;
+    char *newpath, *found;
     struct dirent *tdent;
     DIR *tdir;
     LinkedDirent *dlist = NULL, *ld, *ldlast = NULL;
-    int dlen;
 
     /* Avoid potential infinite looping.  Any tech file should not be very  */
     /* far down the path.  10 levels is already excessive.		    */
@@ -525,13 +524,11 @@ dbCellReadDef(f, cellDef, ignoreTech, dereference)
 {
     int cellStamp = 0, rectCount = 0, rectReport = 10000;
     char line[2048], tech[50], layername[50];
-    PaintResultType *ptable;
     bool result = TRUE, scaleLimit = FALSE, has_mismatch;
     Rect *rp;
     int c;
     TileType type, rtype, loctype;
     TileTypeBitMask *rmask, typemask;
-    Plane *plane;
     Rect r;
     int n = 1, d = 1;
     HashTable dbUseTable;
@@ -1232,7 +1229,6 @@ DBReadBackup(name, archive, usederef)
     char *filename, *rootname, *chrptr, *suffix, *filetype;
     char line[256];
     CellDef *cellDef;
-    bool result = TRUE;
 
     if (archive)
     {
@@ -1447,7 +1443,7 @@ dbReadOpen(cellDef, setFileName, dereference, errptr)
 {
     FILETYPE f = NULL;
     int fd;
-    char *filename, *realname, *savename;
+    char *filename, *realname;
     bool is_locked;
 
 #ifdef FILE_LOCKS
@@ -1654,6 +1650,7 @@ DBOpenOnly(cellDef, name, setFileName, errptr)
 			 */
     int *errptr;	/* Pointer to int to hold error value */
 {
+    ARG_UNUSED(name);
     dbReadOpen(cellDef, setFileName, FALSE, errptr);
 }
 
@@ -3261,7 +3258,7 @@ dbFindPropGCFFunc(key, value, ggcf)
     int *ggcf;		/* Client data */
 {
     Rect bbox;
-    char *vptr = value, *sptr;
+    char *vptr = value;
     int numvals, n;
 
     if (!strcmp(key, "FIXED_BBOX"))
@@ -3398,6 +3395,7 @@ dbCountUseFunc(cellUse, count)
     CellUse *cellUse;	/* Cell use whose "call" is to be written to a file */
     int *count;
 {
+    ARG_UNUSED(cellUse);
     (*count)++;
     return 0;
 }
@@ -3491,6 +3489,8 @@ dbCountPropFunc(key, value, count)
     ClientData value;
     int *count;		/* Client data */
 {
+    ARG_UNUSED(key);
+    ARG_UNUSED(value);
     (*count)++;
     return 0;
 }
@@ -3551,9 +3551,6 @@ DBCellWriteFile(cellDef, f)
     int reducer;
     char *estring;
     char lstring[2048];
-    char *propvalue;
-    bool propfound;
-    CellUse **useList;
     int i, numUses = 0, numProps = 0;
     struct cellUseList cul;
     pwfrec pwf;
@@ -4187,12 +4184,10 @@ dbWritePaintCommandsFunc(tile, cdarg)
     Tile *tile;
     ClientData cdarg;
 {
-    char pstring[256];
     struct writeArg *arg = (struct writeArg *) cdarg;
     FILE *f = arg->wa_file;
 
     TileType type = TiGetType(tile);
-    TileTypeBitMask *lMask, *rMask;
 
     int diridx;
     static const char *directionNames[] = {"nw", "se", "sw", "ne", 0};
@@ -4760,6 +4755,7 @@ dbClearCellFunc(cellUse, cdarg)
     CellUse *cellUse;	/* Cell use */
     ClientData cdarg;	/* Not used */
 {
+    ARG_UNUSED(cdarg);
     cellUse->cu_def->cd_flags &= ~CDVISITED;
     return 0;
 }
@@ -5231,6 +5227,7 @@ dbCheckModifiedCellsFunc(def, cdata)
     CellDef *def;	/* Pointer to CellDef to be saved */
     ClientData cdata;	/* Unused */
 {
+    ARG_UNUSED(cdata);
     if (def->cd_flags & (CDINTERNAL | CDNOEDIT | CDNOTFOUND)) return 0;
     else if (!(def->cd_flags & CDAVAILABLE)) return 0;
     return 1;

--- a/database/DBlabel.c
+++ b/database/DBlabel.c
@@ -1316,8 +1316,7 @@ DBFontLabelSetBBox(label)
     char *tptr;
     Point *coffset, rcenter;
     Rect *cbbox, locbbox, *frect;
-    Transform labTransform = GeoIdentityTransform;
-    int i, ysave, size;
+    int i, ysave;
     double rrad, cr, sr, tmpx, tmpy;
     bool expand;
 
@@ -1563,7 +1562,7 @@ DBLoadFont(fontfile, scale)
 	"v", "w", "x", "y", "z", "braceleft", "bar", "braceright",
 	"asciitilde", ".notdef", NULL
     };
-    int i, j, x, y, asciiidx, chardef, numidx;
+    int i, j, asciiidx, chardef, numidx;
     int numtok[NUMBUF];
     char *token, *psname = NULL;
     MagicFont *newFont = NULL, **newDBFontList;

--- a/database/DBpaint.c
+++ b/database/DBpaint.c
@@ -744,7 +744,7 @@ DBSplitTile(plane, point, splitx)
     Point *point;
     int splitx;
 {
-    Tile *tile, *newtile, *tp;
+    Tile *tile, *newtile;
     tile = PlaneGetHint(plane);
     GOTOPOINT(tile, point);
 
@@ -805,7 +805,6 @@ DBFracturePlane(plane, area, resultTbl, undo)
     TileType oldType;
     Tile *tile, *newtile;
     Tile *tpnew;	/* Used for area search */
-    Tile *tp;		/* Used for paint */
 
     if (area->r_xtop <= area->r_xbot || area->r_ytop <= area->r_ybot)
 	return;
@@ -1511,7 +1510,6 @@ DBNMPaintPlane0(plane, exacttype, area, resultTbl, undo, method)
     if (exacttype & TT_DIAGONAL)
     {
 	int dbNMEnumFunc();	/* Forward reference */
-	TileRect arg;
 
 	dinfo.resultTbl = resultTbl;
 	dinfo.dir = (exacttype & TT_DIRECTION) ? 1 : 0;

--- a/database/DBtcontact.c
+++ b/database/DBtcontact.c
@@ -171,6 +171,7 @@ DBTechAddContact(sectionName, argc, argv)
     int argc;
     char *argv[];
 {
+    ARG_UNUSED(sectionName);
     TileType contactType;
     int nresidues;
 
@@ -216,7 +217,6 @@ DBTechAddContact(sectionName, argc, argv)
 		else
 		{
 		    TileType lastType = TT_SPACE;
-		    char *primary;
 
 		    while (--argc > 1)
 		    {
@@ -826,7 +826,6 @@ DBTechTypesOnPlane(src, plane)
     int plane;
 {
     int i;
-    PlaneMask pmask;
 
     for (i = 0; i < DBNumTypes; i++)
 	if (TTMaskHasType(src, i))

--- a/database/DBtech.c
+++ b/database/DBtech.c
@@ -106,6 +106,7 @@ DBTechSetTech(sectionName, argc, argv)
     int argc;
     char *argv[];
 {
+    ARG_UNUSED(sectionName);
     if (argc != 1)
     {
 	if (argc == 2)
@@ -174,6 +175,7 @@ DBTechSetVersion(sectionName, argc, argv)
     int argc;
     char *argv[];
 {
+    ARG_UNUSED(sectionName);
     char *contline;
     int n, slen;
 
@@ -312,6 +314,7 @@ DBTechAddConnect(sectionName, argc, argv)
     int argc;
     char *argv[];
 {
+    ARG_UNUSED(sectionName);
     TileTypeBitMask types1, types2;
     TileType t1, t2;
 

--- a/database/DBtechname.c
+++ b/database/DBtechname.c
@@ -155,7 +155,6 @@ DBTechNameTypes(typename, bitmask)
     char *slash;
     TileType type;
     int plane;
-    LayerInfo *lp;
 
     TTMaskZero(bitmask);
     slash = strchr(typename, '/');

--- a/database/DBtechtype.c
+++ b/database/DBtechtype.c
@@ -269,6 +269,7 @@ DBTechAddPlane(
     int argc,
     char *argv[])
 {
+    ARG_UNUSED(sectionName);
     const char *cp;
 
     if (DBNumPlanes >= PL_MAXTYPES)
@@ -344,8 +345,7 @@ DBTechAddAlias(sectionName, argc, argv)
     int argc;
     char *argv[];
 {
-    char *cp;
-    int pNum;
+    ARG_UNUSED(sectionName);
     HashEntry *he;
     TileType atype;
     TileTypeBitMask *amask, tmask;

--- a/database/DBtiles.c
+++ b/database/DBtiles.c
@@ -829,7 +829,7 @@ DBClearCellPlane(def)
 
 int dbDeleteCellUse(CellUse *use, ClientData arg)
 {
-    CellDef *def = (CellDef *)arg;
+    ARG_UNUSED(arg);
     CellUse *defuses, *lastuse;
 
     dbInstanceUnplace(use);

--- a/database/DBtpaint.c
+++ b/database/DBtpaint.c
@@ -597,6 +597,7 @@ dbTechAddPaintErase(type, sectionName, argc, argv)
     int argc;
     char *argv[];
 {
+    ARG_UNUSED(sectionName);
     int pNum;
     PlaneMask pMask, rMask;
     TileType t1, t2, tres;

--- a/database/DBtpaint2.c
+++ b/database/DBtpaint2.c
@@ -734,10 +734,10 @@ void
 DBLockContact(ctype)
    TileType ctype;
 {
-    LayerInfo *lpImage, *lpPaint;
-    TileType c, n, itype, eresult;
+    LayerInfo *lpPaint;
+    TileType n;
     TileTypeBitMask *rmask;
-    int m, pNum;
+    int pNum;
 
     /* Have type, Erase * --> Result is type */
 
@@ -778,9 +778,7 @@ DBUnlockContact(ctype)
    TileType ctype;
 {
     LayerInfo *lpImage, *lpPaint;
-    TileType n, itype, eresult;
-    TileTypeBitMask *rmask;
-    int m, pNum;
+    TileType n;
 
     lpImage = &dbLayerInfo[ctype];
 
@@ -868,6 +866,7 @@ dbComposeDecompose(imageType, componentType, remainingType)
     TileType componentType;
     TileType remainingType;
 {
+    ARG_UNUSED(remainingType);
     int pNum = DBPlane(imageType);
     TileType resultType;
 

--- a/dbwind/DBWdisplay.c
+++ b/dbwind/DBWdisplay.c
@@ -163,6 +163,7 @@ DBWredisplay(w, rootArea, clipArea)
     Rect *clipArea;		/* The screen area that we should clip to
 				 */
 {
+    ARG_UNUSED(clipArea);
     int i;
     TileTypeBitMask *mask;
     SearchContext scontext;
@@ -170,7 +171,7 @@ DBWredisplay(w, rootArea, clipArea)
     int bitMask, lambdasPerPixel, pixelsPerLambda;
     DBWclientRec *crec;
     CellDef *cellDef;
-    TileTypeBitMask layers, rmask;
+    TileTypeBitMask layers;
 
     /*
     TxPrintf("Root area (%d, %d) (%d, %d) redisplay.\n",
@@ -703,7 +704,6 @@ DBWDrawLabel(label, rect, pos, style, labelSize, sizeBox)
     Point p;
     Rect location;
     char *text = label->lab_text;
-    int result;
 
     if (style >= 0) GrSetStuff(style);
     GrDrawFastBox(rect, labelSize);
@@ -791,7 +791,6 @@ DBWDrawFontLabel(label, window, trans, style)
     Rect rootArea, labrect;
     int i, rotate, minv, scaledLambdasPerPixel;
     dlong tmp, dval, scale;
-    double rads;
 
     GeoTransRect(trans, &label->lab_rect, &rootArea);
     WindSurfaceToScreen(window, &rootArea, &labrect);
@@ -930,8 +929,9 @@ dbwLabelFunc(scx, label, tpath, clientData)
     TerminalPath *tpath;	/* Contains pointer to full pathname of label */
     ClientData clientData;	/* Used for mask for dbw_visibleLayers */
 {
+    ARG_UNUSED(tpath);
     Rect labRect, tmp;
-    int screenPos, screenRot, newStyle;
+    int screenPos, newStyle;
     TileTypeBitMask *vmask;
 
     vmask = (TileTypeBitMask *)clientData;
@@ -1725,6 +1725,7 @@ DBWTechAddStyle(sectionName, argc, argv)
     int argc;
     char *argv[];
 {
+    ARG_UNUSED(sectionName);
     TileType t, r;
     TileTypeBitMask *rMask;
     int i, sidx;

--- a/dbwind/DBWelement.c
+++ b/dbwind/DBWelement.c
@@ -339,6 +339,7 @@ DBWElementRedraw(window, plane)
 				 * needs to be redrawn.
 				 */
 {
+    ARG_UNUSED(plane);
     int curStyle, newStyle;
     styleptr stylePtr;
     CellDef *windowRoot;
@@ -570,7 +571,6 @@ void
 DBWElementDelete(MagWindow *w, char *name)
 {
     DBWElement *elem;
-    CellDef *currentRoot;
     HashEntry *entry;
     styleptr stylePtr;
 
@@ -673,7 +673,6 @@ DBWElementInbox(area)
     DBWElement *elem;
     HashSearch hs;
     HashEntry *he;
-    int sqdist;
 
 #ifndef MAGIC_WRAPPER
     TxPrintf("Element(s) inside box: ");
@@ -1201,7 +1200,6 @@ DBWElementPos(MagWindow *w, char *ename, Rect *crect)
 {
     DBWElement *elem;
     HashEntry *entry;
-    Rect prect;
     char ptemp[22];
 
     entry = HashFind(&elementTable, ename);

--- a/dbwind/DBWfdback.c
+++ b/dbwind/DBWfdback.c
@@ -276,7 +276,7 @@ void
 DBWFeedbackClear(text)
     char *text;
 {
-    int i, oldCount;
+    int oldCount;
     Feedback *fb, *fl, *fe;
     Rect area;
     CellDef *currentRoot;

--- a/dbwind/DBWhlights.c
+++ b/dbwind/DBWhlights.c
@@ -242,7 +242,6 @@ dbwhlRedrawFunc(window, area)
 
     if (dbwhlErase)
     {
-	bool needErase = TRUE;
 
 	erase.r_xbot += expand.r_xbot;
 	erase.r_ybot += expand.r_ybot;

--- a/dbwind/DBWprocs.c
+++ b/dbwind/DBWprocs.c
@@ -292,7 +292,6 @@ DBWloadWindow(window, name, flags)
     int xadd, yadd;
     Rect loadBox;
     char *rootname;
-    bool isUnnamed;
     int UnexpandFunc();		/* forward declaration */
 
     bool ignoreTech;	/* If FALSE, indicates that the technology of
@@ -677,7 +676,6 @@ DBWcommands(w, cmd)
     MagWindow *w;
     TxCommand *cmd;
 {
-    int cmdNum;
 
     /* If it was a keyboard command, just dispatch to the proper
      * command routine.
@@ -781,7 +779,6 @@ void
 DBWinit()
 {
     MagWindow *initialWindow;
-    int i;
     static char *doc =
 	"You are currently using the \"box\" tool.  The button actions are:\n"
 	"   left    - move the box so its lower-left corner is at cursor position\n"

--- a/dbwind/DBWtools.c
+++ b/dbwind/DBWtools.c
@@ -493,6 +493,7 @@ DBWDrawCrosshair(window, plane)
 				 * which highlight areas must be redrawn.
 				 */
 {
+    ARG_UNUSED(plane);
     Point p;
 
     /* Unlike most highlights, which are related to the database and	*/

--- a/drc/DRCarray.c
+++ b/drc/DRCarray.c
@@ -104,8 +104,8 @@ drcArrayFunc(scx, arg)
 {
     int xsep, ysep;
     int xsize, ysize;
-    int rval, oldTiles;
-    Rect errorArea, yankArea, tmp, tmp2, saveClip;
+    int oldTiles;
+    Rect errorArea, yankArea, tmp, tmp2;
     DRCCookie *save_cptr;
     CellUse *use = scx->scx_use;
     Rect *area;
@@ -113,7 +113,6 @@ drcArrayFunc(scx, arg)
     void (*drcArrayErrorFunc)();	/* Function to call on violations. */
     ClientData drcArrayClientData;	/* Extra parameter to pass to func. */
     PaintResultType (*savedPaintTable)[NT][NT];
-    PaintResultType (*savedEraseTable)[NT][NT];
     int (*savedPaintPlane)();
 
     if ((use->cu_xlo == use->cu_xhi) && (use->cu_ylo == use->cu_yhi))
@@ -291,6 +290,8 @@ drcArrayYankFunc(use, transform, x, y, yankArea)
     Rect *yankArea;			/* Area to yank (in parent coords). */
 
 {
+    ARG_UNUSED(x);
+    ARG_UNUSED(y);
     SearchContext scx;
     Transform tinv;
 
@@ -332,6 +333,8 @@ drcArrayOverlapFunc(use, transform, x, y, arg)
 				 * checking.  See drcExactOverlapTile.
 				 */
 {
+    ARG_UNUSED(x);
+    ARG_UNUSED(y);
     Transform tinv;
     SearchContext scx;
 

--- a/drc/DRCbasic.c
+++ b/drc/DRCbasic.c
@@ -182,7 +182,6 @@ areaCheck(tile, arg)
 
     if (arg->dCD_radial != 0)
     {
-	unsigned int i;
 	int sqx, sqy;
 	int sdist = arg->dCD_radial & 0xfff;
 	long sstest, ssdist = (long) sdist * sdist;
@@ -440,11 +439,11 @@ drcTile (tile, arg)
     Rect *rect = arg->dCD_rect;	/* Area being checked */
     Rect errRect;		/* Area checked for an individual rule */
     MaxRectsData *mrd;		/* Used by widespacing rule */
-    TileTypeBitMask tmpMask, *rMask;
+    TileTypeBitMask tmpMask;
     bool trigpending;		/* Hack for widespacing rule */
     bool firsttile;
     int triggered;
-    int cdist, dist, ccdist, result;
+    int cdist, dist, result;
 
     arg->dCD_constraint = &errRect;
 
@@ -475,7 +474,6 @@ drcTile (tile, arg)
 
     if (IsSplit(tile) && !SplitSide(tile))
     {
-	int deltax, deltay;
 	TileType tt, to;
 
 	tt = TiGetLeftType(tile);	/* inside type */
@@ -495,7 +493,7 @@ drcTile (tile, arg)
 	{
 	    int deltax, deltay, w, h;
 	    double r;
-	    TileType dinfo, dsplit;
+	    TileType dinfo;
 
 	    /* Work to be done:  Handle triggering rules for non-Manhattan  */
 	    /* edges;  especially important for the wide-spacing rule.	    */

--- a/drc/DRCcif.c
+++ b/drc/DRCcif.c
@@ -116,6 +116,7 @@ drcCifSetStyle(argc, argv)
     int argc;
     char *argv[];
 {
+    ARG_UNUSED(argc);
     CIFKeep     *new;
 
     for (new = CIFStyleList; new != NULL; new = new->cs_next)
@@ -182,11 +183,11 @@ drcCifWidth(argc, argv)
     int argc;
     char *argv[];
 {
+    ARG_UNUSED(argc);
     char *layername = argv[1];
     int scalefactor;
     int centidistance = atoi(argv[2]);
     int why = drcWhyCreate(argv[3]);
-    TileTypeBitMask set, setC, tmp1;
     int	thislayer = -1;
     DRCCookie *dpnew,*dpnext;
     TileType i;
@@ -243,11 +244,12 @@ drcCifSpacing(argc, argv)
     int argc;
     char *argv[];
 {
+    ARG_UNUSED(argc);
     char *adjacency = argv[4];
     int why = drcWhyCreate(argv[5]);
     DRCCookie *dpnext, *dpnew;
     int needReverse = FALSE;
-    TileType i, j;
+    TileType i;
     int scalefactor;
     int centidistance = atoi(argv[3]);
     char *layers[2];
@@ -571,7 +573,6 @@ drcCifCheck(arg)
 	    for (drcCifCur = drcCifRules[i][j];
 	       		drcCifCur; drcCifCur = drcCifCur->drcc_next)
             {
-	  	TileTypeBitMask	*mask;
 
 		arg->dCD_plane = i;
 	        DBSrPaintArea((Tile *) NULL, CIFPlanes[i], &cifrect,
@@ -1073,7 +1074,6 @@ areaCifCheck(tile, arg)
      */
     if (arg->dCD_radial != 0)
     {
-	unsigned int i;
 	int sqx, sqy;
 	int sdist = arg->dCD_radial & 0xfff;
 	long sstest, ssdist = (long) sdist * sdist;
@@ -1176,14 +1176,13 @@ drcCifArea(argc, argv)
     int argc;
     char *argv[];
 {
+    ARG_UNUSED(argc);
     char *layers = argv[1];
     int centiarea = atoi(argv[2]);
     int	centihorizon = atoi(argv[3]);
     int why = drcWhyCreate(argv[4]);
-    TileTypeBitMask set, setC, tmp1;
     DRCCookie *dpnext, *dpnew;
-    TileType i, j;
-    int plane;
+    TileType i;
     int	thislayer = -1;
     int scalefactor;
 
@@ -1237,14 +1236,13 @@ drcCifMaxwidth(argc, argv)
     int argc;
     char *argv[];
 {
+    ARG_UNUSED(argc);
     char *layers = argv[1];
     int centidistance = atoi(argv[2]);
     char *bends = argv[3];
     int why = drcWhyCreate(argv[4]);
-    TileTypeBitMask set, setC, tmp1;
     DRCCookie *dpnext, *dpnew;
-    TileType i, j;
-    int plane;
+    TileType i;
     int bend;
     int thislayer = -1;
     int scalefactor;

--- a/drc/DRCcontin.c
+++ b/drc/DRCcontin.c
@@ -188,12 +188,13 @@ DRCCheckThis (celldef, operation, area)
     TileType  operation;		/* TT_CHECKPAINT or TT_CHECKSUBCELL */
     Rect    * area;			/* Area that changed. */
 {
+    ARG_UNUSED(operation);
     CellUse	     * cu;		/* Ptr to uses of the given CellDef */
     Rect	       transRect;	/* Area in coords of parent CellDefs,
 					 * expanded if the use is in an array
 					 */
     Rect               dummyRect, dummyRect2;
-    DRCPendingCookie * p, ** pback;	/* Used to insert new element in list
+    DRCPendingCookie * p;	/* Used to insert new element in list
 					 *  of CellDefs waiting for DRC
 					 */
 
@@ -642,6 +643,7 @@ drcCheckTile(tile, arg)
     Tile        * tile;			/* tile in DRC_CHECK plane */
     ClientData 	  arg;			/* Not used. */
 {
+    ARG_UNUSED(arg);
     Rect square;		/* Square area of the checkerboard
 				 * being processed right now.
 				 */

--- a/drc/DRCextend.c
+++ b/drc/DRCextend.c
@@ -490,8 +490,7 @@ drcCanonicalMaxwidth(starttile, dir, arg, cptr)
     struct	drcClientData	*arg;
     DRCCookie	*cptr;
 {
-    int		    s, edgelimit;
-    Tile	    *tile,*tp;
+    int		    edgelimit;
     TileTypeBitMask wrongtypes;
     static MaxRectsData *mrd = (MaxRectsData *)NULL;
     Rect	    *boundrect, boundorig;

--- a/drc/DRCmain.c
+++ b/drc/DRCmain.c
@@ -151,6 +151,7 @@ drcPaintError(celldef, rect, cptr, plane)
     DRCCookie * cptr;  			/* Design rule violated -- not used */
     Plane     * plane;			/* Where to paint error tiles. */
 {
+    ARG_UNUSED(cptr);
     PaintUndoInfo ui;
 
     ui.pu_def = celldef;
@@ -275,9 +276,9 @@ drcPrintError (celldef, rect, cptr, scx)
     DRCCookie * cptr;  		/* Design rule violated */
     SearchContext * scx;	/* Only errors in scx->scx_area get reported. */
 {
-    HashEntry *h;
+    ARG_UNUSED(celldef);
     int i;
-    Rect *area, r;
+    Rect *area;
 
     ASSERT (cptr != (DRCCookie *) NULL, "drcPrintError");
 
@@ -306,7 +307,7 @@ drcListError (celldef, rect, cptr, scx)
     DRCCookie * cptr;  		/* Design rule violated */
     SearchContext * scx;	/* Only errors in scx->scx_area get reported */
 {
-    HashEntry *h;
+    ARG_UNUSED(celldef);
     int i;
     Rect *area;
 
@@ -340,6 +341,7 @@ drcListallError (celldef, rect, cptr, scx)
     DRCCookie * cptr;  		/* Design rule violated */
     SearchContext * scx;	/* Only errors in scx->scx_area get reported. */
 {
+    ARG_UNUSED(celldef);
     Tcl_Obj *lobj, *pobj;
     HashEntry *h;
     Rect *area, r;
@@ -488,7 +490,7 @@ DRCWhy(dolist, use, area, findonly)
 {
     SearchContext scx;
     Rect box;
-    int i, nerrors;
+    int i;
     extern void drcWhyFunc();		/* Forward reference. */
     LinkedIndex *li;
 
@@ -558,6 +560,7 @@ DRCWhyAll(use, area, fout)
 					 * Write formatted output to fout
 					 */
 {
+    ARG_UNUSED(fout);
     SearchContext scx;
     Rect box;
     extern int drcWhyAllFunc();		/* Forward reference. */
@@ -656,6 +659,7 @@ drcWhyAllFunc(scx, cdarg)
     SearchContext *scx;		/* Describes current state of search. */
     ClientData cdarg;		/* Unused */
 {
+    ARG_UNUSED(cdarg);
     CellDef *def = scx->scx_use->cu_def;
 
     /* Check paint and interactions in this subcell. */
@@ -717,6 +721,7 @@ drcCheckFunc(scx, cdarg)
     SearchContext *scx;
     ClientData cdarg;		/* Not used. */
 {
+    ARG_UNUSED(cdarg);
     Rect cellArea;
     CellDef *def;
 
@@ -781,7 +786,6 @@ DRCCount(use, area, recurse)
     HashSearch	  hs;
     int		  count;
     SearchContext scx;
-    CellDef	  *def;
     extern int drcCountFunc();
 
     /* Shouldn't happen? */

--- a/drc/DRCprint.c
+++ b/drc/DRCprint.c
@@ -169,7 +169,7 @@ maskToPrint (mask)
     int	i;
     int gotSome = FALSE;
     static char printchain[512];
-    char buffer[20], *drcName;
+    char buffer[20];
     int bufsize = 511;
 
     if (TTMaskIsZero(mask))

--- a/drc/DRCsubcell.c
+++ b/drc/DRCsubcell.c
@@ -228,7 +228,7 @@ drcSubcellFunc(subUse, flags)
     CellUse *subUse;		/* Subcell instance. */
     int *flags;			/* Information to propagate up */
 {
-    Rect area, haloArea, intArea, subIntArea, locIntArea;
+    Rect area, haloArea, intArea, subIntArea;
     int i;
 
     /* A subcell has been seen, so set the "cell found" flag */
@@ -965,5 +965,8 @@ drcIncCount(def, area, rule, count)
     DRCCookie *rule;
     int *count;
 {
+    ARG_UNUSED(def);
+    ARG_UNUSED(area);
+    ARG_UNUSED(rule);
     (*count)++;
 }

--- a/drc/DRCtech.c
+++ b/drc/DRCtech.c
@@ -67,11 +67,6 @@ global int DRCRuleOptimization = TRUE;
 static int drcRulesSpecified = 0;
 static int drcRulesOptimized = 0;
 
-/* Rules with unique names are tagged with a reference number	*/
-/* for use in placing errors into the DRC error plane.		*/
-
-static int DRCtag = 0;
-
 /*
  * Forward declarations.
  */
@@ -279,7 +274,6 @@ void
 drcTechFreeStyle()
 {
     int i, j;
-    char *old;
     DRCCookie *dp;
 
     if (DRCCurStyle != NULL)
@@ -481,7 +475,6 @@ drcLoadStyle(stylename)
 void
 DRCReloadCurStyle()
 {
-    char *stylename;
     DRCKeep * style;
 
     if (DRCCurStyle == NULL) return;
@@ -1019,6 +1012,7 @@ DRCTechAddRule(sectionName, argc, argv)
     int argc;
     char *argv[];
 {
+    ARG_UNUSED(sectionName);
     int which, distance, mdist;
     const char *fmt;
     static const struct
@@ -1158,6 +1152,7 @@ drcExtend(argc, argv)
     int argc;
     char *argv[];
 {
+    ARG_UNUSED(argc);
     char *layers1 = argv[1];
     char *layers2 = argv[2];
     int distance = atoi(argv[3]);
@@ -1334,6 +1329,7 @@ drcWidth(argc, argv)
     int argc;
     char *argv[];
 {
+    ARG_UNUSED(argc);
     char *layers = argv[1];
     int distance = atoi(argv[2]);
     int why;
@@ -1445,6 +1441,7 @@ drcArea(argc, argv)
     int argc;
     char *argv[];
 {
+    ARG_UNUSED(argc);
     char *layers = argv[1];
     int distance = atoi(argv[2]);
     int	horizon = atoi(argv[3]);
@@ -1525,6 +1522,7 @@ drcOffGrid(argc, argv)
     int argc;
     char *argv[];
 {
+    ARG_UNUSED(argc);
     char *layers = argv[1];
     int pitch = atoi(argv[2]);
     int why = drcWhyCreate(argv[3]);
@@ -1722,6 +1720,7 @@ drcAngles(argc, argv)
     int argc;
     char *argv[];
 {
+    ARG_UNUSED(argc);
     char *layers = argv[1];
     char *endptr;
     long value;
@@ -1902,10 +1901,10 @@ drcSpacing3(argc, argv)
     int argc;
     char *argv[];
 {
+    ARG_UNUSED(argc);
     char *layers1 = argv[1], *layers2 = argv[2];
     char *layers3 = argv[5];
     int distance = atoi(argv[3]);
-    char *adjacency = argv[4];
     int why = drcWhyCreate(argv[6]);
     TileTypeBitMask set1, set2, set3;
     int plane;
@@ -2006,13 +2005,12 @@ drcMaskSpacing(set1, set2, pmask1, pmask2, wwidth, distance, adjacency,
 {
     TileTypeBitMask tmp1, tmp2, setR, setRreverse;
     int plane, plane2;
-    PlaneMask pset, ptest;
+    PlaneMask pset;
     DRCCookie *dp, *dpnew;
     int needReverse = (widerule) ? TRUE : FALSE;
-    TileType i, j, pref;
+    TileType i, j;
     bool needtrigger = FALSE;
     bool touchingok = TRUE;
-    bool cornerok = FALSE;
     bool surroundok = FALSE;
     unsigned short flags = 0;
 
@@ -2862,6 +2860,7 @@ drcOverhang(argc, argv)
     int argc;
     char *argv[];
 {
+    ARG_UNUSED(argc);
     char *layers2 = argv[1], *layers1 = argv[2];
     int distance = atoi(argv[3]);
     int why = drcWhyCreate(argv[4]);
@@ -2999,6 +2998,7 @@ drcRectOnly(argc, argv)
     int argc;
     char *argv[];
 {
+    ARG_UNUSED(argc);
     char *layers = argv[1];
     int why = drcWhyCreate(argv[2]);
     TileTypeBitMask set1, set2, setC;
@@ -3404,6 +3404,7 @@ drcNoOverlap(argc, argv)
     int argc;
     char *argv[];
 {
+    ARG_UNUSED(argc);
     char *layers1 = argv[1], *layers2 = argv[2];
     TileTypeBitMask set1, set2;
     TileType i, j;
@@ -3458,6 +3459,7 @@ drcExactOverlap(argc, argv)
     int argc;
     char *argv[];
 {
+    ARG_UNUSED(argc);
     char *layers = argv[1];
     TileTypeBitMask set;
 
@@ -3502,6 +3504,7 @@ drcRectangle(argc, argv)
     int argc;
     char *argv[];
 {
+    ARG_UNUSED(argc);
     char *layers = argv[1];
     int why = drcWhyCreate(argv[4]);
     TileTypeBitMask types, nottypes;
@@ -3672,6 +3675,7 @@ drcStepSize(argc, argv)
     int argc;
     char *argv[];
 {
+    ARG_UNUSED(argc);
     if (DRCCurStyle == NULL) return 0;
 
     DRCCurStyle->DRCStepSize = atoi(argv[1]);
@@ -3710,7 +3714,6 @@ drcStepSize(argc, argv)
 void
 DRCTechFinal()
 {
-    DRCStyle *ds;
 
     /* Create a "default" style if there isn't one */
 
@@ -4222,8 +4225,6 @@ void
 DRCTechScale(scalen, scaled)
     int scalen, scaled;
 {
-    DRCCookie  *dp;
-    TileType i, j;
     int scalegcf;
 
     if (DRCCurStyle == NULL) return;
@@ -4492,7 +4493,7 @@ DRCGetDirectionalLayerSurround(ttype1, ttype2)
 {
     int layerSurround = 0;
     DRCCookie *cptr, *cnext;
-    TileTypeBitMask *set, *cset;
+    TileTypeBitMask *set;
 
     for (cptr = DRCCurStyle->DRCRulesTbl[ttype1][TT_SPACE]; cptr != (DRCCookie *) NULL;
 	cptr = cptr->drcc_next)

--- a/ext2sim/ext2sim.c
+++ b/ext2sim/ext2sim.c
@@ -867,6 +867,7 @@ simParseArgs(
     char ***pargv,
     ClientData cdata)	/* unused */
 {
+    ARG_UNUSED(cdata);
     char **argv = *pargv;
     int argc = *pargc;
 
@@ -1022,6 +1023,7 @@ simdevVisit(
     Transform *trans,	/* Coordinate transform */
     ClientData cdata)	/* unused */
 {
+    ARG_UNUSED(cdata);
     const DevTerm *gate, *source, *drain, *term;
     const EFNode *subnode;
     EFNode *snode, *dnode;
@@ -1543,6 +1545,7 @@ simcapVisit(
     double cap,
     ClientData cdata)	/* unused */
 {
+    ARG_UNUSED(cdata);
     cap = cap / 1000;
     if (cap <= EFCapThreshold)
 	return 0;
@@ -1590,6 +1593,7 @@ simresistVisit(
     float res,
     ClientData cdata)	/* unused */
 {
+    ARG_UNUSED(cdata);
     fprintf(esSimF, "r ");
     EFHNOut(hierName1, esSimF);
     fprintf(esSimF, " ");
@@ -1625,6 +1629,7 @@ simnodeVisit(
     double cap,
     ClientData cdata) /* unused */
 {
+    ARG_UNUSED(cdata);
     const EFNodeName *nn;
     const HierName *hierName;
     bool isGlob;
@@ -1797,6 +1802,8 @@ simmergeVisit(
     Transform *trans,	/* Coordinate transform (not used) */
     ClientData cdata)	/* unused */
 {
+    ARG_UNUSED(trans);
+    ARG_UNUSED(cdata);
 	const DevTerm *gate, *source, *drain;
 	const EFNode *subnode, *snode, *dnode, *gnode;
 	int      pmode, l, w;

--- a/ext2spice/ext2hier.c
+++ b/ext2spice/ext2hier.c
@@ -144,6 +144,7 @@ spcHierWriteValue(
     HierContext *hc,
     Dev *dev)           /* Dev being output */
 {
+    ARG_UNUSED(hc);
     DevParam *plist;
 
     plist = efGetDeviceParams(EFDevTypes[dev->dev_type]);
@@ -686,6 +687,7 @@ spcdevHierVisit(
     float scale,	/* Scale transform for output */
     ClientData cdata)	/* unused */
 {
+    ARG_UNUSED(cdata);
     DevParam *plist, *pptr;
     DevTerm *gate, *source, *drain;
     EFNode  *subnode, *snode, *dnode, *subnodeFlat = NULL;
@@ -1295,6 +1297,7 @@ spcdevHierMergeVisit(
     float scale,	/* Scale of transform (may be non-integer) */
     ClientData cdata)	/* unused */
 {
+    ARG_UNUSED(cdata);
     DevTerm *gate, *source, *drain;
     EFNode *subnode, *snode, *dnode, *gnode;
     int pmode, l, w;
@@ -1421,6 +1424,7 @@ spccapHierVisit(
     double cap,
     ClientData cdata)	/* unused */
 {
+    ARG_UNUSED(cdata);
     cap = cap / 1000;
     if (fabs(cap) <= EFCapThreshold)
 	return 0;
@@ -1469,6 +1473,7 @@ spcresistHierVisit(
     float res,
     ClientData cdata)	// UNUSED
 {
+    ARG_UNUSED(cdata);
     HashEntry *he;
     EFNodeName *nn;
 
@@ -1533,6 +1538,8 @@ spcsubHierVisit(
     double cap,		// Unused
     char **resstrptr)
 {
+    ARG_UNUSED(res);
+    ARG_UNUSED(cap);
     HierName *hierName;
     const char *nsn;
 
@@ -1570,6 +1577,7 @@ spcnodeHierVisit(
     int res,
     double cap)
 {
+    ARG_UNUSED(res);
     HierName *hierName;
     bool isConnected = FALSE;
     const char *fmt, *nsn;
@@ -1649,6 +1657,7 @@ nodeSpiceHierName(
     HierContext *hc,
     const HierName *hname)
 {
+    ARG_UNUSED(hc);
     EFNodeName *nn;
     HashEntry *he;
     EFNode *node;
@@ -1874,6 +1883,7 @@ devDistJunctHierVisit(
     float scale,		/* Scale tranform of output */
     ClientData cdata)		/* unused */
 {
+    ARG_UNUSED(cdata);
     EFNode  *n;
     int i, l, w;
 
@@ -1925,6 +1935,7 @@ esMakePorts(
     HierContext *hc,
     ClientData cdata)
 {
+    ARG_UNUSED(cdata);
     Connection *conn;
     Def *def = hc->hc_use->use_def, *portdef, *updef;
     Use *use;

--- a/ext2spice/ext2spice.c
+++ b/ext2spice/ext2spice.c
@@ -1781,6 +1781,8 @@ subcktUndef(
     HierName *hierName,
     bool is_top)	/* TRUE if this is the top-level cell */
 {
+    ARG_UNUSED(hierName);
+    ARG_UNUSED(is_top);
     Def *def = use->use_def;
 
     def->def_flags &= ~(DEF_SUBCIRCUIT);
@@ -1831,6 +1833,7 @@ topVisit(
     Def *def,
     bool doStub)
 {
+    ARG_UNUSED(doStub);
     EFNode *snode;
     EFNodeName *sname, *nodeName;
     HashSearch hs;
@@ -2046,6 +2049,7 @@ spcWriteValue(
     Dev *dev,		/* Dev being output */
     HierName *hierName)	/* Hierarchical path down to this dev */
 {
+    ARG_UNUSED(hierName);
     DevParam *plist;
 
     plist = efGetDeviceParams(EFDevTypes[dev->dev_type]);
@@ -2643,6 +2647,8 @@ spcdevVisit(
     Transform *trans,	/* (unused) */
     ClientData cdata)	/* (unused) */
 {
+    ARG_UNUSED(trans);
+    ARG_UNUSED(cdata);
     DevParam *plist, *pptr;
     DevTerm *gate, *source, *drain;
     EFNode  *subnode, *snode, *dnode, *subnodeFlat = NULL;
@@ -3804,6 +3810,7 @@ spccapVisit(
     double cap,
     ClientData cdata)	/* unused */
 {
+    ARG_UNUSED(cdata);
     cap = cap / 1000;
     if (cap <= EFCapThreshold)
 	return 0;
@@ -3850,6 +3857,7 @@ spcresistVisit(
     float res,
     ClientData cdata)	/* unused */
 {
+    ARG_UNUSED(cdata);
     HashEntry *he;
     EFNodeName *nn;
 
@@ -3914,6 +3922,8 @@ spcsubVisit(
     double cap,		// Unused
     ClientData cdata)
 {
+    ARG_UNUSED(res);
+    ARG_UNUSED(cap);
     char **resstr = (char **)CD2PTR(cdata);
     HierName *hierName;
     const char *nsn;
@@ -3953,6 +3963,8 @@ spcnodeVisit(
     double cap,
     ClientData cdata) /* unused */
 {
+    ARG_UNUSED(res);
+    ARG_UNUSED(cdata);
     HierName *hierName;
     bool isConnected = FALSE;
     const char *fmt;
@@ -4018,6 +4030,9 @@ nodeVisitDebug(
     double cap,
     ClientData cdata)	/* unused */
 {
+    ARG_UNUSED(res);
+    ARG_UNUSED(cap);
+    ARG_UNUSED(cdata);
     HierName *hierName;
     const char *nsn;
 
@@ -4154,7 +4169,7 @@ efHNSprintfPrefix(
     HierName *hierName,
     char *str)
 {
-    char *cp, c;
+    char *cp;
     bool convertEqual = (EFOutputFlags & EF_CONVERTEQUAL) ? TRUE : FALSE;
     bool convertComma = (EFOutputFlags & EF_CONVERTCOMMA) ? TRUE : FALSE;
     bool convertBrackets = (EFOutputFlags & EF_CONVERTBRACKETS) ? TRUE : FALSE;
@@ -4740,6 +4755,8 @@ devDistJunctVisit(
     Transform *trans,		/* (unused) */
     ClientData cdata)		/* (unused) */
 {
+    ARG_UNUSED(trans);
+    ARG_UNUSED(cdata);
     EFNode  *n;
     int      i;
     int l, w;

--- a/extcheck/extcheck.c
+++ b/extcheck/extcheck.c
@@ -22,10 +22,6 @@
  *     *********************************************************************
  */
 
-#ifndef lint
-static const char rcsid[] = "$Header: /usr/cvsroot/magic-8.0/extcheck/extcheck.c,v 1.1.1.1 2008/02/03 20:43:50 tim Exp $";
-#endif  /* not lint */
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <ctype.h>
@@ -138,6 +134,7 @@ nodeVisit(
     double cap,
     ClientData cdata) /* unused */
 {
+    ARG_UNUSED(cdata);
     cap = (cap + 500) / 1000;
     res = (res + 500) / 1000;
 
@@ -159,6 +156,11 @@ devVisit(
     Transform *trans,
     ClientData cdata) /* UNUSED */
 {
+    ARG_UNUSED(dev);
+    ARG_UNUSED(hc);
+    ARG_UNUSED(scale);
+    ARG_UNUSED(trans);
+    ARG_UNUSED(cdata);
     ecNumDevs++;
     return 0;
 }
@@ -172,6 +174,9 @@ capVisit(
     double cap,
     ClientData cdata)	/* UNUSED */
 {
+    ARG_UNUSED(hn1);
+    ARG_UNUSED(hn2);
+    ARG_UNUSED(cdata);
     ecNumCaps++;
     if ((cap / 1000.) > (double) EFCapThreshold) ecNumThreshCaps++;
     return 0;
@@ -186,6 +191,9 @@ resistVisit(
     float res,
     ClientData cdata)   /* UNUSED */
 {
+    ARG_UNUSED(hn1);
+    ARG_UNUSED(hn2);
+    ARG_UNUSED(cdata);
     ecNumResists++;
     if ((res / 1000.) > EFResistThreshold) ecNumThreshResists++;
     return 0;

--- a/extflat/EFantenna.c
+++ b/extflat/EFantenna.c
@@ -129,18 +129,13 @@ CmdAntennaCheck(w, cmd)
 {
     int i, flatFlags;
     char *inName;
-    FILE *f;
-    TileType t;
 
     int option = ANTENNACHECK_RUN;
-    int value;
     int argc = cmd->tx_argc;
     char **argv = cmd->tx_argv;
     const char * const *msg;
     bool err_result;
 
-    short sd_rclass;
-    short sub_rclass;
     char *devname;
     int idx;
 
@@ -295,7 +290,7 @@ antennacheckArgs(pargc, pargv)
     int *pargc;
     char ***pargv;
 {
-    char **argv = *pargv, *cp;
+    char **argv = *pargv;
     int argc = *pargc;
 
     switch (argv[0][1])
@@ -364,15 +359,16 @@ antennacheckVisit(
     Transform *trans,	/* Coordinate transform */
     ClientData cdata)	/* ClientData is edit cell use */
 {
+    ARG_UNUSED(scale);
     CellUse *editUse = (CellUse *) CD2PTR(cdata);
     DevTerm *gate;
     TileType t, conType;
-    int pos, pNum, pNum2, pmax, p, i, j, total;
+    int pos, pNum, pNum2, pmax, p, i, j;
     dlong gatearea, diffarea;
     double anttotal, conttotal;
     float saveRatio, ratioTotal;
     dlong *antennaarea;
-    Rect r, gaterect;
+    Rect r;
     EFNode *gnode;
     SearchContext scx;
     TileTypeBitMask gatemask, saveConMask;

--- a/extflat/EFbuild.c
+++ b/extflat/EFbuild.c
@@ -167,7 +167,7 @@ efBuildNode(def, isSubsnode, isDevSubsnode, isExtNode, nodeName, nodeCap,
     if (newname && (def->def_kills != NULL))
     {
 	HashEntry *hek;
-	EFNodeName *nn, *knn, *nodeAlias, *lastAlias;
+	EFNodeName *knn, *nodeAlias, *lastAlias;
 
 	/* Watch for nodes that are aliases of the node that was most
 	 * recently killed.  This can occur in .res.ext files where an
@@ -644,8 +644,6 @@ efBuildEquiv(def, nodeName1, nodeName2, resist, isspice)
 	    return;		/* Repeated "equiv" statement */
 	if (nn1->efnn_node != nn2->efnn_node)
 	{
-	    struct efnode *node1 = nn1->efnn_node;
-	    struct efnode *node2 = nn2->efnn_node;
     	    HashSearch hs;
 	    HashEntry *he;
 
@@ -854,12 +852,11 @@ efBuildDevice(
     DevParam *newparm, *devp, *sparm;
     TileType ttype;
     int dev_type;
-    char ptype, *pptr, **av;
+    char *pptr, **av;
     char devhash[64];
     int argstart = 1;	/* start of terminal list in argv[] */
     bool hasModel = strcmp(type, "None") ? TRUE : FALSE;
 
-    int area, perim;	/* Total area, perimeter of primary type (i.e., channel) */
 
     newdev = (Dev *)NULL;
     devtmp.dev_subsnode = NULL;
@@ -2110,8 +2107,6 @@ efFreeUseTable(table)
     HashSearch hs;
     HashEntry *he;
     Use *use;
-    HierName *hn;
-    EFNodeName *nn;
 
     HashStartSearch(&hs);
     while ((he = HashNext(table, &hs)))

--- a/extflat/EFdef.c
+++ b/extflat/EFdef.c
@@ -103,7 +103,6 @@ EFDone(func)
     HashEntry *he;
     Kill *kill;
     Def *def;
-    Use *use;
     int n;
 
     HashStartSearch(&hs);

--- a/extflat/EFflat.c
+++ b/extflat/EFflat.c
@@ -182,8 +182,7 @@ EFFlatBuildOneLevel(def, flags)
     Def *def;		/* root def being flattened */
     int flags;
 {
-    int usecount, savecount;
-    Use *use;
+    int usecount;
     int efFlatNodesDeviceless();	/* Forward declaration */
     int efFlatCapsDeviceless();		/* Forward declaration */
     int flatnodeflags;
@@ -402,7 +401,6 @@ efFlatNodesDeviceless(hc, cdata)
 {
     int *usecount = (int *)cdata;
     int newcount;
-    Use *use;
 
     newcount = HashGetNumEntries(&hc->hc_use->use_def->def_uses);
 
@@ -965,7 +963,6 @@ efFlatCapsDeviceless(hc)
 {
     Connection *conn;
     int newcount;
-    Use *use;
 
     newcount = HashGetNumEntries(&hc->hc_use->use_def->def_uses);
 

--- a/extflat/EFhier.c
+++ b/extflat/EFhier.c
@@ -325,6 +325,7 @@ EFHierVisitSubcircuits(hc, subProc, cdata)
     int (*subProc)();
     ClientData cdata;	/* unused */
 {
+    ARG_UNUSED(cdata);
     CallArg ca;
     int efHierVisitSubcircuits();   /* Forward declaration */
 
@@ -389,11 +390,12 @@ efHierDevKilled(hc, dev, prefix)
     Dev *dev;
     HierName *prefix;
 {
+    ARG_UNUSED(hc);
+    ARG_UNUSED(prefix);
     HierName *suffix;
     HashEntry *he;
     EFNodeName *nn;
     int n;
-    Def *def = hc->hc_use->use_def;
 
     for (n = 0; n < dev->dev_nterm; n++)
     {
@@ -622,8 +624,6 @@ efHierVisitResists(
 {
     Def *def = hc->hc_use->use_def;
     Connection *res;
-    Transform t;
-    int scale;
 
     /* Visit all resistors */
     for (res = def->def_resistors; res; res = res->conn_next)
@@ -735,7 +735,6 @@ EFHierVisitNodes(hc, nodeProc, cdata)
     int (*nodeProc)();
     ClientData cdata;
 {
-    Def *def = hc->hc_use->use_def;
     EFCapValue cap;
     int res;
     EFNode *snode;

--- a/extflat/EFname.c
+++ b/extflat/EFname.c
@@ -221,11 +221,9 @@ EFStrToHN(prefix, suffixStr)
     char *suffixStr;	/* Leaf part of name (may have /'s) */
 {
     char *cp;
-    HashEntry *he;
     char *slashPtr;
     HierName *hierName;
     unsigned size;
-    int len;
 
     /* Skip to the end of the relative name */
     slashPtr = NULL;
@@ -360,7 +358,7 @@ EFHNLook(prefix, suffixStr, errorStr)
     char *suffixStr;	/* Part of name on leaf side */
     char *errorStr;	/* Explanatory string for errors */
 {
-    HierName *hierName, *hn;
+    HierName *hierName;
     bool dontFree = FALSE;
     HashEntry *he;
 

--- a/extflat/EFread.c
+++ b/extflat/EFread.c
@@ -191,7 +191,6 @@ efReadDef(
     int argc, ac, n;
     CellDef *dbdef;
     EFCapValue cap;
-    EFNode *node;
     char *line = NULL, *argv[128], *name, *attrs;
     int size = 0;
     int rscale = 1;	/* Multiply resistances by this */
@@ -748,7 +747,6 @@ start:
 	if (size <= 1)
 	{
 	    char *newline;
-	    int i;
 
 	    *sizeptr += 1024;	/* Increase buffer size in 1024 byte increments */
 	    newline = (char *)mallocMagic(*sizeptr);

--- a/extract/ExtBasic.c
+++ b/extract/ExtBasic.c
@@ -17,9 +17,6 @@
  *     *********************************************************************
  */
 
-#ifndef lint
-static char sccsid[] = "@(#)ExtBasic.c	4.13 MAGIC (Berkeley) 12/5/85";
-#endif  /* not lint */
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -170,6 +167,7 @@ extFoundFunc(tile, cxp)
     Tile *tile;
     TreeContext *cxp;
 {
+    ARG_UNUSED(tile);
     CellDef *def = (CellDef *)cxp->tc_filter->tf_arg;
     return (def == cxp->tc_scx->scx_use->cu_def) ? 0 : 1;
 }
@@ -855,7 +853,6 @@ char *
 extSubsName(node)
     LabRegion *node;
 {
-    char *subsName;
 
     /* If the techfile specifies a global name for the substrate, use	*/
     /* that in preference to the default "p_x_y#" name.	 Use this name	*/
@@ -2117,6 +2114,7 @@ extSDTileFunc(tile, pNum)
     Tile *tile;
     int pNum;
 {
+    ARG_UNUSED(pNum);
     LinkedTile *newdevtile;
 
     newdevtile = (LinkedTile *)mallocMagic(sizeof(LinkedTile));
@@ -2198,7 +2196,7 @@ extOutputDevices(def, transList, outFile)
     LabelList *ll;
     TileType t;
     char *subsName;
-    int nsd, length, width, n, i, ntiles, corners, tn, rc, termcount;
+    int nsd, length, width, n, i, ntiles, termcount;
     double dres, dcap;
     char mesg[256];
     bool isAnnular, hasModel, sd_is_tied;
@@ -3116,6 +3114,7 @@ extTransFindSubs(tile, t, mask, def, sn, layerptr)
     NodeRegion **sn;
     TileType *layerptr;
 {
+    ARG_UNUSED(t);
     Rect tileArea, tileAreaPlus;
     int pNum;
     int extTransFindSubsFunc1();	/* Forward declaration */
@@ -3195,7 +3194,6 @@ extTransFindId(tile, mask, def, idtypeptr)
     CellDef *def;
     TileType *idtypeptr;
 {
-    TileType type;
     Rect tileArea;
     int pNum;
     int extTransFindIdFunc1();	/* Forward declaration */
@@ -3337,9 +3335,9 @@ extTransTileFunc(tile, pNum, arg)
     int pNum;
     FindRegion *arg;
 {
-    TileTypeBitMask mask, cmask, *smask;
+    TileTypeBitMask mask, cmask;
     TileType loctype, idlayer, sublayer;
-    int perim, result, i;
+    int perim;
     bool allow_globsubsnode;
     ExtDevice *devptr, *deventry, *devtest;
     NodeRegion *region;
@@ -3597,6 +3595,7 @@ extTermAPFunc(tile, pNum, eapd)
     int   pNum;		/* Plane of tile (unused, set to -1) */
     ExtAreaPerimData *eapd;	/* Area and perimeter totals for terminal */
 {
+    ARG_UNUSED(pNum);
     TileType type;
     Tile *tp;
     Rect r;
@@ -3694,7 +3693,7 @@ extTransPerimFunc(bp)
     Tile *tile;
     NodeRegion *diffNode = (NodeRegion *) extGetRegion(bp->b_outside);
     ExtDevice *devptr, *deventry;
-    int i, area, perim, len = BoundaryLength(bp);
+    int i, len = BoundaryLength(bp);
     int thisterm;
     LabelList *ll;
     Label *lab;
@@ -4867,6 +4866,7 @@ int
 extSubsFunc3(tile)
     Tile *tile;
 {
+    ARG_UNUSED(tile);
     /* Stops the search because something that was not space was found */
     return 1;
 }

--- a/extract/ExtCouple.c
+++ b/extract/ExtCouple.c
@@ -494,11 +494,6 @@ extAddOverlap(tbelow, ecpls)
 	int ob = ExtCurStyle->exts_planeOrder[ecpls->plane_checked];
 	if (oa > ob)
 	{
-	    Tile *tp;
-	    TileType t, tres;
-	    TileTypeBitMask *mask;
-	    int len;
-	    CapValue cp;
 	    /*
 	     * Subtract the substrate capacitance from tabove's region due to
 	     * the area of the overlap, minus any shielded area.  The shielded
@@ -809,8 +804,6 @@ extAddCouple(bp, ecs)
     extCapStruct *ecs;
 {
     TileType tin = TiGetType(bp->b_inside), tout = TiGetType(bp->b_outside);
-    int pNum;
-    PlaneMask pMask;
     Boundary bpCopy;
     Rect r, ovr;
     extSidewallStruct esws;
@@ -928,7 +921,7 @@ extRemoveSubcap(bp, clip, esws)
     extSidewallStruct *esws;	/* Overlapping edge and plane information */
 {
     int dnear, length;
-    double snear, cfrac;
+    double snear;
     NodeRegion *rbp;
     TileType ta, tb;
     float mult;
@@ -1000,6 +993,7 @@ extFindOverlap(tp, area, esws)
     Rect *area;			/* Area to check for coupling */
     extSidewallStruct *esws;	/* Overlapping edge and plane information */
 {
+    ARG_UNUSED(tp);
     PlaneMask pMask;
     int pNum;
     Rect *rsave;
@@ -1063,12 +1057,11 @@ extSideOverlapHalo(tp, esws)
     NodeRegion *rtp = (NodeRegion *) extGetRegion(tp);
     NodeRegion *rbp = (NodeRegion *) extGetRegion(bp->b_inside);
     TileType ta, tb;
-    Rect tpr;
     struct sideoverlap sov;
     HashEntry *he;
     EdgeCap *e;
     int length;
-    double cfrac, sfrac, afrac, mult, efflength;
+    double cfrac, sfrac, mult, efflength;
     CapValue cap, subcap;
     CoupleKey ck;
     int dfar, dnear;
@@ -1290,7 +1283,6 @@ extSideOverlap(tp, esws)
     NodeRegion *rtp = (NodeRegion *) extGetRegion(tp);
     NodeRegion *rbp = (NodeRegion *) extGetRegion(bp->b_inside);
     TileType ta, tb;
-    Rect tpr;
     struct overlap ov;
     HashEntry *he;
     EdgeCap *e;

--- a/extract/ExtHard.c
+++ b/extract/ExtHard.c
@@ -426,7 +426,6 @@ extHardGenerateLabel(scx, reg, arg)
     char gen[100];
     int len;
     Rect r;
-    Point p;
 
     extMakeNodeNumPrint(gen, (LabRegion *)reg);
 

--- a/extract/ExtHier.c
+++ b/extract/ExtHier.c
@@ -72,6 +72,7 @@ int
 extHierSubShieldFunc(tile)
     Tile *tile;
 {
+    ARG_UNUSED(tile);
     return 1;
 }
 
@@ -333,9 +334,8 @@ extHierConnectFunc1(oneTile, ha)
     Rect r;
     TileTypeBitMask mask, *connected;
     TileType rtype;
-    Label *lab, *newlab;
+    Label *lab;
     int i;
-    unsigned n;
 
     /*
      * Find all tiles that connect to 'srcTile', but in the
@@ -950,6 +950,7 @@ extHierLabFirst(tile, arg)
     Tile *tile;
     FindRegion *arg;
 {
+    ARG_UNUSED(tile);
     LabRegion *new;
 
     new = (LabRegion *) mallocMagic((unsigned) (sizeof (LabRegion)));

--- a/extract/ExtMain.c
+++ b/extract/ExtMain.c
@@ -189,6 +189,7 @@ extIsUsedFunc(use, clientData)
     CellUse *use;
     ClientData clientData;	/* unused */
 {
+    ARG_UNUSED(clientData);
     CellDef *def = use->cu_def;
 
     /* If any cell is not marked CDDONTUSE then return 1 and stop the search. */
@@ -213,6 +214,8 @@ extEnumFunc(tile, plane)
     Tile *tile;
     int *plane;
 {
+    ARG_UNUSED(tile);
+    ARG_UNUSED(plane);
     return 1;
 }
 

--- a/extract/ExtRegion.c
+++ b/extract/ExtRegion.c
@@ -214,7 +214,6 @@ ExtLabelRegions(def, connTo, nodeList, clipArea)
     int quad, pNum, n, nclasses;
     Point p;
     bool found;
-    TileType extSubType = 0;
     LabelList *retList = NULL;
 
     for (lab = def->cd_labels; lab; lab = lab->lab_next)

--- a/extract/ExtSubtree.c
+++ b/extract/ExtSubtree.c
@@ -117,6 +117,7 @@ extClearUseFlags(use, clientData)
     CellUse *use;
     ClientData clientData;
 {
+    ARG_UNUSED(clientData);
     use->cu_flags &= ~CU_SUB_EXTRACTED;
     return 0;
 }
@@ -436,7 +437,6 @@ extSubtreeInteraction(ha)
 {
     CellDef *oneDef, *cumDef = ha->ha_cumFlat.et_use->cu_def;
     ExtTree *oneFlat, *nextFlat;
-    NodeRegion *reg;
     SearchContext scx;
 
     scx.scx_trans = GeoIdentityTransform;
@@ -717,6 +717,8 @@ extFoundProc(tile, clientData)
     Tile *tile;
     ClientData clientData;
 {
+    ARG_UNUSED(tile);
+    ARG_UNUSED(clientData);
     return 1;
 }
 
@@ -1056,7 +1058,6 @@ extSubtreeTileToNode(tp, pNum, et, ha, doHard)
 	"Cannot find the name of this node (probable extractor error)";
     CellDef *parentDef = ha->ha_parentUse->cu_def;
     LabRegion *reg;
-    Label *lab;
     Rect r;
     TileType ttype;
 

--- a/extract/ExtTech.c
+++ b/extract/ExtTech.c
@@ -18,9 +18,6 @@
  *     *********************************************************************
  */
 
-#ifndef lint
-static char sccsid[] = "@(#)ExtTech.c	4.8 MAGIC (Berkeley) 10/26/85";
-#endif  /* not lint */
 
 #include <stdio.h>
 #include <stdlib.h>		/* for strtod() */
@@ -543,7 +540,6 @@ int
 ExtGetDiffTypesMask(mask)
     TileTypeBitMask *mask;
 {
-    TileType ttype;
 
     if (ExtCurStyle == NULL) return 1;
 
@@ -808,7 +804,6 @@ ExtStyle *
 extTechStyleAlloc()
 {
     ExtStyle *style;
-    TileType r;
 
     style = (ExtStyle *) mallocMagic(sizeof (ExtStyle));
     return style;
@@ -1112,7 +1107,6 @@ void
 ExtTechInit()
 {
     ExtKeep *style;
-    int r;
 
     /* Delete everything in ExtCurStyle */
 
@@ -1177,7 +1171,6 @@ ExtTechSimpleAreaCap(argc, argv)
     TileType s, t;
     TileTypeBitMask types, subtypes, shields;
     CapValue capVal;
-    float multVal;
     int plane1, plane2, plane3, pnum1, pnum2, pnum3;
     PlaneMask pshield;
 
@@ -1969,7 +1962,8 @@ ExtTechLine(sectionName, argc, argv)
     int argc;
     char *argv[];
 {
-    int n, l, i, j, size, val, p1, p2, p3, nterm, iterm, class;
+    ARG_UNUSED(sectionName);
+    int n, l, i, j, val, p1, p2, p3, nterm, iterm, class;
     PlaneMask pshield, pov;
     CapValue capVal, gscap, gccap;
     ResValue resVal;
@@ -1983,7 +1977,6 @@ ExtTechLine(sectionName, argc, argv)
     ExtKeep *es, *newStyle;
     ParamList *subcktParams, *newParam;
     ExtDevice *devptr;
-    int refcnt;
     int offset;
     double dhalo;
     double doffset;
@@ -3479,7 +3472,6 @@ diffplane:
 void
 ExtTechFinal()
 {
-    ExtStyle *es;
     TileType s, t;
 
     /* Create a "default" style if there isn't one */

--- a/extract/ExtTest.c
+++ b/extract/ExtTest.c
@@ -118,7 +118,6 @@ ExtractTest(w, cmd)
     int n, halo, bloat;
     CellUse *selectedCell;
     Rect editArea;
-    char *addr, *name;
     typedef enum {  CLRDEBUG, CLRLENGTH, DRIVER, DUMP, INTERACTIONS,
 		    INTERCOUNT, EXTPARENTS, RECEIVER, SETDEBUG, SHOWDEBUG,
 		    SHOWPARENTS, SHOWTECH, STATS, STEP, TIME } cmdType;

--- a/extract/ExtTimes.c
+++ b/extract/ExtTimes.c
@@ -400,6 +400,7 @@ extCountTiles(tile, cs)
     Tile *tile;			/* UNUSED */
     struct cellStats *cs;
 {
+    ARG_UNUSED(tile);
     cs->cs_rects++;
     return (0);
 }
@@ -783,7 +784,8 @@ extTimeProc(proc, def, tv)
     CellDef *def;
     struct timeval *tv;
 {
-    int secs, usecs, i;
+    ARG_UNUSED(proc);
+    ARG_UNUSED(def);
 
 #if defined(SYSV) || defined(EMSCRIPTEN)
     tv->tv_sec = 0;

--- a/garouter/gaMaze.c
+++ b/garouter/gaMaze.c
@@ -201,6 +201,7 @@ gaMazeRoute(
 				 * route is possible.
 				 */
 {
+    ARG_UNUSED(side);
     TileTypeBitMask pinLayerMask = *pinLayerMaskp; // TTMaskCopy(&pinLayerMask, pinLayerMaskp);
     Rect routeBounds;
     bool done = FALSE;

--- a/garouter/gaSimple.c
+++ b/garouter/gaSimple.c
@@ -576,6 +576,8 @@ gaIsClearFunc(tile, cxp)
     Tile *tile;
     TreeContext *cxp;
 {
+    ARG_UNUSED(tile);
+    ARG_UNUSED(cxp);
     return 1;
 }
 

--- a/garouter/gaTest.c
+++ b/garouter/gaTest.c
@@ -91,6 +91,7 @@ GATest(w, cmd)
     MagWindow *w;
     TxCommand *cmd;
 {
+    ARG_UNUSED(w);
     int n;
     typedef enum { CLRDEBUG, SETDEBUG, SHOWDEBUG} cmdType;
     static const struct

--- a/gcr/gcrDebug.c
+++ b/gcr/gcrDebug.c
@@ -73,9 +73,7 @@ GCRRouteFromFile(fname)
     static Point initOrigin = { 0, 0 };
     struct tms tbuf1, tbuf2;
     GCRChannel *ch;
-    Transform trans;
     FILE *fp;
-    Rect box;
 
     fp = fopen(fname, "r");
     if (fp == NULL)

--- a/graphics/W3Dmain.c
+++ b/graphics/W3Dmain.c
@@ -645,8 +645,8 @@ w3dHelp(w, cmd)
     MagWindow *w;
     TxCommand *cmd;
 {
+    ARG_UNUSED(w);
     const char * const *msg;
-    W3DclientRec *crec = (W3DclientRec *) w->w_clientData;
 
     if (cmd->tx_argc == 1)
     {
@@ -676,9 +676,6 @@ w3dCutBox(w, cmd)
     MagWindow *w;
     TxCommand *cmd;
 {
-    bool hide = FALSE;
-    int lidx = 1, num_layers;
-    TileTypeBitMask mask;
     W3DclientRec *crec = (W3DclientRec *) w->w_clientData;
 
     if (cmd->tx_argc == 1 || cmd->tx_argc == 2 || cmd->tx_argc == 5)
@@ -759,7 +756,7 @@ w3dSeeLayers(w, cmd)
     TxCommand *cmd;
 {
     bool hide = FALSE;
-    int lidx = 1, num_layers;
+    int lidx = 1;
     TileTypeBitMask mask;
     W3DclientRec *crec = (W3DclientRec *) w->w_clientData;
 
@@ -811,7 +808,6 @@ w3dClose(w, cmd)
     MagWindow *w;
     TxCommand *cmd;
 {
-    W3DclientRec *crec = (W3DclientRec *) w->w_clientData;
 
     if (cmd->tx_argc == 1)
 	(void) WindDelete(w);
@@ -988,7 +984,6 @@ w3dRefresh(w, cmd)
     MagWindow *w;
     TxCommand *cmd;
 {
-    W3DclientRec *crec = (W3DclientRec *) w->w_clientData;
 
     if (cmd->tx_argc == 1)
 	w3drefreshFunc(w);
@@ -1236,7 +1231,6 @@ w3dRenderValues(w, cmd)
 {
     int lidx;
     CIFLayer *layer;
-    W3DclientRec *crec = (W3DclientRec *) w->w_clientData;
 
     if (cmd->tx_argc > 1)
     {
@@ -1638,6 +1632,7 @@ W3Dredisplay(w, rootArea, clipArea)
     Rect *rootArea;	/* Ignore this---area defined by window with box */
     Rect *clipArea;	/* Ignore this, too */
 {
+    ARG_UNUSED(clipArea);
     W3DclientRec *crec;
     CellDef *cellDef;
     SearchContext scontext;
@@ -1715,12 +1710,13 @@ W3DCIFredisplay(w, rootArea, clipArea)
     Rect *rootArea;	/* Ignore this---area defined by window with box */
     Rect *clipArea;	/* Ignore this, too */
 {
+    ARG_UNUSED(rootArea);
+    ARG_UNUSED(clipArea);
     W3DclientRec *crec;
     SearchContext scx;
     CellDef *cellDef;
     Rect clipRect;
     int i;
-    TileTypeBitMask *mask;
 
     w3dLock(w);
 
@@ -1791,7 +1787,6 @@ W3Dcommand(w, cmd)
     MagWindow *w;
     TxCommand *cmd;
 {
-    int cmdNum;
 
     switch (cmd->tx_button)
     {

--- a/graphics/grClip.c
+++ b/graphics/grClip.c
@@ -577,7 +577,6 @@ GrBoxOutline(tile, tilesegs)
 {
     Rect rect;
     TileType ttype;
-    LinkedRect *curseg;
     Tile *tpleft, *tpright, *tptop, *tpbot;
     int edgeTop, edgeBot, edgeRight, edgeLeft;
     int isolate = 0;
@@ -776,7 +775,7 @@ void
 GrBox(MagWindow *mw, Transform *trans, Tile *tile)
 {
     Rect r, r2, clipr;
-    bool needClip, needObscure, simpleBox;
+    bool needClip, needObscure;
     LinkedRect *ob, *tilesegs, *segptr;
     Point polyp[5];
     int np;

--- a/graphics/grDStyle.c
+++ b/graphics/grDStyle.c
@@ -205,7 +205,7 @@ styleBuildDisplayStyle(line, version)
     int ord = 1, mask, color, outline, nfill, stipple;
     char shortName, longName[52];
     char fill[42], ordstr[12], colorName[30];
-    dstylelink *newstyle, *sstyle;
+    dstylelink *newstyle;
 
     char v6scanline[] = "%10s %o %29s %o %40s %d %c %50s";
     char v7scanline[] = "%10s %i %29s %i %40s %d %c %50s";
@@ -482,7 +482,6 @@ char *libPath;
 		}
 		else if (strcmp(sectionName, "display_styles") == 0)
 		{
-		    int locbitplanes;
 
 		    if ((processed & (LAYOUT_STYLES | PALE_STYLES)) != 0)
 		    {

--- a/graphics/grNull.c
+++ b/graphics/grNull.c
@@ -152,6 +152,7 @@ NullTextSize(text, size, r)
     int size;
     Rect *r;
 {
+    ARG_UNUSED(size);
     ASSERT(r != NULL, "nullTextSize");
     r->r_xbot = 0;
     r->r_xtop = strlen(text);
@@ -182,6 +183,8 @@ nullStdin(
     int fd,
     ClientData cdata) /* notused */
 {
+    ARG_UNUSED(fd);
+    ARG_UNUSED(cdata);
     int ch;
     TxInputEvent *event;
 
@@ -245,6 +248,9 @@ nullSetDisplay(dispType, outFileName, mouseFileName)
     char *outFileName;
     char *mouseFileName;
 {
+    ARG_UNUSED(dispType);
+    ARG_UNUSED(outFileName);
+    ARG_UNUSED(mouseFileName);
     TxPrintf("Using NULL graphics device.\n");
 
     TxAdd1InputDevice(fileno(stdin), nullStdin, (ClientData) NULL);

--- a/graphics/grTCairo1.c
+++ b/graphics/grTCairo1.c
@@ -150,6 +150,7 @@ void
 grtcairoSetLineStyle (style)
 int style;			/* New stipple pattern for lines. */
 {
+    ARG_UNUSED(style);
 	// unimplemented for cairo
 }
 
@@ -259,7 +260,6 @@ int stipple;			/* The stipple number to be used. */
 bool
 GrTCairoInit ()
 {
-	bool rstatus;
 
 	if (Tk_InitStubs(magicinterp, Tclmagic_InitStubsVersion, 0) == NULL) return FALSE;
 
@@ -414,6 +414,8 @@ void
 tcairoSetProjection(llx, lly, width, height)
 int llx, lly, width, height;
 {
+    ARG_UNUSED(llx);
+    ARG_UNUSED(lly);
     TCairoData *tcairodata = (TCairoData *)tcairoCurrent.mw->w_grdata2;
     bool offscreen = FALSE;
 
@@ -486,10 +488,8 @@ TCairoEventProc(clientData, xevent)
 ClientData clientData;
 XEvent *xevent;
 {
-	TxInputEvent *event;
 	HashEntry	*entry;
 	Tk_Window tkwind = (Tk_Window)clientData;
-	Window wind;
 	MagWindow *mw;
 	unsigned char LocRedirect = TxInputRedirect;
 
@@ -548,7 +548,7 @@ XEvent *xevent;
 	{
 		int keywstate, keymod, idx, idxmax;
 		char inChar[10];
-		Tcl_Channel outChannel = Tcl_GetStdChannel(TCL_STDOUT);
+		Tcl_GetStdChannel(TCL_STDOUT);
 
 		nbytes = XLookupString(KeyPressedEvent, inChar, sizeof(inChar),
 		                       &keysym, NULL);
@@ -829,7 +829,7 @@ keys_and_buttons:
 		XConfigureEvent *ConfigureEvent = (XConfigureEvent*) xevent;
 		Rect	screenRect;
 		int width, height;
-		bool result, need_resize;
+		bool need_resize;
 
 		width = ConfigureEvent->width;
 		height = ConfigureEvent->height;
@@ -981,9 +981,9 @@ char *dispType;
 char *outFileName;
 char *mouseFileName;
 {
-	char *planecount;
-	char *fullname;
-	FILE* f;
+    ARG_UNUSED(dispType);
+    ARG_UNUSED(outFileName);
+    ARG_UNUSED(mouseFileName);
 	bool execFailed = FALSE;
 	int x, y, width, height;
 
@@ -1097,7 +1097,6 @@ char *name;
 	int		y      = grTransYs(w->w_frameArea.r_ytop);
 	int		width  = w->w_frameArea.r_xtop - w->w_frameArea.r_xbot;
 	int		height = w->w_frameArea.r_ytop - w->w_frameArea.r_ybot;
-	unsigned long        attribmask = CWBackPixel | CWBorderPixel | CWColormap;
 	XSetWindowAttributes grAttributes;
 
 	WindSeparateRedisplay(w);
@@ -1158,7 +1157,6 @@ char *name;
 
 	if (tkwind != 0)
 	{
-		bool result;
 		TCairoData *tcairodata;
 
 		GrTCairoFlush();
@@ -1384,7 +1382,6 @@ GrTCairoLock(w, flag)
 MagWindow *w;
 bool flag;
 {
-	Window wind;
 
 	grSimpleLock(w, flag);
 	if ( w != GR_LOCK_SCREEN )

--- a/graphics/grTCairo3.c
+++ b/graphics/grTCairo3.c
@@ -63,6 +63,7 @@ Rect *prect;            /* A rectangle that forms the template
 int outline;        /* the outline style */
 Rect *clip;         /* a clipping rectangle */
 {
+    ARG_UNUSED(outline);
 	int xsize, ysize;
 	int x, y;
 	int xstart, ystart;
@@ -188,9 +189,9 @@ char *text;
 int size;
 Rect *r;
 {
+    ARG_UNUSED(size);
 	TCairoData *tcairodata;
 	cairo_text_extents_t extents;
-	int width;
 
 	/* Note:  size is ignored, as it is passed the current value;	*/
 	/* but the font size in cairo has already been set.		*/
@@ -233,7 +234,6 @@ grtcairoCreateBackingStore(MagWindow *w)
 	Tk_Window tkwind = (Tk_Window)w->w_grdata;
 	Window wind;
 	unsigned int width, height;
-	GC gc;
 	XGCValues gcValues;
 	int grDepth;
 
@@ -433,6 +433,9 @@ GrTCairoReadPixel (w, x, y)
 MagWindow *w;
 int x, y;       /* the location of a pixel in screen coords */
 {
+    ARG_UNUSED(w);
+    ARG_UNUSED(x);
+    ARG_UNUSED(y);
 	return 0;       /* (unimplemented) */
 }
 
@@ -456,6 +459,8 @@ GrTCairoBitBlt(r, p)
 Rect *r;
 Point *p;
 {
+    ARG_UNUSED(r);
+    ARG_UNUSED(p);
 	// (unimplemented)
 }
 
@@ -474,10 +479,10 @@ FontChar *clist;
 unsigned char tc;
 int pixsize;
 {
+    ARG_UNUSED(tc);
 	Point *tp;
-	int np, nptotal;
+	int np;
 	int i;
-	static int maxnp = 0;
 	FontChar *ccur;
 	TCairoData *tcairodata = (TCairoData *)tcairoCurrent.mw->w_grdata2;
 
@@ -520,13 +525,14 @@ Point *pos;         /* Text base position */
 Rect  *clip;        /* Clipping area */
 LinkedRect *obscure;    /* List of obscuring areas */
 {
+    ARG_UNUSED(clip);
+    ARG_UNUSED(obscure);
 	char *tptr;
 	Point *coffset;     /* vector to next character */
 	Rect *cbbox;
 	float fsize;
 	FontChar *clist;
-	int cheight, baseline;
-	float tmp;
+	int baseline;
 	TCairoData *tcairodata = (TCairoData *)tcairoCurrent.mw->w_grdata2;
 
 	cairo_save(tcairodata->context);
@@ -595,8 +601,6 @@ LinkedRect *obscure;    /* A list of obscuring rectangles */
 	Rect textrect;
 	LinkedRect *ob;
 	void grTCairoGeoSub();
-	int i;
-	float tscale;
 	TCairoData *tcairodata = (TCairoData *)tcairoCurrent.mw->w_grdata2;
 
 	if (GrTCairoTextSize(text, tcairoCurrent.fontSize, &textrect) < 0) return;

--- a/graphics/grTOGL1.c
+++ b/graphics/grTOGL1.c
@@ -262,7 +262,6 @@ grtoglSetStipple (stipple)
 bool
 GrTOGLInit ()
 {
-    bool rstatus;
 #ifdef THREE_D
     static int attributeList[] = { GLX_RGBA, GLX_DOUBLEBUFFER, None };
 #else
@@ -490,10 +489,8 @@ TOGLEventProc(clientData, xevent)
     ClientData clientData;
     XEvent *xevent;
 {
-    TxInputEvent *event;
     HashEntry	*entry;
     Tk_Window tkwind = (Tk_Window)clientData;
-    Window wind;
     MagWindow *mw;
     unsigned char LocRedirect = TxInputRedirect;
 
@@ -552,7 +549,7 @@ TOGLEventProc(clientData, xevent)
 	    {
 		int keywstate, keymod, idx, idxmax;
 		char inChar[10];
-		Tcl_Channel outChannel = Tcl_GetStdChannel(TCL_STDOUT);
+		Tcl_GetStdChannel(TCL_STDOUT);
 
 		nbytes = XLookupString(KeyPressedEvent, inChar, sizeof(inChar),
 			&keysym, NULL);
@@ -833,7 +830,7 @@ keys_and_buttons:
 		XConfigureEvent *ConfigureEvent = (XConfigureEvent*) xevent;
 		Rect	screenRect;
 		int width, height;
-		bool result, need_resize;
+		bool need_resize;
 
 		width = ConfigureEvent->width;
 		height = ConfigureEvent->height;
@@ -973,9 +970,9 @@ oglSetDisplay (dispType, outFileName, mouseFileName)
     char *outFileName;
     char *mouseFileName;
 {
-    char *planecount;
-    char *fullname;
-    FILE* f;
+    ARG_UNUSED(dispType);
+    ARG_UNUSED(outFileName);
+    ARG_UNUSED(mouseFileName);
     bool execFailed = FALSE;
     int x, y, width, height;
 
@@ -1098,7 +1095,6 @@ GrTOGLCreate(w, name)
     int		y      = glTransYs(w->w_frameArea.r_ytop);
     int		width  = w->w_frameArea.r_xtop - w->w_frameArea.r_xbot;
     int		height = w->w_frameArea.r_ytop - w->w_frameArea.r_ybot;
-    unsigned long        attribmask = CWBackPixel | CWBorderPixel | CWColormap;
     XSetWindowAttributes grAttributes;
 
     WindSeparateRedisplay(w);
@@ -1158,7 +1154,6 @@ GrTOGLCreate(w, name)
 
     if (tkwind != 0)
     {
-	bool result;
 
 	GrTOGLFlush();
 
@@ -1358,7 +1353,6 @@ GrTOGLLock(w, flag)
     MagWindow *w;
     bool flag;
 {
-    Window wind;
 
 #ifdef CAIRO_OFFSCREEN_RENDER
     /* Use Cairo graphics for off-screen rendering */

--- a/graphics/grTOGL3.c
+++ b/graphics/grTOGL3.c
@@ -339,7 +339,6 @@ bool
 grtoglScrollBackingStore(MagWindow *w, Point *shift)
 {
     RenderFrame *rf;
-    GLuint FramebufferName, RenderbufferName;
     unsigned int width, height;
     int xorigin, yorigin, xshift, yshift;
 
@@ -399,7 +398,6 @@ void
 grtoglPutBackingStore(MagWindow *w, Rect *area)
 {
     RenderFrame *rf;
-    GLuint FramebufferName, RenderbufferName;
     unsigned int width, height;
     int ybot, xbot;
     Rect r;
@@ -456,6 +454,9 @@ GrTOGLReadPixel (w, x, y)
     MagWindow *w;
     int x,y;		/* the location of a pixel in screen coords */
 {
+    ARG_UNUSED(w);
+    ARG_UNUSED(x);
+    ARG_UNUSED(y);
     return 0;		/* OpenGL has no such function, so return 0 */
 }
 
@@ -479,6 +480,7 @@ GrTOGLBitBlt(r, p)
     Rect *r;
     Point *p;
 {
+    ARG_UNUSED(p);
     glCopyPixels(r->r_xbot, r->r_ybot, r->r_xtop - r->r_xbot + 1,
 		r->r_ytop - r->r_ybot + 1, GL_COLOR);
 }
@@ -498,6 +500,8 @@ void
 myCombine(GLdouble coords[3], GLdouble *vertex_data[4],
           GLfloat weight[4], GLdouble **outData, void *dataptr)
 {
+    ARG_UNUSED(vertex_data);
+    ARG_UNUSED(weight);
     /* This needs to be free'd at the end of gluTessEndPolygon()! */
     GLdouble *new = (GLdouble *)mallocMagic(2 * sizeof(GLdouble));
     new[0] = coords[0];
@@ -605,13 +609,14 @@ grtoglFontText(text, font, size, rotate, pos, clip, obscure)
     Rect  *clip;		/* Clipping area */
     LinkedRect *obscure;	/* List of obscuring areas */
 {
+    ARG_UNUSED(clip);
+    ARG_UNUSED(obscure);
     char *tptr;
     Point *coffset;		/* vector to next character */
     Rect *cbbox;
-    GLfloat fsize, matvals[16];
+    GLfloat fsize;
     FontChar *clist;
-    int cheight, baseline;
-    float tmp;
+    int baseline;
 
     /* Keep it simple for now---ignore clip and obscure */
 
@@ -680,8 +685,6 @@ grtoglPutText (text, pos, clip, obscure)
     Rect textrect;
     LinkedRect *ob;
     void grTOGLGeoSub();
-    int i;
-    float tscale;
 
     if (GrTOGLTextSize(text, toglCurrent.fontSize, &textrect) < 0) return;
 

--- a/graphics/grText.c
+++ b/graphics/grText.c
@@ -57,7 +57,6 @@ GrFontText(str, style, p, font, size, rotate, clip)
     Rect *clip;		/* Clipping area */
 {
     Rect nClip;
-    Point pstart;
 
     /* Fall back on X11 text if vectored text unavailable */
     if (!grFontTextPtr)

--- a/graphics/grTk1.c
+++ b/graphics/grTk1.c
@@ -350,7 +350,7 @@ GrTkInit(dispType)
     char *dispType;
 {
     int i,j;
-    XVisualInfo grvisual_info, *grvisual_get, grtemplate;
+    XVisualInfo *grvisual_get, grtemplate;
     VisualID defpsvid;
     int defpsindex = -1;
     int gritems, gritems_list, grcolorCount;
@@ -677,7 +677,6 @@ GrTkInit(dispType)
 void
 GrTkClose ()
 {
-    int i;
 
     if (grXdpy == NULL) return;
 
@@ -795,7 +794,7 @@ MagicEventProc(clientData, xevent)
 	    {
 		int keywstate, keymod, idx, idxmax;
 		char inChar[10];
-		Tcl_Channel outChannel = Tcl_GetStdChannel(TCL_STDOUT);
+		Tcl_GetStdChannel(TCL_STDOUT);
 
 		nbytes = XLookupString(KeyPressedEvent, inChar, sizeof(inChar),
 			&keysym, NULL);
@@ -1212,9 +1211,8 @@ x11SetDisplay (dispType, outFileName, mouseFileName)
     char *outFileName;
     char *mouseFileName;
 {
-    char *planecount;
-    char *fullname;
-    FILE* f;
+    ARG_UNUSED(outFileName);
+    ARG_UNUSED(mouseFileName);
     bool execFailed = FALSE;
     int x, y, width, height;
 
@@ -1716,7 +1714,6 @@ GrTkUnlock(w)
 bool
 GrTkEventPending()
 {
-   Tk_Window	tkwind = grCurrent.window;
    Window	wind = grCurrent.windowid;
    XEvent	genEvent;
    bool		retval;

--- a/graphics/grTk3.c
+++ b/graphics/grTk3.c
@@ -237,6 +237,7 @@ GrTkReadPixel (w, x, y)
     MagWindow *w;
     int x,y;		/* the location of a pixel in screen coords */
 {
+    ARG_UNUSED(w);
     XImage *image;
     unsigned long value;
     XWindowAttributes	att;
@@ -325,11 +326,13 @@ grtkFontText(text, font, size, rotate, pos, clip, obscure)
     Rect *clip;
     LinkedRect *obscure;
 {
+    ARG_UNUSED(clip);
+    ARG_UNUSED(obscure);
     char *tptr;
     FontChar *ccur, *clist;
-    Point *coffset, *tp, loffset, locoffset, corners[4], lpos;
+    Point *coffset, *tp, loffset, locoffset, lpos;
     Rect *cbbox, charbbox, *frect;
-    int np, i, j, w, h, llx, lly, baseline;
+    int np, i, j, w, h, baseline;
     XPoint *xp;
     Pixmap pxm;
     double fscale, scx, scy, tmpx, tmpy, rrad, cr, sr;

--- a/graphics/grTkCommon.c
+++ b/graphics/grTkCommon.c
@@ -304,7 +304,6 @@ GrTkWindowName(mw)
     MagWindow *mw;
 {
     Tk_Window tkwind;
-    char *tkname;
 
     tkwind = (Tk_Window) mw->w_grdata;
     return Tk_PathName(tkwind);
@@ -677,6 +676,7 @@ static int
 _magic_magiccolor(ClientData clientData,
 	Tcl_Interp *interp, int argc, char *argv[])
 {
+    ARG_UNUSED(clientData);
     char *result;
     char *name;
 
@@ -847,6 +847,7 @@ ImgLayerCreate(interp, name, argc, argv, typePtr, master, clientDataPtr)
     ClientData *clientDataPtr;	/* Store manager's token for image here;
 				 * it will be returned in later callbacks. */
 {
+    ARG_UNUSED(typePtr);
     LayerMaster *masterPtr;
 
     masterPtr = (LayerMaster *) Tcl_Alloc(sizeof(LayerMaster));

--- a/grouter/grouteCrss.c
+++ b/grouter/grouteCrss.c
@@ -577,6 +577,7 @@ glCrossChoose(newRest, tp, pin, newPath)
     GCRPin *pin;	/* Pin on boundary of tp being considered */
     GlPoint *newPath;		/* Update newPath->gl_pin, newPath->gl_cost */
 {
+    ARG_UNUSED(tp);
     GCRPin *savePin;
     int cost;
 

--- a/grouter/groutePath.c
+++ b/grouter/groutePath.c
@@ -16,10 +16,6 @@
  *     *********************************************************************
  */
 
-#ifndef lint
-static char sccsid[] = "@(#)groutePoint.c	4.9 MAGIC (Berkeley) 12/6/85";
-#endif  /* not lint */
-
 #include <stdio.h>
 #include "utils/magic.h"
 #include "utils/geometry.h"

--- a/grouter/groutePen.c
+++ b/grouter/groutePen.c
@@ -183,6 +183,8 @@ glPenCompute(chanList, netList)
     GCRChannel *chanList;	/* All the channels in the routing problem */
     NLNetList *netList;	/* Netlist being routed */
 {
+    ARG_UNUSED(chanList);
+    ARG_UNUSED(netList);
 #ifdef	notdef
     CZone *czones, *cz;
     GlobChan *gc;
@@ -567,6 +569,9 @@ glPenFindCrossingFunc(cz, srcPin, dstPin, rcc)
     GCRPin *srcPin, *dstPin;	/* UNUSED */
     struct glCrossClient *rcc;
 {
+    ARG_UNUSED(cz);
+    ARG_UNUSED(srcPin);
+    ARG_UNUSED(dstPin);
     NetSet *ns;
 
     ns = (NetSet *) mallocMagic((unsigned) (sizeof (NetSet)));
@@ -709,6 +714,8 @@ glPenRouteCost(rootUse, bestPath, pNetId, pCost)
     NetId *pNetId;	/* UNUSED */
     int *pCost;		/* Add bestPath->gl_cost to this */
 {
+    ARG_UNUSED(rootUse);
+    ARG_UNUSED(pNetId);
     *pCost += bestPath->gl_cost;
     return 0;
 }
@@ -852,6 +859,7 @@ glPenSavePath(rootUse, path, pNetId)
     GlPoint *path;	/* Path linked via gl_path pointers */
     NetId *pNetId;	/* Net and segment identifier */
 {
+    ARG_UNUSED(rootUse);
     GlPoint *newpath;
     NetClient *nc;
 
@@ -883,7 +891,6 @@ void
 glPenDensitySet(net)
     NLNet *net;
 {
-    NetClient *nc = (NetClient *) net->nnet_cdata;
     GCRPin *srcPin, *dstPin;
     GlPoint *rp;
     GlPoint *path;

--- a/grouter/grouteTest.c
+++ b/grouter/grouteTest.c
@@ -115,6 +115,7 @@ GlTest(w, cmd)
     MagWindow *w;
     TxCommand *cmd;
 {
+    ARG_UNUSED(w);
     int glDebugSides();
     typedef enum { CLRDEBUG, ONLYNET, SETDEBUG, SHOWDEBUG, SIDES } cmdType;
     Rect editArea;

--- a/irouter/irCommand.c
+++ b/irouter/irCommand.c
@@ -804,6 +804,7 @@ irContactsCmd(w, cmd)
     MagWindow *w;
     TxCommand *cmd;
 {
+    ARG_UNUSED(w);
     TileType tileType;
     RouteContact *rC;
 
@@ -1073,6 +1074,7 @@ irHelpCmd(w, cmd)
     MagWindow *w;
     TxCommand *cmd;
 {
+    ARG_UNUSED(w);
     int n;
     int which;
 
@@ -1178,6 +1180,7 @@ irLayersCmd(w, cmd)
     MagWindow *w;
     TxCommand *cmd;
 {
+    ARG_UNUSED(w);
     TileType tileType;
     RouteLayer *rL;
     bool doList = FALSE;
@@ -1757,6 +1760,7 @@ irSearchCmd(w, cmd)
     MagWindow *w;
     TxCommand *cmd;
 {
+    ARG_UNUSED(w);
 
     /* Process by case */
     if(cmd->tx_argc == 2)
@@ -2136,6 +2140,7 @@ irVerbosityCmd(w, cmd)
     MagWindow *w;
     TxCommand *cmd;
 {
+    ARG_UNUSED(w);
     if(cmd->tx_argc >3)
     {
 	TxError("'iroute verbosity' only takes one arg!\n");
@@ -2201,6 +2206,7 @@ irVersionCmd(w, cmd)
     MagWindow *w;
     TxCommand *cmd;
 {
+    ARG_UNUSED(w);
 
     if(cmd->tx_argc == 2)
     {
@@ -2254,6 +2260,7 @@ irWizardCmd(w, cmd)
     MagWindow *w;
     TxCommand *cmd;
 {
+    ARG_UNUSED(w);
 
     /* Process by case */
     if(cmd->tx_argc == 2)
@@ -2357,6 +2364,7 @@ irSaveParametersCmd(w, cmd)
     MagWindow *w;
     TxCommand *cmd;
 {
+    ARG_UNUSED(w);
     FILE *saveFile;
     RouteContact *rC;
     RouteLayer *rL;

--- a/irouter/irRoute.c
+++ b/irouter/irRoute.c
@@ -384,7 +384,6 @@ irRoute(cmdWindow, startType, argStartPt, argStartLabel, argStartLayers,
     if (path)
     {
 
-	RouteLayer *finalRL = path->rp_rLayer;
 	CellUse *resultUse;
 
         /* Have MazeRouter paint path into resultCell */
@@ -760,8 +759,8 @@ irSelLabelsFunc(label, cellUse, transform, clientData)
     Transform *transform;
     ClientData clientData;
 {
+    ARG_UNUSED(cellUse);
     LabelSearchData *lsd = (LabelSearchData *)clientData;
-    CellDef *cellDef = cellUse->cu_def;
 
     if (strcmp(lsd->lsd_name, label->lab_text) != 0)
     {
@@ -810,6 +809,7 @@ irAllLabelsFunc(rect, name, label, clientData)
     Label *label;
     ClientData clientData;
 {
+    ARG_UNUSED(name);
     LabelSearchData *lsd = (LabelSearchData *)clientData;
 
     if (lsd->lsd_result == LSR_FOUND)
@@ -854,6 +854,7 @@ irSelectedTileFunc(rect, type, c)
     TileType type;
     ClientData c;
 {
+    ARG_UNUSED(type);
     RouteLayer *rL = (RouteLayer *) c;
     MZAddDest(rect, rL->rl_routeType.rt_tileType);
 

--- a/irouter/irTestCmd.c
+++ b/irouter/irTestCmd.c
@@ -81,6 +81,7 @@ irDebugTstCmd(w, cmd)
     MagWindow *w;
     TxCommand *cmd;
 {
+    ARG_UNUSED(w);
     int result;
     bool value;
 
@@ -134,6 +135,7 @@ irHelpTstCmd(w, cmd)
     MagWindow *w;
     TxCommand *cmd;
 {
+    ARG_UNUSED(w);
     int n;
     int which;
 
@@ -210,6 +212,8 @@ irParmsTstCmd(w, cmd)
     MagWindow *w;
     TxCommand *cmd;
 {
+    ARG_UNUSED(w);
+    ARG_UNUSED(cmd);
 
     MZPrintRLs(irRouteLayers);
     TxMore("");

--- a/lef/defRead.c
+++ b/lef/defRead.c
@@ -791,6 +791,7 @@ DefReadNonDefaultRules(
     float oscale,
     int total)
 {
+    ARG_UNUSED(rootDef);
     const char *token;
     int keyword, subkey;
     int processed = 0;
@@ -2429,7 +2430,6 @@ DefRead(
     int keyword, dscale, total;
     float oscale;
     Rect *dierect;
-    bool design_is_root = FALSE;
 
     static const char * const sections[] = {
 	"VERSION",

--- a/lef/defWrite.c
+++ b/lef/defWrite.c
@@ -293,6 +293,8 @@ defnodeCount(
     EFCapValue cap,		/* not used */
     NetCount *total)
 {
+    ARG_UNUSED(res);
+    ARG_UNUSED(cap);
     HierName *hierName;
     char *cp, clast;
 
@@ -658,6 +660,8 @@ defnodeVisit(
     EFCapValue cap,
     DefData *defdata)
 {
+    ARG_UNUSED(res);
+    ARG_UNUSED(cap);
     HierName *hierName;
     char *ndn;
     char ndn2[256];
@@ -1701,6 +1705,7 @@ int
 defCheckFunc(
     Tile *tile)
 {
+    ARG_UNUSED(tile);
     return 1;
 }
 
@@ -2083,6 +2088,7 @@ defWriteVias(
     float oscale,			/* Output scale factor */
     LefMapping *lefMagicToLefLayer)
 {
+    ARG_UNUSED(rootDef);
     HashSearch hs;
     HashEntry *he;
     lefLayer *lefl;
@@ -2585,6 +2591,8 @@ defblockageVisit(
     EFCapValue cap,
     DefObsData *defobsdata)
 {
+    ARG_UNUSED(res);
+    ARG_UNUSED(cap);
     CellDef *def = defobsdata->def;
     TileType magictype;
     TileTypeBitMask tmask;

--- a/lef/lefRead.c
+++ b/lef/lefRead.c
@@ -1028,6 +1028,7 @@ LefReadPolygon(
     Point *gdsOffset,
     int *ppoints)
 {
+    ARG_UNUSED(curlayer);
     LinkedRect *lr = NULL, *newRect;
     Point *plist = NULL;
     const char *token;
@@ -1188,6 +1189,8 @@ lefUnconnectFunc(
     Tile *tile,
     ClientData clientdata)	/* (unused) */
 {
+    ARG_UNUSED(tile);
+    ARG_UNUSED(clientdata);
     return 1;
 }
 
@@ -1291,7 +1294,7 @@ LefReadGeometry(
 
 		    if (is_imported)
 		    {
-			int pNum = DBPlane(curlayer); /* FIXME unused return value from call to function with no side-effects */
+			DBPlane(curlayer); /* FIXME call to function with no side-effects */
 			SearchContext scx;
 			CellUse	dummy;
 			PlaneType pt;
@@ -2564,6 +2567,7 @@ LefGenViaGeometry(
     TileType blayer,		/* Bottom layer type */
     float oscale)		/* output scaling	*/
 {
+    ARG_UNUSED(f);
     Rect rect;
     int i, j, x, y, w, h;
     LinkedRect *viaLR;
@@ -2729,6 +2733,7 @@ LefReadLayerSection(
     int mode,			/* layer, via, or viarule */
     lefLayer *lefl)		/* pointer to layer info  */
 {
+    ARG_UNUSED(mode);
     const char *token;
     int keyword, typekey;
     TileType curlayer = -1;
@@ -2777,12 +2782,6 @@ LefReadLayerSection(
 	"VIA",
 	"GENERATE",
 	"END",
-	NULL
-    };
-
-    static const char * const spacing_keys[] = {
-	"RANGE",
-	";",
 	NULL
     };
 

--- a/lef/lefTech.c
+++ b/lef/lefTech.c
@@ -207,6 +207,7 @@ LefTechLine(
     int argc,                   /* Number of arguments on line. */
     char *argv[])               /* Pointers to fields of line. */
 {
+    ARG_UNUSED(sectionName);
     bool isObstruction, isContact, isInactive;
     HashEntry *he;
     TileType mtype, mtype2 = -1;
@@ -304,7 +305,7 @@ LefTechLine(
 
 	    if (newlefl == NULL)
 	    {
-		float oscale = CIFGetOutputScale(1000); /* FIXME unused return value from call to function with no side-effects */
+		CIFGetOutputScale(1000); /* FIXME call to function with no side-effects */
 
 		newlefl = (lefLayer *)mallocMagic(sizeof(lefLayer));
 		newlefl->refCnt = 0;

--- a/lef/lefWrite.c
+++ b/lef/lefWrite.c
@@ -571,6 +571,8 @@ lefHasPaint(
     Tile *tile,
     ClientData clientData)
 {
+    ARG_UNUSED(tile);
+    ARG_UNUSED(clientData);
     return 1;
 }
 
@@ -616,6 +618,8 @@ lefFindTopmost(
     Tile *tile,
     ClientData cdata)
 {
+    ARG_UNUSED(tile);
+    ARG_UNUSED(cdata);
     return 1;	    /* Stop processing on the first tile found */
 }
 
@@ -2075,6 +2079,7 @@ lefGetSites(
     int i,
     ClientData clientData)
 {
+    ARG_UNUSED(i);
     CellDef *def = (CellDef *)stackItem;
     HashTable *lefSiteTbl = (HashTable *)clientData;
     HashEntry *he;
@@ -2105,6 +2110,7 @@ lefGetProperties(
     int i,
     ClientData clientData)
 {
+    ARG_UNUSED(i);
     CellDef *def = (CellDef *)stackItem;
     HashTable *lefPropTbl = (HashTable *)clientData;
     HashEntry *he;

--- a/mzrouter/mzBlock.c
+++ b/mzrouter/mzBlock.c
@@ -587,7 +587,7 @@ mzBuildFenceBlocksFunc(tile, buildArea)
     RouteType *rT;
     int d;
     Rect r, rAdjusted;
-    TileType tt = TiGetType(tile);
+    TiGetType(tile);
 
     /* Get boundary of tile */
     TITORECT(tile, &r);
@@ -727,6 +727,7 @@ mzExtendBlockFunc(tile, cdarg)
     Tile *tile;
     ClientData cdarg;
 {
+    ARG_UNUSED(cdarg);
     Rect area;
 
     /* Get location of tile */

--- a/mzrouter/mzDebug.c
+++ b/mzrouter/mzDebug.c
@@ -530,7 +530,7 @@ mzDumpTagsFunc(tile, cxp)
     Tile *tile;
     TreeContext *cxp;
 {
-    SearchContext *scx = cxp->tc_scx;
+    ARG_UNUSED(cxp);
     Rect r;
 
     /* if tile has no client data attached, skip it */

--- a/mzrouter/mzEstimate.c
+++ b/mzrouter/mzEstimate.c
@@ -491,6 +491,7 @@ mzReclaimTCFunc(tile, notUsed)
     Tile *tile;
     ClientData notUsed;
 {
+    ARG_UNUSED(notUsed);
     if (tile->ti_client != (ClientData)CLIENTDEFAULT)
     {
 	TileCosts *tc = ((TileCosts *) (tile->ti_client));
@@ -610,6 +611,7 @@ mzDestTileEstFunc(tile, cdarg)
     Tile *tile;
     ClientData cdarg;
 {
+    ARG_UNUSED(cdarg);
     Rect rect;
 
     /* set rect to bounding box of tile */
@@ -660,6 +662,7 @@ mzAddSubcellEstFunc(scx, cdarg)
     SearchContext *scx;
     ClientData cdarg;
 {
+    ARG_UNUSED(cdarg);
     Rect r, rDest;
 
     /* Transform bounding box to result coords */
@@ -701,6 +704,7 @@ mzAddFenceEstFunc(tile, buildArea)
     Tile *tile;
     Rect *buildArea; /* currently ignored */
 {
+    ARG_UNUSED(buildArea);
     Rect r;
 
     /* Get boundary of tile */
@@ -906,6 +910,7 @@ mzBuildEstimatesFunc(tile, notUsed)
     Tile *tile;
     ClientData notUsed;
 {
+    ARG_UNUSED(notUsed);
 
     mzBuildCornerEstimators(tile);
     mzBuildStraightShotEstimators(tile);
@@ -1318,6 +1323,7 @@ mzTrimEstimatesFunc(tile, notUsed)
     Tile *tile;
     ClientData notUsed;
 {
+    ARG_UNUSED(notUsed);
     TileCosts *tc = (TileCosts *) (tile->ti_client);
     Estimate *e;
     Estimate *reqEstimates = NULL;
@@ -1513,7 +1519,6 @@ mzAssignVertexCosts()
 {
     Heap adjHeap;	/* vertices adjacent to the IN set are put here */
     HeapEntry buf, *he;
-    Tile *t;
 
     /* Initialize Heap */
     HeapInitType(&adjHeap, 1024, FALSE, FALSE, HE_DLONG);
@@ -1984,7 +1989,6 @@ mzDumpEstFunc(tile, fd)
 	fprintf(fd,"vcost = %d \n",
 		tilec->tc_vCost);
 	{
-	    char str[100];
 	    Estimate *e;
 
 	    fprintf(fd,"\tEstimates:\n");
@@ -2006,7 +2010,6 @@ mzDumpEstFunc(tile, fd)
 	TxPrintf("vcost = %d \n",
 		tilec->tc_vCost);
 	{
-	    char str[100];
 	    Estimate *e;
 
 	    TxPrintf("\tEstimates:\n");

--- a/mzrouter/mzMain.c
+++ b/mzrouter/mzMain.c
@@ -672,7 +672,6 @@ MZAddDest(rect, type)
     Rect *rect;
     TileType type;
 {
-    ColoredRect *dTerm;
 
     UndoDisable();
 

--- a/mzrouter/mzStart.c
+++ b/mzrouter/mzStart.c
@@ -93,7 +93,6 @@ mzStart(term)
 {
     RouteLayer *rL;
     RouteContact *rC;
-    Tile *tp;
     bool returnCode = TRUE;
     Point point;
     int result;
@@ -212,6 +211,8 @@ mzExtendInitPath(path, rL, point, cost, length, directions)
     int length;		/* length of path (excluding new segment) */
     int directions;	/* directions to extend init path in */
 {
+    ARG_UNUSED(length);
+    ARG_UNUSED(directions);
     Tile *tp;
     bool returnCode = TRUE;
     int orient;

--- a/mzrouter/mzSubrs.c
+++ b/mzrouter/mzSubrs.c
@@ -517,6 +517,7 @@ mzConnectedSubcellFunc(scx, cdarg)
     SearchContext *scx;
     ClientData cdarg;
 {
+    ARG_UNUSED(cdarg);
     CellUse *cu = scx->scx_use;
 
     /* If not already marked, mark celluse and add to marked list */
@@ -589,7 +590,7 @@ mzPaintContact(path, prev)
     RoutePath *path, *prev;
 {
     RouteContact *rC;
-    int pNum, pNumC, cWidth;
+    int pNum, cWidth;
     Rect r;
     TileType cType;
 

--- a/mzrouter/mzTech.c
+++ b/mzrouter/mzTech.c
@@ -326,6 +326,7 @@ MZTechLine(sectionName, argc, argv)
     int argc;
     char *argv[];
 {
+    ARG_UNUSED(sectionName);
     if(strcmp(argv[0], "style") == 0)
     {
         mzTechStyle(argc, argv);
@@ -393,6 +394,7 @@ mzTechStyle(argc, argv)
     int argc;
     char *argv[];
 {
+    ARG_UNUSED(argc);
 
     /* if there is a previous style, complete processing on it */
     if(mzStyles)

--- a/mzrouter/mzTestCmd.c
+++ b/mzrouter/mzTestCmd.c
@@ -83,6 +83,7 @@ mzDebugTstCmd(w, cmd)
     MagWindow *w;
     TxCommand *cmd;
 {
+    ARG_UNUSED(w);
     int result;
     bool value;
 
@@ -137,6 +138,7 @@ mzDumpEstimatesTstCmd(w, cmd)
     MagWindow *w;
     TxCommand *cmd;
 {
+    ARG_UNUSED(w);
     if (cmd->tx_argc > 2)
     {
 	TxPrintf("Too many args on '*mzroute dumpEstimates'\n");
@@ -184,6 +186,7 @@ mzDumpTagsTstCmd(w, cmd)
     MagWindow *w;
     TxCommand *cmd;
 {
+    ARG_UNUSED(w);
     if (cmd->tx_argc > 2)
     {
 	TxPrintf("Too many args on '*mzroute dumpTags'\n");
@@ -231,6 +234,7 @@ mzHelpTstCmd(w, cmd)
     MagWindow *w;
     TxCommand *cmd;
 {
+    ARG_UNUSED(w);
     int n;
     int which;
 
@@ -307,6 +311,8 @@ mzNumberLineTstCmd(w, cmd)
     MagWindow *w;
     TxCommand *cmd;
 {
+    ARG_UNUSED(w);
+    ARG_UNUSED(cmd);
     NumberLine myLine;
     int *result;
 
@@ -386,6 +392,8 @@ mzParmsTstCmd(w, cmd)
     MagWindow *w;
     TxCommand *cmd;
 {
+    ARG_UNUSED(w);
+    ARG_UNUSED(cmd);
 
     MZPrintRLs(mzRouteLayers);
     TxMore("");
@@ -417,6 +425,7 @@ mzPlaneTstCmd(w, cmd)
     MagWindow *w;
     TxCommand *cmd;
 {
+    ARG_UNUSED(w);
     TileType t;
     RouteType *rT;
     char *layerName;
@@ -490,6 +499,7 @@ mzVersionCmd(w, cmd)
     MagWindow *w;
     TxCommand *cmd;
 {
+    ARG_UNUSED(w);
 
     if(cmd->tx_argc == 2)
     {

--- a/mzrouter/mzWalk.c
+++ b/mzrouter/mzWalk.c
@@ -535,7 +535,6 @@ mzWalkLRContact(path)
     RoutePath *path;
 {
     Point pOrg;		/* point to extend from */
-    int extendCode;	/* Interesting directions to extend in */
     RouteContact *rC;   /* Route contact to make connection with */
     RouteLayer *newRL;	/* Route layer of dest area */
     dlong conCost;	/* Cost of final contact */
@@ -622,7 +621,6 @@ mzWalkUDContact(path)
     RoutePath *path;
 {
     Point pOrg;		/* point to extend from */
-    int extendCode;	/* Interesting directions to extend in */
     RouteContact *rC;   /* Route contact to make connection with */
     RouteLayer *newRL;	/* Route layer of dest area */
     dlong conCost;	/* Cost of final contact */

--- a/netmenu/NMbutton.c
+++ b/netmenu/NMbutton.c
@@ -72,6 +72,9 @@ NMButtonNetList(window, cmd, nmButton, point)
     TxCommand *cmd;		/* Used to figure out which button it was. */
     Point *point;		/* Not used. */
 {
+    ARG_UNUSED(window);
+    ARG_UNUSED(nmButton);
+    ARG_UNUSED(point);
 #define MAXLENGTH 200
     char newName[MAXLENGTH];
     if (cmd->tx_button == TX_RIGHT_BUTTON)
@@ -186,6 +189,8 @@ NMButtonRight(w, cmd)
     MagWindow *w;			/* Window in which button was pushed. */
     TxCommand *cmd;		/* Detailed information about command. */
 {
+    ARG_UNUSED(w);
+    ARG_UNUSED(cmd);
     char *name;
     extern int nmButHighlightFunc(), nmButUnHighlightFunc();
     extern int nmButCheckFunc(), nmNewRefFunc(), nmFindNetNameFunc();
@@ -285,6 +290,8 @@ nmButHighlightFunc(area, name, label, pExists)
     Label *label;		/* Pointer to label */
     bool  *pExists;		/* We just set this to TRUE. */
 {
+    ARG_UNUSED(name);
+    ARG_UNUSED(label);
     Rect rootArea;
     Point point;
 
@@ -406,6 +413,8 @@ NMButtonLeft(w, cmd)
     MagWindow *w;			/* Window in which button was pushed. */
     TxCommand *cmd;		/* Detailed information about the command. */
 {
+    ARG_UNUSED(w);
+    ARG_UNUSED(cmd);
     char *name;
 
     name = nmButtonSetup();
@@ -445,6 +454,8 @@ NMButtonMiddle(w, cmd)
     MagWindow *w;		/* Window in which button was pushed. */
     TxCommand *cmd;	/* Detailed information about command. */
 {
+    ARG_UNUSED(w);
+    ARG_UNUSED(cmd);
     char *name;
 
     name = nmButtonSetup();

--- a/netmenu/NMcmdAK.c
+++ b/netmenu/NMcmdAK.c
@@ -61,6 +61,7 @@ NMCmdAdd(w, cmd)
     MagWindow *w;			/* Netlist window. */
     TxCommand *cmd;		/* Contains the command's argc and argv. */
 {
+    ARG_UNUSED(w);
     if (cmd->tx_argc != 3)
     {
 	TxError("Usage: add term1 term2\n");
@@ -129,6 +130,7 @@ NMCmdCleanup(w, cmd)
     MagWindow *w;			/* Netlist window. */
     TxCommand *cmd;		/* Contains the command's argc and argv. */
 {
+    ARG_UNUSED(w);
     extern int nmCleanupFunc1();	/* Forward reference. */
     struct nmcleanup *p;
 
@@ -215,6 +217,7 @@ nmCleanupFunc1(name, firstInNet, cdarg)
     bool firstInNet;		/* TRUE means first terminal of new net. */
     ClientData cdarg;		/* Not used. */
 {
+    ARG_UNUSED(cdarg);
     int count;
     struct nmcleanup *p;
 
@@ -251,6 +254,9 @@ nmCleanupFunc2(rect, name, label, pCount)
     Label *label;		/* Not used. */
     int *pCount;		/* Pointer to word to be incremented. */
 {
+    ARG_UNUSED(rect);
+    ARG_UNUSED(name);
+    ARG_UNUSED(label);
     *pCount += 1;
     return 0;
 }
@@ -300,6 +306,7 @@ NMCmdCull(w, cmd)
     MagWindow *w;			/* Netlist window. */
     TxCommand *cmd;		/* Contains the command's argc and argv. */
 {
+    ARG_UNUSED(w);
     if (cmd->tx_argc != 1)
     {
 	TxError("Usage: cull\n");
@@ -338,6 +345,7 @@ NMCmdDnet(w, cmd)
     MagWindow *w;			/* Netlist window. */
     TxCommand *cmd;		/* Contains the command's argc and argv. */
 {
+    ARG_UNUSED(w);
     int i;
 
     if (!NMHasList())
@@ -393,6 +401,7 @@ NMCmdDterm(w, cmd)
     MagWindow *w;			/* Netlist window. */
     TxCommand *cmd;		/* Contains the command's argc and argv. */
 {
+    ARG_UNUSED(w);
     int i;
     if (cmd->tx_argc < 2)
     {
@@ -444,6 +453,7 @@ NMCmdExtract(w, cmd)
     MagWindow *w;			/* Netlist window. */
     TxCommand *cmd;		/* Contains the command's argc and argv. */
 {
+    ARG_UNUSED(w);
     if (cmd->tx_argc != 1)
     {
 	TxError("Usage: extract\n");
@@ -483,6 +493,7 @@ NMCmdFindLabels(w, cmd)
     MagWindow *w;			/* Netlist window. */
     TxCommand *cmd;		/* Contains the command's argc and argv. */
 {
+    ARG_UNUSED(w);
     TileTypeBitMask mask, *pMask;
     char *pattern;
 
@@ -528,6 +539,7 @@ NMCmdFlush(w, cmd)
     MagWindow *w;			/* Netlist window. */
     TxCommand *cmd;		/* Contains the command's argc and argv. */
 {
+    ARG_UNUSED(w);
     char *name;
 
     if (cmd->tx_argc >= 3)
@@ -579,6 +591,7 @@ NMCmdJoinNets(w, cmd)
     MagWindow *w;			/* Netlist window. */
     TxCommand *cmd;		/* Contains the command's argc and argv. */
 {
+    ARG_UNUSED(w);
     if (cmd->tx_argc != 3)
     {
 	TxError("Usage: joinnets term1 term2\n");

--- a/netmenu/NMcmdLZ.c
+++ b/netmenu/NMcmdLZ.c
@@ -62,6 +62,7 @@ NMCmdMeasure(w, cmd)
     MagWindow *w;			/* Netlist window. */
     TxCommand *cmd;		/* Contains the command's argc and argv. */
 {
+    ARG_UNUSED(w);
     FILE * fp, * fopen();
 
     if (cmd->tx_argc > 3)
@@ -130,6 +131,7 @@ NMCmdNetlist(w, cmd)
     MagWindow *w;			/* Netlist window. */
     TxCommand *cmd;		/* Contains the command's argc and argv. */
 {
+    ARG_UNUSED(w);
     if (cmd->tx_argc > 2)
     {
 	TxError("Usage: netlist [name]\n");
@@ -165,6 +167,7 @@ NMCmdPrint(w, cmd)
     MagWindow *w;			/* Netlist window. */
     TxCommand *cmd;		/* Contains the command's argc and argv. */
 {
+    ARG_UNUSED(w);
     extern int nmCmdPrintFunc();
     int gotAny;
     char *name;
@@ -234,7 +237,7 @@ NMCmdPushButton(w, cmd)
     MagWindow *w;			/* Netlist window. */
     TxCommand *cmd;		/* Contains the command's argc and argv. */
 {
-    int button, action;
+    int button;
     static const char * const NMButton[] = {"left", "middle", "right", NULL};
 
     if (cmd->tx_argc != 2)
@@ -292,6 +295,7 @@ NMCmdRipup(w, cmd)
     MagWindow *w;			/* Netlist window. */
     TxCommand *cmd;		/* Contains the command's argc and argv. */
 {
+    ARG_UNUSED(w);
     if (cmd->tx_argc == 1)
 	NMRipup();
     else if (cmd->tx_argc == 2)
@@ -330,6 +334,7 @@ NMCmdSavenetlist(w, cmd)
     MagWindow *w;			/* Netlist window. */
     TxCommand *cmd;		/* Contains the command's argc and argv. */
 {
+    ARG_UNUSED(w);
     if ((cmd->tx_argc != 2) && (cmd->tx_argc != 1))
     {
 	TxError("Usage: savenetlist [file]\n");
@@ -370,6 +375,7 @@ NMCmdShownet(w, cmd)
     MagWindow *w;			/* Netlist window. */
     TxCommand *cmd;		/* Contains the command's argc and argv. */
 {
+    ARG_UNUSED(w);
     if (cmd->tx_argc != 1)
     {
 	if (!strncmp(cmd->tx_argv[1], "erase", 5))
@@ -407,6 +413,7 @@ NMCmdShowterms(w, cmd)
     MagWindow *w;			/* Netlist window. */
     TxCommand *cmd;		/* Contains the command's argc and argv. */
 {
+    ARG_UNUSED(w);
     extern int nmShowtermsFunc1();	/* Forward reference. */
 
     if (cmd->tx_argc != 1)
@@ -434,6 +441,8 @@ nmShowtermsFunc1(name, firstInNet, cdarg)
     bool firstInNet;				/* Not used. */
     ClientData cdarg;				/* Not used. */
 {
+    ARG_UNUSED(firstInNet);
+    ARG_UNUSED(cdarg);
     extern int nmShowtermsFunc2();		/* Forward reference. */
 
     (void) DBSrLabelLoc(EditCellUse, name, nmShowtermsFunc2,
@@ -453,6 +462,9 @@ nmShowtermsFunc2(rect, name, label, cdarg)
     Label *label;		/* Not used. */
     ClientData cdarg;		/* Not used. */
 {
+    ARG_UNUSED(name);
+    ARG_UNUSED(label);
+    ARG_UNUSED(cdarg);
     Rect expanded;
     GEO_EXPAND(rect, 1, &expanded);
     DBWFeedbackAdd(&expanded, "\"Showterms\" result", EditCellUse->cu_def,
@@ -486,6 +498,7 @@ NMCmdTrace(w, cmd)
     MagWindow *w;			/* Netlist window. */
     TxCommand *cmd;		/* Contains the command's argc and argv. */
 {
+    ARG_UNUSED(w);
     if ((cmd->tx_argc != 1) && (cmd->tx_argc != 2))
     {
 	TxError("Usage: trace [name]\n");
@@ -523,6 +536,7 @@ NMCmdVerify(w, cmd)
     MagWindow *w;			/* Netlist window. */
     TxCommand *cmd;		/* Contains the command's argc and argv. */
 {
+    ARG_UNUSED(w);
     if (cmd->tx_argc != 1)
     {
 	TxError("Usage: verify\n");
@@ -563,6 +577,7 @@ NMCmdWriteall(w, cmd)
     MagWindow *w;			/* Netlist window. */
     TxCommand *cmd;		/* Contains the command's argc and argv. */
 {
+    ARG_UNUSED(w);
     if (cmd->tx_argc != 1)
     {
 	TxError("Usage: writeall\n");

--- a/netmenu/NMlabel.c
+++ b/netmenu/NMlabel.c
@@ -391,6 +391,8 @@ NMChangeNum(window,cmd, nmButton, point)
     Point *point;		/* Cursor position in surface coords. */
 
 {
+    ARG_UNUSED(window);
+    ARG_UNUSED(point);
     int *pNum;
 
     /* Figure out which number is involved. */
@@ -502,6 +504,8 @@ NMPutLabel(window, cmd, nmButton, point)
     TxCommand *cmd;		/* Complete info about command. (ignored) */
     Point *point;		/* Cursor position in surface coords. */
 {
+    ARG_UNUSED(window);
+    ARG_UNUSED(cmd);
     int pos;
     char *text;
 
@@ -542,6 +546,8 @@ NMReOrientLabel(window, cmd, nmButton, point)
     TxCommand *cmd;		/* Detailed info on command (ignored). */
     Point *point;		/* Cursor position in surface coords. */
 {
+    ARG_UNUSED(window);
+    ARG_UNUSED(cmd);
     int pos;
     Rect editArea;
 

--- a/netmenu/NMmain.c
+++ b/netmenu/NMmain.c
@@ -139,6 +139,7 @@ NMcreate(window, argc, argv)
     int argc;			/* Count of additional arguments. */
     char *argv[];		/* Pointers to additional arguments. */
 {
+    ARG_UNUSED(argv);
     if (argc > 0)
         TxError("Ignoring extra argments for netlist menu creation.\n");
     if (NMWindow != NULL)
@@ -179,6 +180,7 @@ bool
 NMdelete(window)
     MagWindow *window;		/* The window that's about to disappear. */
 {
+    ARG_UNUSED(window);
     NMWindow = NULL;
     NMClearPoints();
     return TRUE;
@@ -216,6 +218,7 @@ NMreposition(window, newScreenArea, final)
 					 * cleanup.
 					 */
 {
+    ARG_UNUSED(newScreenArea);
     if (final) WindMove(window, &nmSurfaceArea);
     return 0;
 }
@@ -366,7 +369,6 @@ NMcommand(w, cmd)
     NetButton *nb;
     Point surfacePoint;
     void (*proc)();
-    int cmdNum;
 
     if (cmd->tx_button == TX_NO_BUTTON)
     {

--- a/netmenu/NMshowcell.c
+++ b/netmenu/NMshowcell.c
@@ -407,6 +407,7 @@ nmSRNFunc(rect, name, label, cdarg)
     Label *label;
     ClientData cdarg;
 {
+    ARG_UNUSED(name);
     SearchContext scx;
 
     /* Expand the box area by one so we'll get everything that even

--- a/netmenu/NMwiring.c
+++ b/netmenu/NMwiring.c
@@ -128,6 +128,7 @@ nmwRipTileFunc(tile, plane, listHead)
     int plane;			/* Plane index of the tile */
     struct nmwarea **listHead;	/* Pointer to list head pointer. */
 {
+    ARG_UNUSED(plane);
     struct nmwarea *new;
 
     new = (struct nmwarea *) mallocMagic(sizeof(struct nmwarea));
@@ -227,6 +228,7 @@ nmRipLocFunc(rect, name, label, area)
 				 * all the tiles we delete.
 				 */
 {
+    ARG_UNUSED(name);
     struct nmwarea *list;
     Rect initialArea;
     TileTypeBitMask maskBits;
@@ -281,6 +283,7 @@ nmRipNameFunc(name, firstInNet, area)
 				 * nmRipLocFunc.
 				 */
 {
+    ARG_UNUSED(firstInNet);
     (void) DBSrLabelLoc(EditCellUse, name, nmRipLocFunc, (ClientData) area);
     return 0;
 }
@@ -407,6 +410,7 @@ nmwNetTermFunc(scx, label, tpath, netPtr)
     TerminalPath *tpath;	/* Gives hierarchical label name. */
     char **netPtr;		/* Pointer to a terminal in current net. */
 {
+    ARG_UNUSED(scx);
     char *p, *p2;
 
     if (strchr(tpath->tp_first, '/') == 0) return 0;
@@ -479,6 +483,7 @@ nmwNetTileFunc(tile, plane, netPtr)
     int plane;			/* Plane index of the tile */
     char **netPtr;		/* Pointer to pointer to net name. */
 {
+    ARG_UNUSED(plane);
     SearchContext scx;
     char label[TERMLENGTH];
     TerminalPath tpath;
@@ -717,6 +722,7 @@ nmwVerifyTileFunc(
     int plane,			/* Plane index of the tile. */
     ClientData cdata)		/* Processing function for each tile. */
 {
+    ARG_UNUSED(plane);
     int (*func)(Tile *) = (int (*)(Tile *))CD2FUN(cdata);
     SearchContext scx;
     char label[TERMLENGTH];
@@ -827,6 +833,7 @@ nmwVErrorLabelFunc(rect, name, label)
     char *name;			/* Hierarchical name of label. */
     Label *label;		/* Pointer to the label itself (not used). */
 {
+    ARG_UNUSED(label);
     char msg[200];
     Rect biggerArea;
 
@@ -1223,6 +1230,7 @@ nmMeasureFunc(r, type, clientData)
     TileType type;
     ClientData clientData;
 {
+    ARG_UNUSED(clientData);
     if(type == RtrMetalType)
 	nmMArea=nmMArea+(r->r_xtop-r->r_xbot)*(r->r_ytop-r->r_ybot);
     else

--- a/plot/plotCmd.c
+++ b/plot/plotCmd.c
@@ -90,6 +90,7 @@ CmdPlot(w, cmd)
     MagWindow *w;
     TxCommand *cmd;
 {
+    ARG_UNUSED(w);
     int option;
     const char * const *msg;
     MagWindow *window;
@@ -97,7 +98,6 @@ CmdPlot(w, cmd)
     TileTypeBitMask mask;
     CellDef *boxRootDef;
     SearchContext scx;
-    float width;
     int iwidth, scale;
 
 #if defined(HAVE_LIBCAIRO) && defined(MAGIC_WRAPPER)

--- a/plot/plotGremln.c
+++ b/plot/plotGremln.c
@@ -211,6 +211,9 @@ PlotGremlinTechLine(sectionName, argc, argv)
     int argc;			/* Number of arguments on line (unused). */
     char *argv[];		/* Pointers to fields of line (unused). */
 {
+    ARG_UNUSED(sectionName);
+    ARG_UNUSED(argc);
+    ARG_UNUSED(argv);
     return TRUE;
 }
 

--- a/plot/plotHP.c
+++ b/plot/plotHP.c
@@ -299,7 +299,7 @@ PlotDumpHPRTL(hpfile, kRaster, cRaster, mRaster, yRaster)
     Raster *mRaster;
     Raster *yRaster;
 {
-    int line, count, line_offset = 0;
+    int line, count;
     int ipl, bpl;
     register int *c, *m, *y, *k;
     unsigned char *obytes;	/* bytes to output (compressed) */

--- a/plot/plotPNM.c
+++ b/plot/plotPNM.c
@@ -398,7 +398,7 @@ pnmTile (tile, cxp)
     if (IsSplit(tile))
     {
 	TileType dinfo;
-	int w, h, llx, lly, urx, ury;
+	int llx, lly, urx, ury;
 	Rect scaledClip;
 
         type = (SplitSide(tile)) ? SplitRightType(tile) : SplitLeftType(tile);
@@ -577,9 +577,8 @@ PlotPNM(fileName, scx, layers, xMask, width)
 					 */
 {
     FILE *fp = NULL;
-    Rect bbox;
     int bb_ysize, bb_xsize;
-    int i, x, y, tile_ydelta;
+    int x, y, tile_ydelta;
     int save_ds, iter;
     int scale_over_2, ds_over_2;
     float *strip = NULL;
@@ -1132,6 +1131,7 @@ PlotPNMTechLine(sectionName, argc, argv)
     int argc;			/* Number of arguments on line. */
     char *argv[];		/* Pointers to fields of line. */
 {
+    ARG_UNUSED(sectionName);
     int i, j, k, style;
     void PlotPNMSetDefaults();	/* Forward declaration */
 
@@ -1356,7 +1356,7 @@ PlotLoadStyles(filename)
     char fullName[256];
     char *buf;
     int newsec;
-    int ord, mask, color, outline, nfill, stipple;
+    int ord, mask, color, outline, stipple;
     int ir, ig, ib;
     char shortname;
     char longname[128];

--- a/plot/plotPS.c
+++ b/plot/plotPS.c
@@ -111,7 +111,6 @@ static PSStyle *curStyle;	/* Current style being output. */
 static PSColor *curColor;	/* Current color being output. */
 static PSPattern *curPattern;	/* Current pattern being output. */
 static int curLineWidth;	/* Current line width */
-static int curFont;		/* Current font */
 static TileTypeBitMask curMask;	/* Layers currently being searched:  this
 				 * is the AND of the mask from curStyle and
 				 * the layers that the user specified.
@@ -174,7 +173,6 @@ PSReset()
 void
 PlotPSTechInit()
 {
-    int i, j;
     PSStyle *style;
     PSColor *color;
     PSPattern *pattern;
@@ -230,6 +228,7 @@ PlotPSTechLine(sectionName, argc, argv)
     int argc;			/* Number of arguments on line. */
     char *argv[];		/* Pointers to fields of line. */
 {
+    ARG_UNUSED(sectionName);
     PSStyle *newstyle;
     PSColor *newcolor;
     PSPattern *newpattern;
@@ -382,7 +381,7 @@ plotPSLine(p1, p2)
 				 * coordinates.
 				 */
 {
-    int x1, x2, y1, y2, limit, diff;
+    int x1, x2, y1, y2, limit;
     bool tmptf;
 
     /* Clip the line to the rectangular area being output.  First,
@@ -525,7 +524,6 @@ plotPSPaint(tile, cxp)
 	 * to corner, and skip the rest of this procedure.
 	 */
 
-	Point ul, lr;
 
 	if (curLineWidth != PS_MEDIUM) {
 	    fprintf(file, "l2\n");
@@ -1135,7 +1133,7 @@ PlotPS(fileName, scx, layers, xMask)
 {
     int xsize, ysize;
     float yscale;
-    int i, j;
+    int j;
     int twidth, theight;
     char *fontptr, *fptr2, *fptr3;
     char line_in[100];

--- a/plot/plotPixels.c
+++ b/plot/plotPixels.c
@@ -177,6 +177,9 @@ PlotPixTechLine(sectionName, argc, argv)
     int argc;			/* Number of arguments on line. */
     char *argv[];		/* Pointers to fields of line. */
 {
+    ARG_UNUSED(sectionName);
+    ARG_UNUSED(argc);
+    ARG_UNUSED(argv);
     return TRUE;
 }
 

--- a/plot/plotVers.c
+++ b/plot/plotVers.c
@@ -321,8 +321,8 @@ PlotVersTechLine(sectionName, argc, argv)
     int argc;			/* Number of arguments on line. */
     char *argv[];		/* Pointers to fields of line. */
 {
+    ARG_UNUSED(sectionName);
     VersatecStyle *new;
-    int i;
 
     new = (VersatecStyle *) mallocMagic(sizeof(VersatecStyle));
 
@@ -408,6 +408,7 @@ PlotColorVersTechLine(sectionName, argc, argv)
     int argc;			/* Number of arguments on line. */
     char *argv[];		/* Pointers to fields of line. */
 {
+    ARG_UNUSED(sectionName);
     VersatecStyle *new;
     static const struct { const char *l_str; int l_color; } colors[] = {
 	{"black",   BLACK},
@@ -420,7 +421,6 @@ PlotColorVersTechLine(sectionName, argc, argv)
 	{"Y",	   YELLOW},
 	{0}
     };
-    int i;
 
     new = (VersatecStyle *)mallocMagic(sizeof(VersatecStyle));
 
@@ -696,7 +696,6 @@ plotVersTile(tile, cxp)
 
     if (IsSplit(tile))
     {
-	int i, j;
 	TileType dinfo;
 	Rect r;
 
@@ -855,6 +854,7 @@ plotVersLabel(scx, label, tpath, raster)
     TerminalPath *tpath;	/* Ignored. */
     Raster *raster;		/* Raster to write to */
 {
+    ARG_UNUSED(tpath);
     Rect rootArea, swathArea, labelSize;
     Point point;
     int pos;

--- a/plow/PlowMain.c
+++ b/plow/PlowMain.c
@@ -991,6 +991,7 @@ plowSelPaintBox(rect, type, pSelBox)
     TileType type;
     Rect *pSelBox;
 {
+    ARG_UNUSED(type);
     Rect editRect;
 
     GeoTransRect(&RootToEditTransform, rect, &editRect);
@@ -1005,6 +1006,8 @@ plowSelCellBox(selUse, realUse, transform, pSelBox)
     Transform *transform;
     Rect *pSelBox;
 {
+    ARG_UNUSED(selUse);
+    ARG_UNUSED(transform);
     GeoInclude(&realUse->cu_bbox, pSelBox);
     return (0);
 }
@@ -1102,6 +1105,8 @@ plowSelCellPlow(selUse, realUse, transform, distance)
     Transform *transform;	/* UNUSED */
     int distance;		/* Plow distance */
 {
+    ARG_UNUSED(selUse);
+    ARG_UNUSED(transform);
     int plowFindSelCell();
     ClientData save;
 

--- a/plow/PlowQueue.c
+++ b/plow/PlowQueue.c
@@ -158,7 +158,6 @@ plowQueueAdd(eadd)
 				 * edge, respectively.
 				 */
 {
-    extern CellDef *plowYankDef;
     extern int plowQueuedEdges;
     int xbin = eadd->e_x - plowBinXBase;
     Edge *enew, *eprev, *ep;

--- a/plow/PlowRandom.c
+++ b/plow/PlowRandom.c
@@ -95,7 +95,6 @@ PlowRandomTest(def)
     static char *dirnames[] = { "up", "down", "right", "left" };
     Rect plowRect;
     int dir, plowDir;
-    Plane *savePlane;
 
 #ifdef	notdef
     strcpy(goodName, tempgood);

--- a/plow/PlowRules3.c
+++ b/plow/PlowRules3.c
@@ -203,6 +203,7 @@ scanDown(inarg, type, canMoveInargEdge)
     TileType type;
     bool canMoveInargEdge;
 {
+    ARG_UNUSED(canMoveInargEdge);
     TileType ltype = inarg->ina_moving->e_ltype;
     Edge *movingEdge = inarg->ina_moving;
     TileTypeBitMask badTypes;
@@ -298,6 +299,7 @@ scanUp(inarg, type, canMoveInargEdge)
     TileType type;
     bool canMoveInargEdge;
 {
+    ARG_UNUSED(canMoveInargEdge);
     TileType ltype = inarg->ina_moving->e_ltype;
     Edge *movingEdge = inarg->ina_moving;
     TileTypeBitMask badTypes;

--- a/plow/PlowTech.c
+++ b/plow/PlowTech.c
@@ -174,6 +174,7 @@ PlowDRCLine(sectionName, argc, argv)
     int argc;
     char *argv[];
 {
+    ARG_UNUSED(sectionName);
     int which;
     static const struct
     {
@@ -229,6 +230,7 @@ plowWidthRule(argc, argv)
     int argc;
     char *argv[];
 {
+    ARG_UNUSED(argc);
     char *layers = argv[1];
     int distance = atoi(argv[2]);
     TileTypeBitMask set, setC;
@@ -310,6 +312,7 @@ plowSpacingRule(argc, argv)
     int argc;
     char *argv[];
 {
+    ARG_UNUSED(argc);
     char *layers1 = argv[1], *layers2 = argv[2];
     int distance = atoi(argv[3]);
     char *adjacency = argv[4];
@@ -758,8 +761,6 @@ next:	;
 void
 PlowTechInit()
 {
-    register TileType i, j;
-    PlowRule *pr;
 
     PlowFixedTypes = DBZeroTypeBits;
     PlowCoveredTypes = DBZeroTypeBits;
@@ -814,6 +815,7 @@ PlowTechLine(sectionName, argc, argv)
     int argc;
     char *argv[];
 {
+    ARG_UNUSED(sectionName);
     TileTypeBitMask types;
 
     if (argc != 2)

--- a/plow/PlowTest.c
+++ b/plow/PlowTest.c
@@ -134,6 +134,7 @@ PlowTest(w, cmd)
     MagWindow *w;
     TxCommand *cmd;
 {
+    ARG_UNUSED(w);
     pCmd plowCmd, plowGetCommand();
     Rect editArea, dummyRect, rootBox, area2;
     CellDef *def, *rootBoxDef, *saveDef;

--- a/resis/ResJunct.c
+++ b/resis/ResJunct.c
@@ -121,6 +121,7 @@ ResNewSubDevice(tile, tp, xj, yj, direction, PendingList)
     int 	xj, yj, direction;
     resNode	**PendingList;
 {
+    ARG_UNUSED(direction);
     resNode	*resptr;
     resDevice	*resDev;
     tElement	*tcell;

--- a/resis/ResMain.c
+++ b/resis/ResMain.c
@@ -355,7 +355,6 @@ ResAddBreakpointFunc(tile, node)
    Tile *tile;
    ResSimNode *node;
 {
-    tileJunk *junk;
 
     if (TiGetClient(tile) == CLIENTDEFAULT)
 	return 0;
@@ -492,8 +491,6 @@ ResProcessTiles(goodies, origin)
     resNode	*resptr2;
     jElement	*workingj;
     cElement	*workingc;
-    ResFixPoint	*fix;
-    resNode	*resptr;
     int		(*tilefunc)();
 
 #ifdef LAPLACE
@@ -802,7 +799,6 @@ resExpandDevFunc(tile, cx)
     ResDevTile	    *thisDev = (ResDevTile *)cx->tc_filter->tf_arg;
     static Stack    *devExtentsStack = NULL;
     static Stack    *devResetStack = NULL;
-    TileTypeBitMask *rMask;
     Tile *tp, *tp2;
     TileType	ttype;
     int pNum;
@@ -923,7 +919,6 @@ ResShaveContacts(tile, def)
     CellDef *def;
 {
     TileType ttype;
-    TileTypeBitMask *rmask;
     Rect area;
     Plane *plane;
     int pNum;
@@ -981,7 +976,6 @@ ResExtractNet(node, goodies, cellname)
     Point		startpoint;
     static int		first = 1;
     ResDevTile		*DevTiles, *thisDev;
-    ResFixPoint		*fix;
     devPtr		*tptr;
     int			pNum;
     int			resMakeDevFunc();

--- a/resis/ResPrint.c
+++ b/resis/ResPrint.c
@@ -113,7 +113,7 @@ ResPrintExtDev(outextfile, devices)
     RDev	*devices;
 {
     char *subsName;
-    ExtDevice *devptr, *devtest;
+    ExtDevice *devptr;
 
     for (; devices != NULL; devices = devices->nextDev)
     {
@@ -389,7 +389,7 @@ ResPrintFHNodes(fp, nodelist, nodename, nidx, celldef)
     int		*nidx;
     CellDef	*celldef;
 {
-    char 	newname[16];
+    ARG_UNUSED(nodename);
     resNode	*nodeptr;
     resResistor	*resptr, *contact_res;
     resElement	*elemptr;
@@ -576,6 +576,7 @@ ResPrintFHRects(fp, reslist, nodename, eidx)
     char	*nodename;
     int		*eidx;		/* element (segment) index */
 {
+    ARG_UNUSED(nodename);
     resResistor	*resistors;
     float	oscale, thick, cwidth;
     int		edge;
@@ -677,6 +678,7 @@ ResPrintReference(fp, devices, cellDef)
     RDev	*devices;
     CellDef	*cellDef;
 {
+    ARG_UNUSED(devices);
     char 	*outfile = cellDef->cd_name;
     Rect	*bbox = &(cellDef->cd_bbox);
     int		numsegsx, numsegsy;

--- a/resis/ResReadSim.c
+++ b/resis/ResReadSim.c
@@ -124,6 +124,7 @@ ResReadSim(simfile, fetproc, capproc, resproc, attrproc, mergeproc, subproc)
     int	 (*attrproc)(), (*mergeproc)(), (*subproc)();
 
 {
+    ARG_UNUSED(mergeproc);
     char line[MAXLINE][MAXTOKEN];
     int	result, fettype, extfile;
     FILE *fp, *fopen();
@@ -255,7 +256,6 @@ ResReadNode(nodefile)
     HashEntry	*entry;
     ResSimNode	*node;
     char *cp;
-    float lambda;
 
     fp = PaOpen(nodefile, "r", ".nodes", ".", (char *)NULL, (char **)NULL);
     if (fp == NULL)
@@ -360,7 +360,6 @@ ResSimSubckt(line)
 {
     RDev	*device;
     int		rvalue, i, j, k;
-    static int	nowarning = TRUE;
     float	lambda;
     TileType	ttype = TT_SPACE;
     char	*lptr = NULL, *wptr = NULL;
@@ -498,7 +497,7 @@ ResSimDevice(line, rpersquare, devptr)
 
 {
     RDev	*device;
-    int		rvalue, i, j, k;
+    int		rvalue, i;
     char	*newattr, tmpattr[MAXTOKEN];
     static int	nowarning = TRUE;
     float	lambda;

--- a/resis/ResRex.c
+++ b/resis/ResRex.c
@@ -244,6 +244,7 @@ CmdExtResis(win, cmd)
     MagWindow *win;
     TxCommand *cmd;
 {
+    ARG_UNUSED(win);
     int i, j, k, option, value, saveFlags;
     static int init = 1;
     static float rthresh, tdiTolerance, fhFrequency;
@@ -759,6 +760,7 @@ resPortFunc(scx, lab, tpath, result)
     TerminalPath *tpath;
     int *result;
 {
+    ARG_UNUSED(tpath);
     Rect r;
     int pclass, puse;
     Point portloc;
@@ -993,7 +995,6 @@ ResCheckSimNodes(celldef, resisdata)
     int		total =0;
     char	*outfile = celldef->cd_name;
     float	rctol = resisdata->tdiTolerance;
-    float	rthresh = resisdata->rthresh;
     int		nidx = 1, eidx = 1;	/* node & segment counters for geom. */
 
     if (ResOptionsFlags & ResOpt_DoExtFile)
@@ -1203,7 +1204,6 @@ ResCheckSimNodes(celldef, resisdata)
 	if ((node->resistance > ftolerance) || (node->status & FORCE) ||
 		(ResOpt_ExtractAll & ResOptionsFlags))
 	{
-	    ResFixPoint	fp;
 
 	    failed1++;
 	    if (ResExtractNet(node, &gparams, outfile) != 0)
@@ -1767,6 +1767,7 @@ ResAlignNodes(nodelist, reslist)
     resNode	*nodelist;
     resResistor *reslist;
 {
+    ARG_UNUSED(nodelist);
     resResistor *resistor;
     resNode	*node1;
     short	i;

--- a/resis/ResUtils.c
+++ b/resis/ResUtils.c
@@ -149,6 +149,7 @@ ResEach(tile, pNum, arg)
     int		pNum;
     FindRegion	*arg;
 {
+    ARG_UNUSED(pNum);
 
     if (((ResContactPoint *)(arg->fra_region))->cp_contactTile != tile)
     {
@@ -656,6 +657,7 @@ ResRemovePlumbing(tile, arg)
     ClientData	*arg;
 
 {
+    ARG_UNUSED(arg);
     ClientData ticlient = TiGetClient(tile);
     if (ticlient != CLIENTDEFAULT)
     {

--- a/router/rtrCmd.c
+++ b/router/rtrCmd.c
@@ -192,6 +192,7 @@ CmdChannel(w, cmd)
     MagWindow *w;
     TxCommand *cmd;
 {
+    ARG_UNUSED(w);
     Rect newBox;
     CellDef *def, *RtrDecomposeName();
     char *name;
@@ -266,7 +267,6 @@ CmdGaRoute(w, cmd)
     char *name, *channame;
     int n, chanType;
     Rect editArea;
-    FILE *f;
     static const struct
     {
 	const char *cmd_name;
@@ -784,6 +784,7 @@ CmdSeeFlags(w, cmd)
     MagWindow * w;
     TxCommand *cmd;
 {
+    ARG_UNUSED(w);
     Rect      rootRect;
     Point     point;
     MagWindow * window;

--- a/router/rtrDcmpose.c
+++ b/router/rtrDcmpose.c
@@ -169,6 +169,7 @@ RtrDecompose(routeUse, area, netList)
     Rect *area;
     NLNetList *netList;
 {
+    ARG_UNUSED(netList);
     SearchContext scx;
     CellDef *cdTo;
     int tmp;

--- a/router/rtrStem.c
+++ b/router/rtrStem.c
@@ -241,6 +241,7 @@ RtrStemAssignExt(use, doWarn, loc, term, net)
     NLTerm *term;	/* For nterm_name */
     NLNet *net;		/* For marking pin */
 {
+    ARG_UNUSED(term);
     TileType type = loc->nloc_label->lab_type;
     int dirMask, termWidth, pins;
     Rect r, errorArea;
@@ -519,6 +520,7 @@ int
 rtrAbort(tile)
     Tile *tile;
 {
+    ARG_UNUSED(tile);
     return 1;
 }
 
@@ -654,7 +656,7 @@ rtrTreeSrArea(loc, dir, p, use)
     Point *p;		/* Point at channel boundary */
     CellUse *use;	/* Parent cell use */
 {
-    Rect tmp, tmp1, tmp2;
+    Rect tmp, tmp1;
     Point contact, jog, start;
     int i, width = MAX(RtrMetalWidth, RtrPolyWidth);
     int delta;

--- a/router/rtrTech.c
+++ b/router/rtrTech.c
@@ -134,6 +134,7 @@ RtrTechLine(sectionName, argc, argv)
     int argc;				/* Number of fields on line. */
     char *argv[];			/* Values of fields. */
 {
+    ARG_UNUSED(sectionName);
     TileTypeBitMask mask;
     int type, width, i, distance;
     char **nextArg;

--- a/router/rtrTravers.c
+++ b/router/rtrTravers.c
@@ -443,6 +443,7 @@ rtrExamineStack(tile, ts)
     Tile *tile;
     struct rtrTileStack *ts;
 {
+    ARG_UNUSED(tile);
     int i;
     Tile *tp[3];
     struct conSrArg *csa = ts->ts_csa;

--- a/router/rtrVia.c
+++ b/router/rtrVia.c
@@ -118,6 +118,8 @@ rtrFollowLocFunc(rect, name, label, area)
 				 * all the tiles we delete.
 				 */
 {
+    ARG_UNUSED(name);
+    ARG_UNUSED(area);
     CellDef *def = EditCellUse->cu_def;
     Rect initialArea;
 

--- a/select/selCreate.c
+++ b/select/selCreate.c
@@ -291,7 +291,6 @@ int
 selIntersectPaintFunc(tile)
     Tile *tile;			/* The tile to copy paint from. */
 {
-    TileTypeBitMask tMask;
     Rect r;
     int pNum;
 
@@ -344,8 +343,7 @@ SelectIntersect(scx, type, xMask, negate)
 				 */
     bool negate;		/* If true, search on NOT(type) */
 {
-    TileTypeBitMask tMask, rMask;
-    TileType s, t;
+    TileTypeBitMask tMask;
     int plane;
     SearchContext scx2;
 
@@ -703,7 +701,6 @@ SelectChunk(scx, type, xMask, pArea, less)
 #define INITIALSIZE 10
     SearchContext newscx;
     TileTypeBitMask wrongTypes, typeMask;
-    TileType ttype;
     Rect bestChunk;
     int bestMin, bestMax, width, height;
     extern int selSplitFunc();		/* Forward reference. */
@@ -1225,7 +1222,7 @@ SelectAndCopy2(newSourceDef)
 					 */
 {
     SearchContext scx;
-    Rect editArea, labelArea, expanded;
+    Rect editArea;
     int plane;
     int (*savedPaintPlane)();
     extern int selACPaintFunc();	/* Forward reference. */

--- a/select/selEnum.c
+++ b/select/selEnum.c
@@ -186,7 +186,6 @@ selEnumPFunc1(tile, arg)
 {
     Rect editRect, rootRect;
     TileType loctype;
-    TileTypeBitMask uMask;
     extern int selEnumPFunc2();
 
     TiToRect(tile, &arg->sea_rect);
@@ -916,6 +915,7 @@ selEnumLFunc(scx, label, tpath, arg)
     TerminalPath *tpath;	/* Ignored. */
     struct searg *arg;		/* Indicates what we're looking for. */
 {
+    ARG_UNUSED(tpath);
     Rect *want, got;
 
     GeoTransRect(&scx->scx_trans, &label->lab_rect, &got);
@@ -951,6 +951,7 @@ selEnumLFunc2(scx, label, tpath, arg)
     TerminalPath *tpath;	/* Ignored. */
     struct searg *arg;		/* Indicates what we're looking for. */
 {
+    ARG_UNUSED(tpath);
     Rect *want, got;
     int mismatch = 0;
 

--- a/select/selOps.c
+++ b/select/selOps.c
@@ -241,6 +241,7 @@ selDelCellFunc(selUse, use)
     CellUse *selUse;		/* Not used. */
     CellUse *use;		/* What to delete. */
 {
+    ARG_UNUSED(selUse);
     if (use->cu_flags & CU_LOCKED) return 0;
 
     DBUnLinkCell(use, use->cu_parent);
@@ -793,6 +794,7 @@ selShortFindForward(srctile, srctype, srcpnum, desttile)
     int srcpnum;
     Tile *desttile;
 {
+    ARG_UNUSED(desttile);
     TileType type;
     TileTypeBitMask *lmask;
     Tile *tile, *tp;
@@ -1112,6 +1114,7 @@ selTransCellFunc(selUse, realUse, realTrans, transform)
 				 * copying.
 				 */
 {
+    ARG_UNUSED(realTrans);
     CellUse  *newUse;
     Transform newTrans;
 
@@ -1150,6 +1153,7 @@ selTransLabelFunc(label, cellUse, defTransform, transform)
 				 * Select2Def.
 				 */
 {
+    ARG_UNUSED(cellUse);
     Rect rootArea, finalArea;
     int rootJust, finalJust;
     Point rootOffset, finalOffset;
@@ -1253,6 +1257,7 @@ selExpandFunc(selUse, use, transform, mask)
     Transform *transform;	/* Not used. */
     int mask;			/* Windows in which to expand. */
 {
+    ARG_UNUSED(transform);
     /* Don't change expansion status of root cell:  screws up
      * DBWAreaChanged (need to always have at least top-level
      * cell be expanded).
@@ -1381,6 +1386,7 @@ selArrayCFunc(selUse, use, transform, arrayInfo)
     Transform *transform;	/* Transform from use->cu_def to root. */
     ArrayInfo *arrayInfo;	/* Array characteristics desired. */
 {
+    ARG_UNUSED(selUse);
     CellUse *newUse;
     Transform tinv, newTrans;
     Rect tmp, oldBbox;
@@ -1439,6 +1445,7 @@ selArrayLFunc(label, use, transform, arrayInfo)
     Transform *transform;	/* Transform from coords of def to root. */
     ArrayInfo *arrayInfo;	/* How to replicate. */
 {
+    ARG_UNUSED(use);
     int y, nx, ny, rootJust, rootRotate;
     Point rootOffset;
     Rect original, current;
@@ -1634,7 +1641,7 @@ selStretchEraseFunc(tile, plane)
     int planeNum;
     planeAndArea pa;
     TileType type, t;
-    TileTypeBitMask tmpmask, mask, *residueMask;
+    TileTypeBitMask tmpmask, mask;
     PaintUndoInfo ui;
     PaintResultType selStretchEraseTbl[NT];
     extern int selStretchEraseFunc2();
@@ -1916,7 +1923,7 @@ selStretchFillFunc3(tile, area)
 {
     Rect editArea, rootArea;
     TileType type, stype;
-    TileTypeBitMask *mask, *sMask, *tMask;
+    TileTypeBitMask *sMask, *tMask;
     StretchArea *sa;
 
     /* Compute the area to be painted. */

--- a/select/selUnselect.c
+++ b/select/selUnselect.c
@@ -48,6 +48,7 @@ selUnselFunc(tile, arg)
      Tile *tile;
      ClientData *arg;
 {
+    ARG_UNUSED(arg);
   TileType type;
   Rect rect;
 
@@ -214,6 +215,7 @@ selRemoveLabelPaintFunc(tile, label)
      Tile *tile;
      Label *label;
 {
+    ARG_UNUSED(tile);
   (void) DBPutFontLabel(Select2Def, &label->lab_rect, label->lab_font,
 	label->lab_size, label->lab_rotate, &label->lab_offset,
 	label->lab_just, label->lab_text, label->lab_type,

--- a/sim/SimExtract.c
+++ b/sim/SimExtract.c
@@ -222,7 +222,6 @@ SimAddNodeList(
 void
 SimFreeNodeRegs(void)
 {
-    NodeRegion *p, *q;
 
     if( NodeRegList != (NodeRegion *) NULL )		/* sanity */
 	ExtFreeLabRegions((LabRegion *) NodeRegList );
@@ -242,7 +241,7 @@ SimFreeNodeRegs(void)
 int
 SimInitConnTables(void)
 {
-    int  i, t, sd, p;
+    int  i, t, sd;
     ExtDevice *devptr;
 
     SimTransMask = ExtCurStyle->exts_deviceMask;
@@ -480,6 +479,7 @@ SimTransistorTile(
     int		pNum,
     FindRegion	*arg)
 {
+    ARG_UNUSED(arg);
     int i;
     TileType t;
     ExtDevice *devptr;
@@ -709,7 +709,6 @@ SimGetNodeName(
 					 */
     const char		*path)		/* path name of hierarchy of search */
 {
-    CellDef	*def = sx->scx_use->cu_def;
     NodeRegion 	*nodeList;
     LabelList 	*ll;
     static char nodename[256];

--- a/sim/SimSelect.c
+++ b/sim/SimSelect.c
@@ -18,10 +18,6 @@
  * of California
  */
 
-#ifndef lint
-static const char sccsid[] = "@(#)SimSelect.c	4.14 MAGIC (Berkeley) 10/3/85";
-#endif  /* not lint */
-
 #include <stdio.h>
 #include <string.h>
 

--- a/tcltk/tclmagic.c
+++ b/tcltk/tclmagic.c
@@ -301,6 +301,8 @@ static int
 AddCommandTag(ClientData clientData,
         Tcl_Interp *interp, int argc, char *argv[])
 {
+    ARG_UNUSED(clientData);
+    ARG_UNUSED(interp);
     HashEntry *entry;
     char *hstring;
     int argstart = 1, idx;
@@ -540,7 +542,6 @@ _tk_dispatch(ClientData clientData,
         Tcl_Interp *interp, int argc, char *argv[])
 {
     int id;
-    char *tkpath;
     char *arg0;
     Point txp;
 
@@ -662,12 +663,12 @@ static int
 _magic_initialize(ClientData clientData,
         Tcl_Interp *interp, int argc, char *argv[])
 {
+    ARG_UNUSED(clientData);
     WindClient client;
-    int n, i;
+    int n;
     char keyword[100];
     char *kwptr = keyword + 7;
     const char * const *commandTable;
-    int result;
 
     /* Is magic being executed in a slave interpreter? */
 
@@ -781,6 +782,7 @@ static int
 _magic_flags(ClientData clientData,
         Tcl_Interp *interp, int objc, Tcl_Obj *const objv[])
 {
+    ARG_UNUSED(clientData);
     int index, index2;
     bool value;
     static char *flagOptions[] = {"debug", "recover", "silent",
@@ -877,6 +879,10 @@ static int
 _magic_display(ClientData clientData,
         Tcl_Interp *interp, int argc, char *argv[])
 {
+    ARG_UNUSED(clientData);
+    ARG_UNUSED(interp);
+    ARG_UNUSED(argc);
+    ARG_UNUSED(argv);
     /* Set the result to the name of the graphics mode used. */
     Tcl_SetResult(magicinterp, MainDisplayType, NULL);
     return TCL_OK;
@@ -892,6 +898,9 @@ static int
 _magic_startup(ClientData clientData,
         Tcl_Interp *interp, int argc, char *argv[])
 {
+    ARG_UNUSED(clientData);
+    ARG_UNUSED(argc);
+    ARG_UNUSED(argv);
     /* Execute contents of startup files and load any initial cell */
 
     if (mainInitFinal() != 0)
@@ -1050,7 +1059,6 @@ TxGetLinePfix(dest, maxChars, prefix)
     char *prefix;
 {
     Tcl_Obj *objPtr;
-    int charsStored;
 #if TCL_MAJOR_VERSION < 9
     int length;
 #else
@@ -1229,7 +1237,7 @@ Tcl_printf(FILE *f, const char *fmt, va_list args_in)
     va_list args;
     static char outstr[128] = "puts -nonewline std";
     char *outptr, *bigstr = NULL, *finalstr = NULL;
-    int i, nchars, result, escapes = 0, limit;
+    int i, nchars, result, escapes = 0;
     Tcl_Interp *printinterp = (TxTkOutput) ? consoleinterp : magicinterp;
 
     strcpy (outstr + 19, (f == stderr) ? "err \"" : "out \"");
@@ -1375,7 +1383,7 @@ TerminalInputProc(instanceData, buf, toRead, errorCodePtr)
     int *errorCodePtr;
 {
     FileState *fsPtr = (FileState *)instanceData;
-    int bytesRead, i, tlen;
+    int bytesRead, tlen;
     char *locbuf;
 
     *errorCodePtr = 0;

--- a/textio/txCommands.c
+++ b/textio/txCommands.c
@@ -137,11 +137,6 @@ int TxCurButtons = 0;
 int TxCommandNumber = 0;
 
 /*
- * The "cmd" structure is shared by lisp and eval using this pointer
- */
-static TxCommand *lisp_cur_cmd = NULL;
-
-/*
  * ----------------------------------------------------------------------------
  *
  * FD_IsZero --
@@ -718,7 +713,6 @@ TxLogStart(
     else
     {
 	time_t t_stamp = time((time_t *)NULL);
-	struct tm *clock = localtime(&t_stamp);
 	char *now = ctime(&t_stamp);
 
 	TxPrintf("Logging commands to file \"%s\"\n", fileName);
@@ -1176,6 +1170,8 @@ TxParseString_internal(
     DQueue *q,
     TxInputEvent *event)
 {
+    ARG_UNUSED(q);
+    ARG_UNUSED(event);
     TxParseString(str);
 }
 

--- a/textio/txInput.c
+++ b/textio/txInput.c
@@ -1006,8 +1006,7 @@ TxGetLineWPrompt(
     const char *prompt,
     const char *prefix)
 {
-    char *res, *hist_res, *tmp;
-    int return_nothing = 0;
+    char *res;
 
     if (txHavePrompt) TxUnPrompt();
 #ifndef USE_READLINE

--- a/textio/txOutput.c
+++ b/textio/txOutput.c
@@ -51,7 +51,6 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
  */
 
 FILE * TxMoreFile = NULL;
-static int txMorePid;
 static bool txPrintFlag = TRUE;
 
 

--- a/utils/geometry.c
+++ b/utils/geometry.c
@@ -946,6 +946,8 @@ GeoDummyFunc(
     const Rect *box,
     ClientData cdarg)
 {
+    ARG_UNUSED(box);
+    ARG_UNUSED(cdarg);
     return TRUE;
 }
 

--- a/utils/getrect.c
+++ b/utils/getrect.c
@@ -62,7 +62,6 @@ GetRect(fin, skip, rect, scalen, scaled)
     int scaled;			/* Scale down by this amount */
 {
     int n, c;
-    char *cp;
     bool isNegative;
     int dir = 0x1;
 

--- a/utils/ihash.c
+++ b/utils/ihash.c
@@ -42,7 +42,6 @@
 
 #define DEREF(ptr,offset) (((char*)ptr)+(offset))
 
-static char rcsid[] = "$Header$";
 #include <string.h>
 #include <stdio.h>
 #include "utils/magic.h"
@@ -128,8 +127,6 @@ void *IHashLookUpNext(IHashTable *table, void *prevEntry)
 {
   void *entry;
   void *key = DEREF(prevEntry,table->iht_keyOffset);
-  int hash = (table->iht_hashFn)(key);
-  int bucket = ABS(hash) % table->iht_nBuckets;
 
   for(entry = *((void **) DEREF(prevEntry,table->iht_nextOffset));
       entry && !(table->iht_sameKeyFn)(key,DEREF(entry,table->iht_keyOffset));

--- a/utils/macros.c
+++ b/utils/macros.c
@@ -101,7 +101,7 @@ MacroDefineByName(clientName, xc, str, help, imacro)
     bool imacro;	/* is this an interactive macro? */
 {
     HashEntry *h;
-    HashTable *clienttable, newTable;
+    HashTable *clienttable;
     macrodef *oldMacro, *newMacro;
 
     /* If a macro exists, delete the old string and redefine it */
@@ -464,7 +464,6 @@ MacroCopy(client, clientkey)
     char *clientkey;	/* Name of client to copy macros to */
 {
     HashTable *clienttable;
-    HashTable *copytable;
     HashEntry *h, *he;
     HashSearch hs;
     char *clientName;

--- a/utils/magic.h
+++ b/utils/magic.h
@@ -189,8 +189,6 @@ extern char AbortMessage[];
  #define ANALYSER_CSTRING(n) __attribute__((null_terminated_string_arg(n)))
  #define ANALYSER_FD_ARG(fd) __attribute__((fd_arg(fd)))
  #define ANALYSER_MALLOC(dealloc, idx) __attribute__((malloc, malloc(dealloc, idx)))
- /* looking to squash excessive -Wpedantic warnings ? add into defs.mak: CPPFLAGS += -Wno-variadic-macros */
- #define ANALYSER_NONNULL(n...) __attribute__((nonnull(n)))
  #define ANALYSER_RETURNS_NONNULL __attribute__((returns_nonnull))
 #else
  #define ATTR_FORMAT_PRINTF_1 /* */
@@ -203,9 +201,11 @@ extern char AbortMessage[];
  #define ANALYSER_CSTRING(n) /* */
  #define ANALYSER_FD_ARG(fd) /* */
  #define ANALYSER_MALLOC(dealloc, idx) /* */
- #define ANALYSER_NONNULL(n...) /* */
  #define ANALYSER_RETURNS_NONNULL /* */
 #endif
+
+/* ---------------- Miscellaneous Helper Macros -------------------------- */
+#define ARG_UNUSED(arg) (void) arg
 
 /* ---------------- Start of Machine Configuration Section ----------------- */
 

--- a/utils/main.c
+++ b/utils/main.c
@@ -511,6 +511,8 @@ mainInitBeforeArgs(argc, argv)
     int argc;
     char *argv[];
 {
+    ARG_UNUSED(argc);
+    ARG_UNUSED(argv);
     TechOverridesDefault = FALSE;
     if (Path == NULL)
 	Path = StrDup((char **) NULL, ".");

--- a/utils/maxrect.c
+++ b/utils/maxrect.c
@@ -32,8 +32,6 @@ genCanonicalMaxwidth(bbox, starttile, plane, mask)
     Plane	*plane;		/* Plane being searched */
     TileTypeBitMask *mask;	/* Mask of types to check */
 {
-    int		    s;
-    Tile	    *tile, *tp;
     TileTypeBitMask wrongtypes;
     static MaxRectsData *mrd = (MaxRectsData *)NULL;
     Rect	    boundorig;
@@ -251,9 +249,9 @@ FindMaxRectangle(bbox, startpoint, plane, expandtypes)
     Plane *plane;			/* plane of types to expand */
     TileTypeBitMask *expandtypes;	/* types to expand in */
 {
+    ARG_UNUSED(expandtypes);
     MaxRectsData *mrd;
     Tile *starttile;
-    TileType tt;
     int rectArea;
     int maxarea = 0;
     int s, sidx = -1;
@@ -310,7 +308,6 @@ FindMaxRectangle2(bbox, starttile, plane, expandtypes)
     TileTypeBitMask *expandtypes;	/* types to expand in, may be NULL */
 {
     MaxRectsData *mrd;
-    TileType tt;
     int rectArea;
     int maxarea = 0;
     int s, sidx = -1;

--- a/utils/netlist.c
+++ b/utils/netlist.c
@@ -218,6 +218,7 @@ nlLabelFunc(area, name, label, term)
     Label *label;	/* Label within scx->scx_use->cu_def */
     NLTerm *term;	/* Prepend new NLTermLoc to this terminal */
 {
+    ARG_UNUSED(name);
     NLTermLoc *loc;
 
     loc = (NLTermLoc *) mallocMagic((unsigned) (sizeof (NLTermLoc)));

--- a/utils/niceabort.c
+++ b/utils/niceabort.c
@@ -61,7 +61,7 @@ void
 DumpCore()
 {
     int parentPid = getpid();
-    int cpid, gcpid, wpid;
+    int cpid, gcpid;
     FILE *commentFile, *crashFile;
     time_t now;
     char pidString[20], line[150], command[512], tempName[200], *crashDir;

--- a/utils/signals.c
+++ b/utils/signals.c
@@ -164,6 +164,7 @@ SigRemoveTimer()
 sigRetVal
 sigOnAlarm(int signo)
 {
+    ARG_UNUSED(signo);
     if (GrDisplayStatus == DISPLAY_IN_PROGRESS)
 	GrDisplayStatus = DISPLAY_BREAK_PENDING;
 
@@ -205,6 +206,7 @@ SigTimerInterrupts()
 sigRetVal
 sigOnStop(int signo)
 {
+    ARG_UNUSED(signo);
     /* fix things up */
     TxResetTerminal(TRUE);
     GrStop();
@@ -410,6 +412,7 @@ SigUnWatchFile(filenum, filename)
 				 * calls (such as windows: /dev/winXX).
 				 */
 {
+    ARG_UNUSED(filename);
     int flags;
 
     flags = fcntl(filenum, F_GETFL, 0);
@@ -448,6 +451,7 @@ SigUnWatchFile(filenum, filename)
 sigRetVal
 sigOnInterrupt(int signo)
 {
+    ARG_UNUSED(signo);
     if (sigNumDisables != 0)
 	sigInterruptReceived = TRUE;
     else
@@ -476,6 +480,7 @@ sigOnInterrupt(int signo)
 sigRetVal
 sigOnTerm(int signo)
 {
+    ARG_UNUSED(signo);
     DBWriteBackup(NULL);
     exit (1);
 }
@@ -499,6 +504,7 @@ sigOnTerm(int signo)
 sigRetVal
 sigOnWinch(int signo)
 {
+    ARG_UNUSED(signo);
     SigGotSigWinch = TRUE;
     sigReturn;
 }
@@ -520,6 +526,7 @@ sigOnWinch(int signo)
 sigRetVal
 sigIO(int signo)
 {
+    ARG_UNUSED(signo);
     SigIOReady = TRUE;
     if (SigInterruptOnSigIO == 1) sigOnInterrupt(0);
     sigReturn;

--- a/utils/stack.c
+++ b/utils/stack.c
@@ -281,6 +281,7 @@ stackCopyFn(stackItem, i, cd)
     int i;
     ClientData cd;
 {
+    ARG_UNUSED(i);
     if(stackCopyStr)
 	StackPush((ClientData) StrDup((char **) NULL, (char *)stackItem), (Stack *) cd);
     else

--- a/utils/undo.c
+++ b/utils/undo.c
@@ -234,6 +234,8 @@ UndoInit(logFileName, mode)
 			 */
     char *mode;		/* Mode for opening.  Must be "r", "rw", or "w" */
 {
+    ARG_UNUSED(logFileName);
+    ARG_UNUSED(mode);
     UndoDisableCount = 0;
     undoLogTail = NULL;
     undoLogCur = NULL;
@@ -336,6 +338,8 @@ UndoAddClient(init, done, readEvent, writeEvent, forwEvent, backEvent, name)
     void (*forwEvent)(), (*backEvent)();
     char *name;
 {
+    ARG_UNUSED(readEvent);
+    ARG_UNUSED(writeEvent);
     if (undoNumClients >= MAXUNDOCLIENTS)
 	return ((UndoType) -1);
 

--- a/windows/windClient.c
+++ b/windows/windClient.c
@@ -345,6 +345,7 @@ windFrameUp(w, cmd)
     MagWindow *w;
     TxCommand *cmd;
 {
+    ARG_UNUSED(w);
     if (WindNewButtons == 0)
     {
 	GrSetCursor(STYLE_CURS_NORMAL);
@@ -642,7 +643,6 @@ windCmdInterp(w, cmd)
     MagWindow *w;
     TxCommand *cmd;
 {
-    int cmdNum;
 
     switch (cmd->tx_button)
     {

--- a/windows/windCmdAM.c
+++ b/windows/windCmdAM.c
@@ -153,7 +153,6 @@ windCaptionCmd(w, cmd)
     TxCommand *cmd;
 {
     int place;
-    Rect ts;
     static const char * const onoff[] = {"on", "off", 0};
     static const bool truth[] = {TRUE, FALSE};
 
@@ -414,6 +413,7 @@ windCrashCmd(w, cmd)
     MagWindow *w;
     TxCommand *cmd;
 {
+    ARG_UNUSED(w);
     if (cmd->tx_argc != 1)
     {
 	TxError("Usage:  *crash\n");
@@ -576,6 +576,7 @@ windDebugCmd(w, cmd)
     MagWindow *w;
     TxCommand *cmd;
 {
+    ARG_UNUSED(w);
     if (cmd->tx_argc != 1) goto usage;
     windPrintCommands = !windPrintCommands;
     TxError("Window command debugging set to %s\n",
@@ -605,6 +606,8 @@ windDumpCmd(w, cmd)
     MagWindow *w;
     TxCommand *cmd;
 {
+    ARG_UNUSED(w);
+    ARG_UNUSED(cmd);
     (void) windDump();
 }
 
@@ -674,6 +677,8 @@ windFilesCmd(w, cmd)
     MagWindow *w;
     TxCommand *cmd;
 {
+    ARG_UNUSED(w);
+    ARG_UNUSED(cmd);
 #define NUM_FD	20	/* max number of open files per process */
     int fd;
     struct stat buf;
@@ -728,6 +733,7 @@ windGrowCmd(w, cmd)
     MagWindow *w;
     TxCommand *cmd;
 {
+    ARG_UNUSED(cmd);
     if (w == NULL)
     {
 	TxError("Point to a window first.\n");
@@ -863,6 +869,8 @@ windHelpCmd(w, cmd)
     MagWindow *w;
     TxCommand *cmd;
 {
+    ARG_UNUSED(w);
+    ARG_UNUSED(cmd);
     ASSERT(FALSE, windHelpCmd);
 }
 

--- a/windows/windCmdNR.c
+++ b/windows/windCmdNR.c
@@ -152,6 +152,7 @@ windPauseCmd(w, cmd)
     MagWindow *w;
     TxCommand *cmd;
 {
+    ARG_UNUSED(w);
     int i;
     static char ssline[TX_MAX_CMDLEN];
 
@@ -263,6 +264,7 @@ windQuitCmd(w, cmd)
     MagWindow *w;
     TxCommand *cmd;
 {
+    ARG_UNUSED(w);
     clientRec *cr;
     bool checkfirst = TRUE;
     int exit_status = 0;
@@ -336,6 +338,7 @@ windRedoCmd(w, cmd)
     MagWindow *w;
     TxCommand *cmd;
 {
+    ARG_UNUSED(w);
     int count;
 
     if (cmd->tx_argc > 3)
@@ -410,6 +413,8 @@ windRedrawCmd(w, cmd)
     MagWindow *w;
     TxCommand *cmd;
 {
+    ARG_UNUSED(w);
+    ARG_UNUSED(cmd);
    WindAreaChanged((MagWindow *) NULL, (Rect *) NULL);
 }
 
@@ -436,6 +441,7 @@ windResetCmd(w, cmd)
     MagWindow *w;
     TxCommand *cmd;
 {
+    ARG_UNUSED(w);
     if (cmd->tx_argc != 1)
     {
 	TxError("Usage: %s\n", cmd->tx_argv[0]);

--- a/windows/windCmdSZ.c
+++ b/windows/windCmdSZ.c
@@ -79,7 +79,7 @@ windScrollCmd(w, cmd)
     Rect r;
     int xsize, ysize;
     Point p;
-    int pos, locargc = cmd->tx_argc;
+    int pos;
     float amount;
     bool doFractional = FALSE;
 
@@ -320,6 +320,7 @@ windSleepCmd(w, cmd)
     MagWindow *w;
     TxCommand *cmd;
 {
+    ARG_UNUSED(w);
     int time;
 
     if (cmd->tx_argc != 2)
@@ -635,6 +636,7 @@ windUndoCmd(w, cmd)
     MagWindow *w;
     TxCommand *cmd;
 {
+    ARG_UNUSED(w);
     int count;
 
     if (cmd->tx_argc > 3)
@@ -717,6 +719,7 @@ windUpdateCmd(w, cmd)
     MagWindow *w;
     TxCommand *cmd;
 {
+    ARG_UNUSED(w);
     if (cmd->tx_argc == 1)
 	WindUpdate();
 #ifdef MAGIC_WRAPPER
@@ -763,6 +766,7 @@ windVersionCmd(w, cmd)
     MagWindow *w;
     TxCommand *cmd;
 {
+    ARG_UNUSED(w);
     if (cmd->tx_argc != 1) {
 	TxError("Usage: %s\n", cmd->tx_argv[0]);
 	return;
@@ -813,7 +817,7 @@ windViewCmd(w, cmd)
     else if (cmd->tx_argc == 2)
     {
 #ifdef MAGIC_WRAPPER
-	Tcl_Obj *listxy, *fval;
+	Tcl_Obj *listxy;
 
 	listxy = Tcl_NewListObj(0, NULL);
 #endif
@@ -928,6 +932,7 @@ windXviewCmd(w, cmd)
     MagWindow *w;
     TxCommand *cmd;
 {
+    ARG_UNUSED(cmd);
     CellUse *celluse;
     int ViewUnexpandFunc();
 
@@ -989,6 +994,7 @@ windScrollBarsCmd(w, cmd)
     MagWindow *w;
     TxCommand *cmd;
 {
+    ARG_UNUSED(w);
     int place;
     static const char * const onoff[] = {"on", "off", 0};
     static const bool truth[] = {TRUE, FALSE};
@@ -1120,6 +1126,7 @@ windPositionsCmd(w, cmd)
     MagWindow *w;
     TxCommand *cmd;
 {
+    ARG_UNUSED(w);
     extern int windPositionsFunc();
     char *filename = NULL;
     cdwpos windpos;

--- a/windows/windDisp.c
+++ b/windows/windDisp.c
@@ -967,6 +967,7 @@ windBackgroundFunc(tile, notUsed)
     Tile *tile;
     ClientData notUsed;
 {
+    ARG_UNUSED(notUsed);
     Rect area;
 
     if (TiGetType(tile) == (TileType) TT_SPACE) return 0;

--- a/windows/windMain.c
+++ b/windows/windMain.c
@@ -370,7 +370,6 @@ WindNextClient(client)
     WindClient client;
 {
     clientRec *cr = (clientRec *)client;
-    int length;
 
     if (cr == NULL)
 	return (WindClient)windFirstClientRec;

--- a/windows/windMove.c
+++ b/windows/windMove.c
@@ -196,6 +196,7 @@ void
 windSetWindowPosition(w)
     MagWindow *w;
 {
+    ARG_UNUSED(w);
 }
 
 /*
@@ -264,6 +265,7 @@ WindCreate(client, frameArea, isHint, argc, argv)
     int argc;			/* Passed to the client */
     char *argv[];
 {
+    ARG_UNUSED(isHint);
     MagWindow *w;
     clientRec *cr;
     bool OK;

--- a/wiring/wireOps.c
+++ b/wiring/wireOps.c
@@ -561,9 +561,8 @@ WireAddLeg(
 void
 WireShowLeg(void)
 {
-    Rect current, new, leg, editArea, *rect = &current;
+    Rect current, new, *rect = &current;
     CellDef *boxRootDef;
-    SearchContext scx;
     Point cursorPos, *point = &cursorPos;
     TileTypeBitMask mask;
     int direction = WIRE_CHOOSE;
@@ -1078,6 +1077,7 @@ WireButtonProc(
     MagWindow *w,		/* Window in which button was pushed. */
     TxCommand *cmd)		/* Describes exactly what happened. */
 {
+    ARG_UNUSED(w);
     /* We do commands on the down-pushes and ignore the releases. */
 
     if (cmd->tx_buttonAction != TX_BUTTON_DOWN)

--- a/wiring/wireTech.c
+++ b/wiring/wireTech.c
@@ -58,8 +58,6 @@ int WireUnits;		    // Units per lambda for wiring sizes
 void
 WireTechInit(void)
 {
-    Contact *contact;
-    int i;
 
     while (WireContacts != NULL)
     {
@@ -92,6 +90,7 @@ WireTechLine(
     int argc,			/* Number of arguments on line. */
     char *argv[])		/* Pointers to fields of line. */
 {
+    ARG_UNUSED(sectionName);
     Contact *new;
     int hasExtend = 0;
 


### PR DESCRIPTION
### What
These changes delete unused local/static variables and mark unused function parameters as unused.

### Why
I believe it would be helpful to integrate more warnings into the build process, as other pull requests and currently existing warnings show that some warnings might hint to serious issues, but get lost in a large amount of warnings, if enabled.

### Comments
Unfortunately, this affects a lot of files, but the changes are easy to understand: Either unused variables are removed, which is simple or a function parameter is marked as unused. For the latter case I introduced a new macro `ARG_UNUSED`, which is a cast to void. I guess this should be supported by any compiler. Later on the macro should help finding functions with unused parameters, for potential clean-up.
For unused variables there are a few cases where results from function calls are stored. In a few instances I removed these calls, where they were actually macros without side effects. In other cases I left the function call, to be sure that potential side effects are still happening.

### Improvements
If this pull request is too large I can also break it down into smaller parts, perhaps per source directory.