### PR TITLE
fix(ext2spice): use ';' instead of '$' for NGSpice end-of-line comments

### DIFF
--- a/ext2spice/ext2hier.c
+++ b/ext2spice/ext2hier.c
@@ -757,7 +757,7 @@ spcdevHierVisit(
 	case DEV_FET:
 	    if (source == drain)
 	    {
-		if (esFormat == NGSPICE) fprintf(esSpiceF, "$ ");
+		if (esFormat == NGSPICE) fprintf(esSpiceF, "; ");
 		fprintf(esSpiceF, "** SOURCE/DRAIN TIED\n");
 	    }
 	    break;
@@ -765,7 +765,7 @@ spcdevHierVisit(
 	default:
 	    if (gate == source)
 	    {
-		if (esFormat == NGSPICE) fprintf(esSpiceF, "$ ");
+		if (esFormat == NGSPICE) fprintf(esSpiceF, "; ");
 		fprintf(esSpiceF, "** SHORTED DEVICE\n");
 	    }
 	    break;
@@ -1658,7 +1658,7 @@ spcnodeHierVisit(
 	static char ntmp[MAX_STR_SIZE];
 
 	EFHNSprintf(ntmp, hierName);
-	if (esFormat == NGSPICE) fprintf(esSpiceF, " $ ");
+	if (esFormat == NGSPICE) fprintf(esSpiceF, " ; ");
 	fprintf(esSpiceF, "** %s == %s\n", ntmp, nsn);
     }
     cap = cap  / 1000;
@@ -1668,14 +1668,14 @@ spcnodeHierVisit(
 	esSIvalue(esSpiceF, 1.0E-15 * cap);
 	if (!isConnected)
 	{
-	    if (esFormat == NGSPICE) fprintf(esSpiceF, " $");
+	    if (esFormat == NGSPICE) fprintf(esSpiceF, " ;");
 	    fprintf(esSpiceF, " **FLOATING");
 	}
 	fprintf(esSpiceF, "\n");
     }
     if (node->efnode_attrs && !esNoAttrs)
     {
-	if (esFormat == NGSPICE) fprintf(esSpiceF, " $ ");
+	if (esFormat == NGSPICE) fprintf(esSpiceF, " ; ");
 	fprintf(esSpiceF, "**nodeattr %s :",nsn );
 	for (fmt = " %s", ap = node->efnode_attrs; ap; ap = ap->efa_next)
 	{

--- a/ext2spice/ext2spice.c
+++ b/ext2spice/ext2spice.c
@@ -2817,7 +2817,7 @@ spcdevVisit(
 	case DEV_FET:
 	    if (source == drain)
 	    {
-		if (esFormat == NGSPICE) fprintf(esSpiceF, "$ ");
+		if (esFormat == NGSPICE) fprintf(esSpiceF, "; ");
 		fprintf(esSpiceF, "** SOURCE/DRAIN TIED\n");
 	    }
 	    break;
@@ -2825,7 +2825,7 @@ spcdevVisit(
 	default:
 	    if (gate == source)
 	    {
-		if (esFormat == NGSPICE) fprintf(esSpiceF, "$ ");
+		if (esFormat == NGSPICE) fprintf(esSpiceF, "; ");
 		fprintf(esSpiceF, "** SHORTED DEVICE\n");
 	    }
 	    break;
@@ -4111,7 +4111,7 @@ spcnodeVisit(
 	static char ntmp[MAX_STR_SIZE];
 
 	EFHNSprintf(ntmp, hierName);
-	if (esFormat == NGSPICE) fprintf(esSpiceF, "$ ");
+	if (esFormat == NGSPICE) fprintf(esSpiceF, "; ");
 	fprintf(esSpiceF, "** %s == %s\n", ntmp, nsn);
     }
     cap = cap  / 1000;
@@ -4121,14 +4121,14 @@ spcnodeVisit(
 	esSIvalue(esSpiceF, 1.0E-15 * cap);
 	if (!isConnected)
 	{
-	    if (esFormat == NGSPICE) fprintf(esSpiceF, " $");
+	    if (esFormat == NGSPICE) fprintf(esSpiceF, " ;");
 	    fprintf(esSpiceF, " **FLOATING");
 	}
 	fprintf(esSpiceF, "\n");
     }
     if (node->efnode_attrs && !esNoAttrs)
     {
-	if (esFormat == NGSPICE) fprintf(esSpiceF, " $ ");
+	if (esFormat == NGSPICE) fprintf(esSpiceF, " ; ");
 	fprintf(esSpiceF, "**nodeattr %s :",nsn );
 	for (fmt = " %s", ap = node->efnode_attrs; ap; ap = ap->efa_next)
 	{


### PR DESCRIPTION
This is a simple character replacement that replaces the end-of-line comment character
from '$' to ';' to ensure broader compatibility.

**Motivation:**

Currently I run a mix of both Xyce and NGSpice, however, to be able to run the extracted
netlists on Xyce I need to convert from '$' to ';', due to Xyce only supporting ';' as the
end-of-line character, as referenced in their reference guide (Sec. 2.1.39):

> ; (in-line Comment)
> Add a netlist in-line comment.

While NGSpice has (Sec. 2.4.4 in the manual):

> 2.4.4 End-of-line comments
> General Form:
> `<any command> $ <any comment> <any command> ; <any comment>`

i.e. supporting both syntaxes.

## Example

Running `ext2spice` on a circuit that I have, and selecting some of the
commented devices, I now get:

**Currently**

```
C1050 CLK.t1 AGND 0.14479f $ **FLOATING
C1051 CLK.n0 AGND 2.72796f $ **FLOATING
C1052 CLK.n1 AGND 0.04897f $ **FLOATING
C1053 CLK.t0 AGND 0.30747f $ **FLOATING
C1054 CLK_GATED.t3 AGND 0.16529f $ **FLOATING
C1055 CLK_GATED.t2 AGND 0.1563f $ **FLOATING
C1056 CLK_GATED.n0 AGND 0.2546f $ **FLOATING
C1057 CLK_GATED.t0 AGND 0.10698f $ **FLOATING
C1058 CLK_GATED.t1 AGND 0.10247f $ **FLOATING
C1059 CLK_GATED.n1 AGND 0.15776f $ **FLOATING
C1060 CLK_GATED.n2 AGND 0.04006f $ **FLOATING
```

**This PR**

```
C1050 CLK.t1 AGND 0.14479f ; **FLOATING
C1051 CLK.n0 AGND 2.72796f ; **FLOATING
C1052 CLK.n1 AGND 0.04897f ; **FLOATING
C1053 CLK.t0 AGND 0.30747f ; **FLOATING
C1054 CLK_GATED.t2 AGND 0.16529f ; **FLOATING
C1055 CLK_GATED.t3 AGND 0.1563f ; **FLOATING
C1056 CLK_GATED.n0 AGND 0.2546f ; **FLOATING
C1057 CLK_GATED.t1 AGND 0.10698f ; **FLOATING
C1058 CLK_GATED.t0 AGND 0.10247f ; **FLOATING
C1059 CLK_GATED.n1 AGND 0.15776f ; **FLOATING
C1060 CLK_GATED.n2 AGND 0.04006f ; **FLOATING
```

Let me know if there's any changes wanted/required,
Thanks!