### PR TITLE
Prefer original ports over duplicate ports in extracted spice netlist.

### DIFF
--- a/extflat/EFbuild.c
+++ b/extflat/EFbuild.c
@@ -652,7 +652,14 @@ efBuildEquiv(def, nodeName1, nodeName2, resist, isspice)
 	    if (efWarn)
 		efReadError("Merged nodes %s and %s\n", nodeName1, nodeName2);
 	    lostnode = efNodeMerge(&nn1->efnn_node, &nn2->efnn_node);
-	    if (nn1->efnn_port > 0) nn2->efnn_port = nn1->efnn_port;
+	    // keep the lowest valid port number
+	    if (nn1->efnn_port > 0)
+	    {
+		if (nn2->efnn_port > 0 && nn2->efnn_port < nn1->efnn_port)
+			nn1->efnn_port = nn2->efnn_port;
+		else
+			nn2->efnn_port = nn1->efnn_port;
+	    }
 	    else if (nn2->efnn_port > 0) nn1->efnn_port = nn2->efnn_port;
 
 	    /* Check if there are any device terminals pointing to the
@@ -1912,7 +1919,7 @@ EFNode *
 efNodeMerge(node1ptr, node2ptr)
     EFNode **node1ptr, **node2ptr;	/* Pointers to hierarchical nodes */
 {
-    EFNodeName *nn, *nnlast;
+    EFNodeName *nn, *nnlast, *nn1, *nn2;
     EFAttr *ap;
     int n;
     EFNode *keeping, *removing;
@@ -1923,8 +1930,22 @@ efNodeMerge(node1ptr, node2ptr)
 
     /* Keep the node with the greater number of entries, and merge  */
     /* the node with fewer entries into it.			    */
+    /* If one node is a port, keep that node                        */
+    /* If both nodes are ports, keep the lowest numbered port       */
+    /* Since duplicate ports always have higher numbers, this       */
+    /* should keep the original.                                    */
 
-    if ((*node1ptr)->efnode_num >= (*node2ptr)->efnode_num)
+    int keep = 0; // unknown
+    nn1 = (*node1ptr)->efnode_name;
+    nn2 = (*node2ptr)->efnode_name;
+    if ( nn1 && nn1->efnn_port > 0 )
+    {
+        if ( nn2 && nn2->efnn_port > 0 && nn2->efnn_port < nn1->efnn_port ) keep = 2;
+        else keep = 1;
+    }
+    else if ( nn2 && nn2->efnn_port > 0 ) keep = 2;
+
+    if (keep == 1 || ((keep == 0 && (*node1ptr)->efnode_num >= (*node2ptr)->efnode_num)))
     {
 	keeping = *node1ptr;
 	removing = *node2ptr;

--- a/extflat/EFflat.c
+++ b/extflat/EFflat.c
@@ -562,7 +562,8 @@ efAddNodes(
 	    HashSetValue(he, (char *) newname);
 	    newname->efnn_node = newnode;
 	    newname->efnn_hier = hierName;
-	    newname->efnn_port = -1;
+	    // keep the port number
+	    newname->efnn_port = node->efnode_name->efnn_port;
 	    newname->efnn_refc = 0;
 	    if (newnode->efnode_name)
 	    {


### PR DESCRIPTION
Prioritize lowest port number when merging nodes.

For example, when the ports `VSS` and `VSS_uq1` are merged, `VSS` will be preferred.

Changed `efBuildEquiv` in `EFbuild.c` but didn't seem to have any effect.

Changing `efAddNodes` in `EFflat.c` and `efNodeMerge` in `EFbuild.c` gave the expected results.

There is still an uneccesary short resistor output.

Here's a test case from the IHP memory macro.

[testcase_magic_extract_unique.tar.gz](https://github.com/user-attachments/files/24322538/testcase_magic_extract_unique.tar.gz)

```
tar xzf testcase_magic_extract_unique.tar.gz
cd testcase_magic_extract_unique
./run_magic.sh
```
Output is in `magic_RM_IHPSG13_1P_512x32_c2_bm_bist/RM_IHPSG13_1P_512x32_c2_bm_bist.layout.spice`

Before
```
.subckt RM_IHPSG13_1P_512x32_c2_bm_bist A_BIST_MEN A_BIST_WEN A_BIST_REN A_BIST_CLK
...
+ A_DIN<30> A_BM<16> A_BM<25> A_BIST_DIN<16> A_BIST_ADDR<8> A_DIN<16> VDD_uq19 VDDARRAY_uq19
+ VSS_uq34
...
R0 VSS_uq34 VSS_uq34 0.000000
.ends
```

After
```
.subckt RM_IHPSG13_1P_512x32_c2_bm_bist A_BIST_MEN A_BIST_WEN A_BIST_REN A_BIST_CLK
...
+ A_DIN<30> A_BM<16> A_BM<25> A_BIST_DIN<16> A_BIST_ADDR<8> A_DIN<16> VDD VDDARRAY
+ VSS
...
R0 VSS VSS 0.000000
.ends
```

Thanks for the test data @H-Ojiro.

Fixes #192 