### PR TITLE
Implement existing cell check for layout generation

### DIFF
--- a/tcltk/toolkit.tcl
+++ b/tcltk/toolkit.tcl
@@ -536,6 +536,12 @@ proc magic::netlist_to_layout {netfile library} {
         if {[catch {load $subckt -fail -silent}] == 0} {
             puts stdout "Subcircuit $subckt successfully loaded."
             set existing_cells($subckt) "true"
+
+			# Make sure to load all cells into memory to avoid 
+			# corruption when saving all files (files get loaded
+			# without taking the scale into account)
+			select top cell
+            expand
         } else {
             puts stdout "Subcircuit $subckt not found. Will generate."
             set existing_cells($subckt) "false"

--- a/tcltk/toolkit.tcl
+++ b/tcltk/toolkit.tcl
@@ -525,11 +525,25 @@ proc magic::netlist_to_layout {netfile library} {
    # Pre-generate placeholders for all subcircuits.
    set curtop [cellname list self]
 
+   array set existing_cells {}
    foreach subckt $allsubs {
-	# Diagnostic output
-        puts stdout "Pre-generating subcircuit $subckt placeholder"
-	load $subckt -silent
+        if {$subckt == $curtop || $subckt == $topname} {
+            set existing_cells($subckt) "false"
+            load $subckt -silent
+            continue
+        }
+
+        if {[catch {load $subckt -fail -silent}] == 0} {
+            puts stdout "Subcircuit $subckt successfully loaded."
+            set existing_cells($subckt) "true"
+        } else {
+            puts stdout "Subcircuit $subckt not found. Will generate."
+            set existing_cells($subckt) "false"
+            # Now we load it normally to create the placeholder for the generator
+            load $subckt -silent
+        }
    }
+
    load $curtop
 
    # Parse the file and process all lines
@@ -561,7 +575,14 @@ proc magic::netlist_to_layout {netfile library} {
       } else {
 	 if {[regexp -nocase {^[ \t]*\.ends} $line]} {
 	    set insub false
-	    magic::generate_layout_add $subname $subpins $complist $library
+
+        if {[info exists existing_cells($subname)] && $existing_cells($subname) == "false"} {
+            puts stdout "Cell $subname is empty. Generating initial layout..."
+            magic::generate_layout_add $subname $subpins $complist $library
+        } else {
+            puts stdout "Cell $subname already contains layout. Skipping generation."
+        }
+
 	    set subname ""
 	    set subpins ""
 	    set complist {}


### PR DESCRIPTION
The current netlist_to_layout implementation lacks an existence check for subcircuits. When importing a SPICE netlist into an existing hierarchy, Magic's default behavior causes two critical failures:

Layout Corruption: While "paint" remains in place, all subcell instances are snapped to a default coordinate. This destroys the placement of any previously laid-out cells and causes a loss of instance-specific property modifications (e.g., transistor guard ring parameters).

Redundant Disk Writes: Cells already present in the search path (e.g., library cells or external IP) are treated as new, resulting in redundant .mag files being written to the current working directory, breaking synchronization with the source library (for incremental design).

Solution:
1. This patch introduces a pre-import verification step using load -fail to probe the search path for existing cell definitions.
2. It creates a mapping of existing vs. non-existing cells.
3. It gates the magic::generate_layout_add procedure, ensuring that only new cells are "filled" with components.

It explicitly excludes the top-level cell from the "skip" logic to allow for top-level connectivity updates while preserving the sub-hierarchy.

NOTE:
I'm not sure if checking "[info exists existing_cells($subname)]" in line 579 is fully needed. Please remove if unneeded.

Testing:
Verified on Magic 8.3.638. Incremental imports now successfully preserve existing placement and do not create local copies of library components.

This addresses issue #506 