### PR TITLE
Fix SIGSEGV in -dnull extraction/DEF read: guard Tk_RestrictEvents with TxTkConsole

### DIFF
--- a/cif/CIFhier.c
+++ b/cif/CIFhier.c
@@ -40,6 +40,7 @@ static const char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magi
 #include "drc/drc.h"
 #include "graphics/graphics.h"
 #include "textio/textio.h"
+#include "utils/main.h"
 #include "utils/undo.h"
 #include "utils/malloc.h"
 #include "utils/signals.h"
@@ -732,7 +733,7 @@ CIFGenSubcells(
     Tk_RestrictProc *oldProc;
     ClientData oldArg;
 
-    if (SigInterruptOnSigIO != -1)	/* Check for batch mode */
+    if (TxTkConsole)		/* only when a Tk console exists (never in -dnull) */
 	oldProc = Tk_RestrictEvents(RestrictInputProc, (ClientData)NULL, &oldArg);
 #endif /* MAGIC_NO_TK */
 #endif /* MAGIC_WRAPPER */
@@ -888,7 +889,7 @@ CIFGenSubcells(
 #ifdef MAGIC_WRAPPER
 #ifndef MAGIC_NO_TK
     /* Restore full event access */
-    if (SigInterruptOnSigIO != -1)	/* Check for batch mode */
+    if (TxTkConsole)		/* only when a Tk console exists (never in -dnull) */
 	Tk_RestrictEvents(oldProc, oldArg, &oldArg);
 #endif /* MAGIC_NO_TK */
 #endif /* MAGIC_WRAPPER */

--- a/extract/ExtSubtree.c
+++ b/extract/ExtSubtree.c
@@ -42,6 +42,7 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 #include "database/database.h"
 #include "utils/malloc.h"
 #include "textio/textio.h"
+#include "utils/main.h"
 #include "debug/debug.h"
 #include "extract/extract.h"
 #include "extract/extractInt.h"
@@ -190,7 +191,7 @@ extSubtree(parentUse, reg, f)
     Tk_RestrictProc *oldProc;
     ClientData oldArg;
 
-    if (SigInterruptOnSigIO != -1)	/* Check for batch mode */
+    if (TxTkConsole)		/* only when a Tk console exists (never in -dnull) */
 	oldProc = Tk_RestrictEvents(RestrictInputProc, (ClientData)NULL, &oldArg);
 #endif /* MAGIC_NO_TK */
 #endif /* MAGIC_WRAPPER */
@@ -389,7 +390,7 @@ done:
 #ifdef MAGIC_WRAPPER
 #ifndef MAGIC_NO_TK
     /* Restore full event access */
-    if (SigInterruptOnSigIO != -1)	/* Check for batch mode */
+    if (TxTkConsole)		/* only when a Tk console exists (never in -dnull) */
 	Tk_RestrictEvents(oldProc, oldArg, &oldArg);
 #endif /* MAGIC_NO_TK */
 #endif /* MAGIC_WRAPPER */

--- a/lef/defRead.c
+++ b/lef/defRead.c
@@ -2536,7 +2536,7 @@ DefRead(
      * corrupt the database during DEF reads.
      */
 
-    if (SigInterruptOnSigIO != -1)	/* Check for batch mode */
+    if (TxTkConsole)		/* only when a Tk console exists (never in -dnull) */
 	oldProc = Tk_RestrictEvents(RestrictInputProc, (ClientData)NULL, &oldArg);
 #endif /* MAGIC_NO_TK */
 #endif /* MAGIC_WRAPPER */
@@ -2764,7 +2764,7 @@ DefRead(
 #ifdef MAGIC_WRAPPER
 #ifndef MAGIC_NO_TK
     /* Restore full event access */
-    if (SigInterruptOnSigIO != -1)	/* Check for batch mode */
+    if (TxTkConsole)		/* only when a Tk console exists (never in -dnull) */
 	Tk_RestrictEvents(oldProc, oldArg, &oldArg);
 #endif /* MAGIC_NO_TK */
 #endif /* MAGIC_WRAPPER */


### PR DESCRIPTION
## Problem

Running magic headless (`magic -dnull -noconsole`) **segfaults during `extract` / DEF read**. Minimal repro (sky130A, any cell with subcells):

```
magic -dnull -noconsole -rcfile sky130A.magicrc <<'TCL'
load inv.mag
extract all
TCL
```
```
Program received signal SIGSEGV
#0  extSubtree () at ExtSubtree.c:194
      oldProc = Tk_RestrictEvents(RestrictInputProc, NULL, &oldArg);
#1  extCellFile () ExtCell.c:523
#4  ExtAll () ExtMain.c:389
```

It is reliably fatal on **aarch64** (the bad indirect call trips Pointer Authentication); on x86_64 it often survives, so it can go unnoticed. This breaks headless extraction/LVS in SAK / LibreLane / open_pdks-style flows.

## Cause

Commit d8046fb added `Tk_RestrictEvents()` to `extract/ExtSubtree.c`, `cif/CIFhier.c` and `lef/defRead.c`, guarded by:

```c
if (SigInterruptOnSigIO != -1)	/* Check for batch mode */
```

`SigInterruptOnSigIO` is only `-1` for true `batchmode` (`SigInit(TRUE)`). The `-dnull -noconsole` interpreter (`magicdnull`) is **not** batch mode (`SigInterruptOnSigIO == 0`), so the guard passes — but `magicdnull` never initializes the Tk package, so the Tk stubs table is NULL and the call dereferences it.

## Fix

Guard the six call sites with `TxTkConsole` (`RuntimeFlags & MAIN_TK_CONSOLE`, from `utils/main.h`) — true only when a Tk console is actually present — and add the missing `#include "utils/main.h"` to the two files that lacked it.

Verified on aarch64 (Ubuntu 24.04, magic 8.3.670): `extract all` + `ext2spice` on a sky130A inverter now completes cleanly and LVS passes; previously it segfaulted.