### PR TITLE
Bugfix for WASM Build with emscripten >6.0.2

### DIFF
--- a/toolchains/emscripten/build-tcl-wasm.sh
+++ b/toolchains/emscripten/build-tcl-wasm.sh
@@ -93,6 +93,18 @@ cd "$OUT"
 # --disable-shared      we statically link libtcl into magic.wasm.
 # --disable-load        no dynamic loading inside wasm.
 # --enable-symbols=no   release (-O2). Override CFLAGS to add -g for debug.
+#
+# ac_cv_header_sys_epoll_h=no forces TCL onto its select()-based notifier.
+# On a Linux host, TCL's configure runs `AC_CHECK_HEADERS([sys/epoll.h])` and,
+# if found, defines NOTIFIER_EPOLL and compiles tclEpollNotfy.c. Emscripten
+# 6.0.2 started shipping a <sys/epoll.h> stub in its sysroot (6.0.1 did not),
+# so that probe now passes — but tclEpollNotfy.c also needs <sys/queue.h>,
+# which emscripten does NOT provide, so the build dies with
+#   tclEpollNotfy.c: fatal error: 'sys/queue.h' file not found
+# The select() notifier is the correct choice for single-threaded WASM anyway
+# (emscripten's epoll is a stub), so we pin it here rather than track the
+# emscripten sysroot. Overriding the autoconf cache var is cleaner than
+# patching the read-only TCL source tree.
 if [ ! -f Makefile ]; then
   echo "=== emconfigure ==="
   CFLAGS="-O2 -sUSE_ZLIB=1" \
@@ -101,7 +113,8 @@ if [ ! -f Makefile ]; then
       --disable-load \
       --enable-symbols=no \
       --host=wasm32-unknown-emscripten \
-      --prefix="$OUT/install"
+      --prefix="$OUT/install" \
+      ac_cv_header_sys_epoll_h=no
 fi
 
 # emconfigure writes tclConfig.sh into the build dir. If it is missing, the

--- a/toolchains/emscripten/defs.mak
+++ b/toolchains/emscripten/defs.mak
@@ -20,6 +20,15 @@ MAKE_WASM = 1
 # Emscripten linker flags.
 # The link step runs from the magic/ subdirectory, so embed-file paths
 # are relative to that directory (../scmos, ../windows/...).
+#
+# INCOMING_MODULE_JS_API is emscripten's default list plus `wasmBinary`.
+# Our JS loaders (npm/examples/*.js) pass Module.wasmBinary to embed the .wasm,
+# but emscripten 6.0.2 dropped wasmBinary (and a batch of GL/SDL members) from
+# the default INCOMING_MODULE_JS_API. With ASSERTIONS=1 that turns into a hard
+# runtime abort: "`Module.wasmBinary` was supplied but `wasmBinary` not included
+# in INCOMING_MODULE_JS_API". We spell out the full default list (so external
+# consumers passing locateFile/arguments/etc. keep working) and re-add
+# wasmBinary. Keep this in sync with emscripten's default if it grows.
 TOP_EXTRA_LIBS += \
     -sWASM=1 \
     -sMODULARIZE=1 \
@@ -27,6 +36,7 @@ TOP_EXTRA_LIBS += \
     -sUSE_ZLIB=1 \
     -sEXPORTED_FUNCTIONS=_magic_wasm_init,_magic_wasm_run_command,_magic_wasm_source_file,_magic_wasm_update \
     -sEXPORTED_RUNTIME_METHODS=cwrap,ccall,FS,setValue,getValue \
+    -sINCOMING_MODULE_JS_API=ENVIRONMENT,arguments,canvas,dynamicLibraries,elementPointerLock,instantiateWasm,locateFile,monitorRunDependencies,noExitRuntime,noInitialRun,onAbort,onExit,onRuntimeInitialized,postRun,preInit,preRun,print,printErr,setStatus,statusMessage,stderr,stdin,stdout,thisProgram,wasm,websocket,wasmBinary \
     -sALLOW_MEMORY_GROWTH=1 \
     -sINITIAL_MEMORY=67108864 \
     -Wl,-z,stack-size=10485760 \


### PR DESCRIPTION
This PR is related to Issue #533 . Here a small summary:

- What broke it — emscripten 6.0.2 (6.0.1 was fine) made two sysroot/default changes: it started shipping a
  <sys/epoll.h> stub, and it dropped wasmBinary from the default INCOMING_MODULE_JS_API list. Both broke the
  WASM build in different ways.
  - toolchains/emscripten/build-tcl-wasm.sh — Added ac_cv_header_sys_epoll_h=no to TCL's configure
  invocation, forcing the select()-based notifier. The new <sys/epoll.h> stub made TCL pick the epoll
  notifier (tclEpollNotfy.c), which needs <sys/queue.h> — a header emscripten doesn't provide — causing a
  compile-time fatal error: 'sys/queue.h' file not found.
  - toolchains/emscripten/defs.mak — Added -sINCOMING_MODULE_JS_API= (emscripten's full default list plus
  wasmBinary). Because wasmBinary was removed from the default, the loaders passing Module.wasmBinary
  triggered a hard runtime abort under -sASSERTIONS=1 (Module.wasmBinary … not included in
  INCOMING_MODULE_JS_API), failing every example test.