### PR TITLE
tcl/tk: Fix layer toolbar icon synchronization on left-click

### DIFF
--- a/tcltk/wrapper.tcl
+++ b/tcltk/wrapper.tcl
@@ -706,7 +706,7 @@ proc magic::cursorview {win} {
    *bypass logcommands resume
 }
 
-proc magic::toolupdate {win {yesno "yes"} {layerlist "none"}} {
+proc magic::toolupdate {win {yesno "yes"} {layerlist ""}} {
    global Winopts
 
    if {[magic::display] == "NULL"} {return}
@@ -728,7 +728,7 @@ proc magic::toolupdate {win {yesno "yes"} {layerlist "none"}} {
    # Don't do anything if toolbar is not present
    if { $Winopts(${topname},toolbar) == 0 } { return }
 
-   if {$layerlist == "none"} {
+   if {$layerlist == ""} {
 	set layerlist $yesno
 	set yesno "yes"
    }

--- a/tcltk/wrapper.tcl
+++ b/tcltk/wrapper.tcl
@@ -728,7 +728,9 @@ proc magic::toolupdate {win {yesno "yes"} {layerlist ""}} {
    # Don't do anything if toolbar is not present
    if { $Winopts(${topname},toolbar) == 0 } { return }
 
-   if {$layerlist == ""} {
+   # To ensure backwards compatibility, we check if the 
+   # layer is called none, so avoid naming a layer none.
+   if {$layerlist == "" || $layerlist == "none"} {
 	set layerlist $yesno
 	set yesno "yes"
    }


### PR DESCRIPTION
There is a bug where left-clicking a hidden layer in the toolbar successfully makes the layer visible in the layout but fails to update the toolbar icon to the "active" state.

The root cause is a positional argument mismatch in magic::toolupdate. When the Magic C-core issues a callback for a "see" command with two arguments, the third argument (layerlist) is passed as an empty string ("") rather than being omitted. This prevents the Tcl procedure from falling back to its hardcoded default of "none", causing the script to skip the logic that reassigns $yesno to "yes".

This patch changes the default value of $layerlist to "" and updates the conditional check to ensure the state and layer name are correctly reassigned regardless of how the C-core signals the update.

This pull request fixes Issue #507 